### PR TITLE
batch-write retry mechanism causes list properties to be mangled...

### DIFF
--- a/lib/aws/dynamo_db/batch_write.rb
+++ b/lib/aws/dynamo_db/batch_write.rb
@@ -235,7 +235,7 @@ module AWS
       end
 
       def str2sym key_desc
-        type, value = key_desc.to_a.flatten
+        type, value = key_desc.flatten
         case type
         when "S"  then { :s  => value }
         when "N"  then { :n  => value }


### PR DESCRIPTION
... and in turn rejected by validation. e.g. {"SS" => ['A','B']} will be converted to {:ss => 'A'}
