### PR TITLE
[SES] Bugfix for send_raw_email.

### DIFF
--- a/lib/aws/simple_email_service.rb
+++ b/lib/aws/simple_email_service.rb
@@ -290,14 +290,12 @@ module AWS
       send_opts = {}
       send_opts[:raw_message] = {}
       send_opts[:raw_message][:data] = raw_message.to_s
-      
-      if raw_message.class.name == 'Mail::Message'
-        send_opts[:source] = raw_message.from.first
+      send_opts[:source] = options[:from] if options[:from]
+
+      if raw_message.respond_to?(:destinations)
         send_opts[:destinations] = raw_message.destinations
-      else
-        send_opts[:source] = options[:from] if options[:from]
-        send_opts[:destinations] = [options[:to]].flatten if options[:to]
       end
+      send_opts[:destinations] = [options[:to]].flatten if options[:to]
 
       client.send_raw_email(send_opts)
       nil

--- a/spec/aws/simple_email_service_spec.rb
+++ b/spec/aws/simple_email_service_spec.rb
@@ -216,6 +216,36 @@ module AWS
         ses.method(:send_raw_email).should == ses.method(:deliver!)
       end
 
+      context 'with an object as input, that understands destinations (e.g. Mail::Message)' do
+        let(:raw) do
+          r = "raw"
+          r.stub!(:destinations => ['bcc'])
+          r
+        end
+
+        it 'should use the destinations from raw' do
+          client.should_receive(:send_raw_email).with(
+              :raw_message => { :data => 'raw' },
+              :destinations => ['bcc'])
+          ses.send_raw_email(raw)
+        end
+
+        it 'should use the to option as destination, when given' do
+          client.should_receive(:send_raw_email).with(
+              :raw_message => { :data => 'raw' },
+              :destinations => ['to1', 'to2'])
+          ses.send_raw_email(raw, :to => ['to1', 'to2'])
+        end
+
+        it 'should use the from option, when given' do
+          client.should_receive(:send_raw_email).with(
+              :raw_message => { :data => 'raw' },
+              :destinations => ['bcc'],
+              :source => 'from')
+          ses.send_raw_email(raw, :from => 'from')
+        end
+      end
+
     end
 
     context '#quotas' do


### PR DESCRIPTION
When passing a mail option to send_raw_email, options[:to] and options[:from] where useless. With this fix, options can still be passed. Also BCC addresses from the mail object work correctly.
