### PR TITLE
Modify time-stamp related tests to work correctly in all time-zones worldwide

### DIFF
--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -668,22 +668,25 @@ module AWS
       end
 
       shared_examples_for 'formats date header' do |option_name, header|
-
+      	t_now = Time.now
+	req_header_ts = t_now.strftime('%a, %d %b %Y %H:%M:%S %z').to_s
+	parse_ts = t_now.strftime('%Y-%m-%d %H:%M:%S %z').to_s
+      
         it "formats Time values" do
           http_handler.should_receive(:handle) do |req, resp|
-            req.headers[header].should == "Mon, 13 Jun 2011 15:42:31 -0700"
+            req.headers[header].should == req_header_ts
           end
           my_opts = opts.dup
-          my_opts[option_name] = Time.parse("2011-06-13 15:42:31 -0700")
+          my_opts[option_name] = Time.parse(parse_ts)
           client.send(method, my_opts)
         end
 
         it "formats DateTime values" do
           http_handler.should_receive(:handle) do |req, resp|
-            req.headers[header].should == "Mon, 13 Jun 2011 15:42:31 -0700"
+            req.headers[header].should == req_header_ts
           end
           my_opts = opts.dup
-          my_opts[option_name] = DateTime.parse("2011-06-13 15:42:31 -0700")
+          my_opts[option_name] = DateTime.parse(parse_ts)
           client.send(method, my_opts)
         end
 


### PR DESCRIPTION
The code currently erroneously assumes that the the tests are being run in UTC-7.  Your code translates that into a local time-zone, immediately end up with a mismatch between the expected and actual results.

The pull request simply uses the local time zone, formatted in the correct way, and hence the tests now pass properly (e.g. I am UTC+1 at present).

Example error output:
https://gist.github.com/1095270
