### PR TITLE
Bug with Base64 encoding in AWS::S3::PresignedPost#policy

### DIFF
--- a/lib/aws/s3/presigned_post.rb
+++ b/lib/aws/s3/presigned_post.rb
@@ -317,7 +317,7 @@ module AWS
           "expiration" => format_expiration,
           "conditions" => generate_conditions
         }.to_json
-        Base64.encode64(json)
+        Base64.encode64(json).gsub(/\n/, '')
       end
 
       # @return [Hash] A collection of form fields (including a

--- a/spec/aws/s3/presigned_post_spec.rb
+++ b/spec/aws/s3/presigned_post_spec.rb
@@ -311,12 +311,16 @@ module AWS
 
       context '#policy' do
 
+        let(:policy) { JSON.load(Base64.decode64(post.policy)) }
+
         it 'should be valid Base64-encoded JSON' do
           lambda { policy }.
             should_not raise_error
         end
 
-        let(:policy) { JSON.load(Base64.decode64(post.policy)) }
+        it "should remove newline breaks from the Base64-encoded JSON" do
+          post.policy.should == Base64.encode64(policy.to_json).gsub(/\n/, '')
+        end
 
         it 'should expire an hour from now by default' do
           Time.stub(:now).


### PR DESCRIPTION
We need to strip newlines characters when Base64 encoding the policy to generate a valid signature for the policy.
