### PR TITLE
fix AWS::S3::Client specs for non-PDT timezones.

### DIFF
--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -671,7 +671,7 @@ module AWS
 
         it "formats Time values" do
           http_handler.should_receive(:handle) do |req, resp|
-            req.headers[header].should == "Mon, 13 Jun 2011 15:42:31 -0700"
+            req.headers[header].should == Time.parse("Mon, 13 Jun 2011 15:42:31 -0700").rfc2822
           end
           my_opts = opts.dup
           my_opts[option_name] = Time.parse("2011-06-13 15:42:31 -0700")
@@ -680,7 +680,7 @@ module AWS
 
         it "formats DateTime values" do
           http_handler.should_receive(:handle) do |req, resp|
-            req.headers[header].should == "Mon, 13 Jun 2011 15:42:31 -0700"
+            req.headers[header].should == Time.parse("Mon, 13 Jun 2011 15:42:31 -0700").rfc2822
           end
           my_opts = opts.dup
           my_opts[option_name] = DateTime.parse("2011-06-13 15:42:31 -0700")


### PR DESCRIPTION
Spec for AWS::S3::Client is failed when local timezone is not PDT.
I modified expectation strings but its bit more unclear than before.
Have any ideas?

```
$ bundle exec rspec -cfs ./spec/aws/s3/client_spec.rb

Failures:

  1) AWS::S3::Client#get_object it should behave like formats date header formats Time values
     Failure/Error: client.send(method, my_opts)
       Double "a handler" received :handle but passed block failed with: expected: "Mon, 13 Jun 2011 15:42:31 -0700"
            got: "Tue, 14 Jun 2011 07:42:31 +0900" (using ==)
     Shared Example Group: "formats date header" called from ./spec/aws/s3/client_spec.rb:1110
     # ./lib/aws/base_client.rb:269:in `block in make_sync_request'
     # ./lib/aws/base_client.rb:281:in `retry_server_errors'
     # ./lib/aws/base_client.rb:264:in `make_sync_request'
     # ./lib/aws/base_client.rb:412:in `block (2 levels) in client_request'
     # ./lib/aws/base_client.rb:179:in `block in log_client_request'
     # ./lib/aws/base_client.rb:178:in `log_client_request'
     # ./lib/aws/base_client.rb:375:in `block in client_request'
     # ./lib/aws/base_client.rb:314:in `return_or_raise'
     # ./lib/aws/base_client.rb:374:in `client_request'
     # (eval):3:in `get_object'
     # ./spec/aws/s3/client_spec.rb:679:in `block (3 levels) in <class:S3>'

  2) AWS::S3::Client#get_object it should behave like formats date header formats DateTime values
     Failure/Error: client.send(method, my_opts)
       Double "a handler" received :handle but passed block failed with: expected: "Mon, 13 Jun 2011 15:42:31 -0700"
            got: "Tue, 14 Jun 2011 07:42:31 +0900" (using ==)
     Shared Example Group: "formats date header" called from ./spec/aws/s3/client_spec.rb:1110
     # ./lib/aws/base_client.rb:269:in `block in make_sync_request'
     # ./lib/aws/base_client.rb:281:in `retry_server_errors'
     # ./lib/aws/base_client.rb:264:in `make_sync_request'
     # ./lib/aws/base_client.rb:412:in `block (2 levels) in client_request'
     # ./lib/aws/base_client.rb:179:in `block in log_client_request'
     # ./lib/aws/base_client.rb:178:in `log_client_request'
     # ./lib/aws/base_client.rb:375:in `block in client_request'
     # ./lib/aws/base_client.rb:314:in `return_or_raise'
     # ./lib/aws/base_client.rb:374:in `client_request'
     # (eval):3:in `get_object'
     # ./spec/aws/s3/client_spec.rb:689:in `block (3 levels) in <class:S3>'

  3) AWS::S3::Client#get_object it should behave like formats date header formats Time values
     Failure/Error: client.send(method, my_opts)
       Double "a handler" received :handle but passed block failed with: expected: "Mon, 13 Jun 2011 15:42:31 -0700"
            got: "Tue, 14 Jun 2011 07:42:31 +0900" (using ==)
     Shared Example Group: "formats date header" called from ./spec/aws/s3/client_spec.rb:1111
     # ./lib/aws/base_client.rb:269:in `block in make_sync_request'
     # ./lib/aws/base_client.rb:281:in `retry_server_errors'
     # ./lib/aws/base_client.rb:264:in `make_sync_request'
     # ./lib/aws/base_client.rb:412:in `block (2 levels) in client_request'
     # ./lib/aws/base_client.rb:179:in `block in log_client_request'
     # ./lib/aws/base_client.rb:178:in `log_client_request'
     # ./lib/aws/base_client.rb:375:in `block in client_request'
     # ./lib/aws/base_client.rb:314:in `return_or_raise'
     # ./lib/aws/base_client.rb:374:in `client_request'
     # (eval):3:in `get_object'
     # ./spec/aws/s3/client_spec.rb:679:in `block (3 levels) in <class:S3>'

  4) AWS::S3::Client#get_object it should behave like formats date header formats DateTime values
     Failure/Error: client.send(method, my_opts)
       Double "a handler" received :handle but passed block failed with: expected: "Mon, 13 Jun 2011 15:42:31 -0700"
            got: "Tue, 14 Jun 2011 07:42:31 +0900" (using ==)
     Shared Example Group: "formats date header" called from ./spec/aws/s3/client_spec.rb:1111
     # ./lib/aws/base_client.rb:269:in `block in make_sync_request'
     # ./lib/aws/base_client.rb:281:in `retry_server_errors'
     # ./lib/aws/base_client.rb:264:in `make_sync_request'
     # ./lib/aws/base_client.rb:412:in `block (2 levels) in client_request'
     # ./lib/aws/base_client.rb:179:in `block in log_client_request'
     # ./lib/aws/base_client.rb:178:in `log_client_request'
     # ./lib/aws/base_client.rb:375:in `block in client_request'
     # ./lib/aws/base_client.rb:314:in `return_or_raise'
     # ./lib/aws/base_client.rb:374:in `client_request'
     # (eval):3:in `get_object'
     # ./spec/aws/s3/client_spec.rb:689:in `block (3 levels) in <class:S3>'

Finished in 8.63 seconds
1485 examples, 4 failures
```
