### PR TITLE
Missing documentation for :part_number in MultipartUpload class

### DIFF
--- a/lib/aws/s3/multipart_upload.rb
+++ b/lib/aws/s3/multipart_upload.rb
@@ -178,6 +178,8 @@ module AWS
       #     this option must match the total number of bytes written
       #     to S3 during the operation.  This option is required if
       #     +:data+ is an IO-like object without a +size+ method.
+      #
+      #   @option options [Integer] :part_number The part number.
       def add_part(data_or_options, options = {})
         if data_or_options.kind_of?(Hash)
           part_options = base_opts.merge(data_or_options)


### PR DESCRIPTION
The `add_part` method of `MultipartUpload` accepts `:part_number` as a option, but references to it were missing in the Yard documentation.
