### PR TITLE
Every once in awhile, we are getting undefined method `version_id' for #...

### DIFF
--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -310,7 +310,7 @@ module AWS
         else
           opts = { :bucket_name => bucket.name, :key => key }
           resp = client.put_object(opts.merge(put_options).merge(data_options))
-          if resp.version_id
+          if resp.respond_to? :version_id
             ObjectVersion.new(self, resp.version_id)
           else
             self


### PR DESCRIPTION
...AWS::Core::Data:0x007fce82d81c08

..../shared/bundle/ruby/1.9.1/gems/aws-sdk-1.5.1/lib/aws/core/response.rb:175:in `method_missing'
..../shared/bundle/ruby/1.9.1/gems/aws-sdk-1.5.1/lib/aws/s3/s3_object.rb:313:in`write'
