### PR TITLE
Fix SignatureDoesNotMatch caused by URI escape not conform to RFC 3986

### DIFF
--- a/lib/aws/core/uri_escape.rb
+++ b/lib/aws/core/uri_escape.rb
@@ -25,7 +25,7 @@ module AWS
       protected
       def escape value
         value = value.encode("UTF-8") if value.respond_to?(:encode)
-        CGI::escape(value.to_s).gsub('+', '%20')
+        CGI::escape(value.to_s).gsub('+', '%20').gsub('%7E', '~')
       end
 
       # URI-escapes a path without escaping the separators


### PR DESCRIPTION
Replace %7E with ~ to make escaped string conform to RFC 3986
