### PR TITLE
Fix bug in SortableFloatAttr.deserialize that renders it unusable.

### DIFF
--- a/lib/aws/record/model/attributes.rb
+++ b/lib/aws/record/model/attributes.rb
@@ -126,9 +126,11 @@ module AWS
           end
 
           def self.deserialize string_value, options = {}
-            left, right = float.to_s.split('.')
-            left = SortableIntegerAttr.deserialize(left, options)
-            "#{left}.#{right}".to_f
+            expect(String, string_value) do
+              left, right = string_value.split('.')
+              left = SortableIntegerAttr.deserialize(left, options)
+              "#{left}.#{right}".to_f
+            end
           end
 
         end


### PR DESCRIPTION
Method references a parameter that has the wrong name, resulting in errors when attempting to get existing Model objects from SimpleDB.
