### PR TITLE
Fixed S3 request logging slowdown

### DIFF
--- a/lib/aws/core/client_logging.rb
+++ b/lib/aws/core/client_logging.rb
@@ -25,12 +25,14 @@ module AWS
           response = yield
         end
   
-        if options[:async]
-          response.on_complete do
+        if config.logger
+          if options[:async]
+            response.on_complete do
+              log_client_request_on_success(name, options, response, time)
+            end
+          else
             log_client_request_on_success(name, options, response, time)
           end
-        else
-          log_client_request_on_success(name, options, response, time)
         end
         response
       end


### PR DESCRIPTION
Logging sanity checks peg CPU on S3 uploads. Bail out of logging code sooner when logging is disabled. EC2 upload throughput to S3 increased from 15Mbit to >100Mbit.
