### PR TITLE
fix proxy url

### DIFF
--- a/lib/aws/http/httparty_handler.rb
+++ b/lib/aws/http/httparty_handler.rb
@@ -62,7 +62,7 @@ module AWS
         })
 
         if request.proxy_uri
-          opts[:http_proxyaddr] = request.proxy_uri.to_s
+          opts[:http_proxyaddr] = request.proxy_uri.to_s.gsub(/https?:\/\//i, '')
           opts[:http_proxyport] = request.proxy_uri.port
         end
 

--- a/spec/aws/http/httparty_handler_spec.rb
+++ b/spec/aws/http/httparty_handler_spec.rb
@@ -85,7 +85,7 @@ module AWS
             req.proxy_uri = URI.parse('https://user:pass@proxy.com:443/path?query')
 
             httparty_options[:http_proxyaddr].
-              should == 'https://user:pass@proxy.com/path?query'
+              should == 'user:pass@proxy.com/path?query'
 
             httparty_options[:http_proxyport].should == 443
 


### PR DESCRIPTION
This is a somewhat naive patch.
It fixes the problem I see on windows/linux with ruby 1.8.7 but I have not tried it with other versions of ruby or other platforms. Before making the patch I received the following error when using :proxy_uri => 'http://myproxyserver'

The patch updates the test for setting the uri and the code for setting it (to remove the precedding http(s)://)

getaddrinfo: The storage control blocks were destroyed.  (SocketError)
c:/ruby/lib/ruby/1.8/net/http.rb:560:in `initialize'
c:/ruby/lib/ruby/1.8/net/http.rb:560:in`open'
c:/ruby/lib/ruby/1.8/net/http.rb:560:in `connect'
c:/ruby/lib/ruby/1.8/timeout.rb:53:in`timeout'
c:/ruby/lib/ruby/1.8/timeout.rb:101:in `timeout'
c:/ruby/lib/ruby/1.8/net/http.rb:560:in`connect'
c:/ruby/lib/ruby/1.8/net/http.rb:553:in `do_start'
c:/ruby/lib/ruby/1.8/net/http.rb:542:in`start'
c:/ruby/lib/ruby/1.8/net/http.rb:1035:in `request'
c:/ruby/lib/ruby/gems/1.8/gems/httparty-0.7.8/lib/httparty/request.rb:69:in`perform'
c:/ruby/lib/ruby/gems/1.8/gems/httparty-0.7.8/lib/httparty.rb:390:in `perform_request'
c:/ruby/lib/ruby/gems/1.8/gems/httparty-0.7.8/lib/httparty.rb:358:in`post'
c:/ruby/lib/ruby/gems/1.8/gems/aws-sdk-1.0.4/lib/aws/http/httparty_handler.rb:92:in `send'
c:/ruby/lib/ruby/gems/1.8/gems/aws-sdk-1.0.4/lib/aws/http/httparty_handler.rb:92:in`handle'
c:/ruby/lib/ruby/gems/1.8/gems/aws-sdk-1.0.4/lib/aws/base_client.rb:220:in `make_sync_request'
