### PR TITLE
Improved documentation on S3 object versions

### DIFF
--- a/lib/aws/s3/object_version_collection.rb
+++ b/lib/aws/s3/object_version_collection.rb
@@ -23,7 +23,21 @@ module AWS
     #   object.write('3')
     #
     #   object.versions.collect(&:read)
-    #   #=> ['1', '2', '3']
+    #   #=> ['1', '2', '3']         
+    #                                         
+    # To see all the version id for a particular object, access the any particular version,
+    # and see the latest version:
+    #
+    #   object.versions.each do |version| puts version.version_id end
+    #   #=> T2TwAiZ3SmNr7tOfe0QBa4RZnSb3GSLq
+    #   #=> kAEHC_ysT65bT4P3zyYOP1ELA6ajar_6
+    #   #=> itHPX6m8na_sog0cAtkgP3QITEE8v5ij
+    #  
+    #   object.versions['itHPX6m8na_sog0cAtkgP3QITEE8v5ij']
+    #   #=> <AWS::S3::ObjectVersion:<<bucket>>:myobj:itHPX6m8na_sog0cAtkgP3QITEE8v5ij>
+    #
+    #   object.versions.latest
+    #   #=> <AWS::S3::ObjectVersion:<<bucket>>:myobj:T2TwAiZ3SmNr7tOfe0QBa4RZnSb3GSLq>
     #
     # If you know the id of a particular version you can get that object.
     #


### PR DESCRIPTION
After using the API for the first time, I found that the examples I needed were not originally provided. I've updated them to be more clear for the next person.

Now, that I can find the version id for older versions of S3 objects, it is still not clear to me on how to get it out of S3. 
