### PR TITLE
Allow filename as a presigned post parameter

### DIFF
--- a/lib/aws/s3/presigned_post.rb
+++ b/lib/aws/s3/presigned_post.rb
@@ -81,7 +81,8 @@ module AWS
                         :acl,
                         :server_side_encryption,
                         :success_action_redirect,
-                        :success_action_status]
+                        :success_action_status,
+                        :filename]
 
       # @private
       attr_reader :conditions

--- a/spec/aws/s3/presigned_post_spec.rb
+++ b/spec/aws/s3/presigned_post_spec.rb
@@ -569,6 +569,8 @@ module AWS
                       "success_action_redirect", :success_action_redirect)
       it_behaves_like("presigned post special field",
                       "success_action_status", :success_action_status)
+      it_behaves_like("presigned post special field",
+                      "Filename", :filename)
 
     end
 


### PR DESCRIPTION
Flash adds a 'Filename' parameter to any posted upload. This commit adds 'filename' to the list of fields allowable as conditions on presigned post uploads. S3 discards it, but it's required to generate policies that work with flash uploaders.

As an example, the following is now allowed (and is required in order to work with a flash uploader:)

```
  policy = bucket.presigned_post(key: key, success_action_status: 201, acl: 'public-read')
                  .where(:filename).starts_with('')
```
