### PR TITLE
normalize s3 key in delete xml

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -912,7 +912,7 @@ module AWS
           keys = options[:objects] || options[:keys]
 
           objects = keys.inject('') do |xml,o|
-            xml << "<Object><Key>#{o[:key]}</Key>"
+            xml << "<Object><Key>#{REXML::Text.normalize(o[:key])}</Key>"
             xml << "<VersionId>#{o[:version_id]}</VersionId>" if o[:version_id]
             xml << "</Object>"
           end


### PR DESCRIPTION
Was having some issues removing objects from one of our s3 buckets due to ampersands in the keys. This simple patch normalizes the key in the delete xml, and should resolve the issue.
