### PR TITLE
fix new_request: %T -> %H:%M:%S

### DIFF
--- a/lib/aws/base_client.rb
+++ b/lib/aws/base_client.rb
@@ -156,7 +156,7 @@ module AWS
       req = self.class::REQUEST_CLASS.new
       req.http_method = 'POST'
       req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-      req.add_param 'Timestamp', Time.now.utc.strftime('%Y-%m-%dT%TZ')
+      req.add_param 'Timestamp', Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
       req.add_param 'Version', self.class::API_VERSION
       req
     end


### PR DESCRIPTION
Hi,

%T is not correctly converted in i386-mswin32. 

```
~$ ruby -v
ruby 1.8.7 (2010-12-23 patchlevel 330) [i386-mswin32]
~$ ruby -e 'p Time.now.strftime("%T")'
""
```

So, Please change "%T" to "%H:%M:%S". 
