### PR TITLE
Handle nil output in AWS::EC2::Instance#console_output

### DIFF
--- a/lib/aws/ec2/instance.rb
+++ b/lib/aws/ec2/instance.rb
@@ -467,7 +467,8 @@ module AWS
       #
       # @return [String] the console output.
       def console_output
-        Base64.decode64(client.get_console_output(:instance_id => self.id).output)
+        output = client.get_console_output(:instance_id => self.id).output
+        Base64.decode64(output) if output
       end
 
       # Associates the elastic IP address with this instance.


### PR DESCRIPTION
Freshly started instances don't yet have console output available, in which case the current code passes nil to Base64::decode64. This commit makes console_output return nil instead.

```
>> i.console_output
NoMethodError: undefined method `unpack' for nil:NilClass
    from /usr/lib/ruby/1.8/base64.rb:59:in `decode64'
    from /var/lib/gems/1.8/gems/aws-sdk-1.2.4/lib/aws/ec2/instance.rb:470:in `console_output'
    from (irb):27
    from :0
```
