### PR TITLE
Alias to work with rails model

### DIFF
--- a/lib/aws/record/abstract_base.rb
+++ b/lib/aws/record/abstract_base.rb
@@ -202,6 +202,7 @@ module AWS
             raise 'unable to delete, this object has not been saved yet'
           end
         end
+        alias_method :destroy, :delete
   
         # @return [Boolean] Returns true if this instance object has been deleted.
         def deleted?


### PR DESCRIPTION
ActiveRecord and ActiveModel classes in Rails use the destroy method instead of the delete method. This commit contains an alias_method for delete and destroy.
