### PR TITLE
a friendlier nokogiri version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ source 'http://rubygems.org'
 
 gem 'uuidtools', '~> 2.1'
 gem 'httparty', '~> 0.7'
-gem 'nokogiri', '<= 1.5.0'
+gem 'nokogiri', '<= 1.6.0'
 gem 'json', '~> 1.4.6'
 
 group :debug do


### PR DESCRIPTION
This version requirement is friendlier for libraries that require higher versions of nokogiri.

If you are going to allow 1.5, you may as well allow anything in the 1.5.x series unless you have reason to do otherwise. (although perhaps I'm not aware of the reason for the version requirement)

all the specs pass.
