### PR TITLE
fix sdb no block select bug

### DIFF
--- a/lib/aws/simple_db/item_collection.rb
+++ b/lib/aws/simple_db/item_collection.rb
@@ -185,11 +185,11 @@ module AWS
 
         args = attributes + [options]
 
-        return if handle_query_options(:select, *args, &block)
-
         unless block_given?
           return Enumerator.new(self, :select, *args)
         end
+
+        return if handle_query_options(:select, *args, &block)
   
         if attributes.empty?
           output_list = '*'


### PR DESCRIPTION
follow method return nil:

domain.items.select(:age, :limit => 100) #=> nil

I think that correct return value is #&lt;Enumerable::Enumerator:...&gt;
