### PR TITLE
Fix for SSL verification failure on Ubuntu Hardy

### DIFF
--- a/lib/aws/http/httparty_handler.rb
+++ b/lib/aws/http/httparty_handler.rb
@@ -70,6 +70,8 @@ module AWS
           url = "https://#{request.host}:443#{request.uri}"
           opts[:ssl_ca_file] = request.ssl_ca_file if
             request.ssl_verify_peer?
+          opts[:ssl_ca_path] = '/etc/ssl/certs' if
+            request.ssl_verify_peer? && FileTest.directory?('/etc/ssl/certs')
         else
           url = "http://#{request.host}#{request.uri}"
         end


### PR DESCRIPTION
There's a bug/feature in the version of OpenSSL that ships with Ubuntu Hardy that seems to break SSL verification unless ssl_ca_path is manually set.

I know it's strictly distro dodginess, but is there any chance you'd include this patch?
