### PR TITLE
Issue with include? in IpPermissionCollection

### DIFF
--- a/lib/aws/ec2/security_group/ip_permission.rb
+++ b/lib/aws/ec2/security_group/ip_permission.rb
@@ -43,7 +43,7 @@ module AWS
 
           @groups = Array(options[:groups])
 
-          @egress = options[:egress]
+          @egress = options[:egress] || false
 
           # not all egress permissions require port ranges, depends on the
           # protocol
@@ -71,6 +71,9 @@ module AWS
         # @return [Array] An array of security groups that have been 
         # granted access with this permission.
         attr_reader :groups
+
+        # @return [Boolean] True if this is an egress permission
+        attr_reader :egress
 
         # @return [Boolean] Returns true if this is an egress permission.
         def egress?

--- a/spec/aws/ec2/security_group/ip_permission_collection_spec.rb
+++ b/spec/aws/ec2/security_group/ip_permission_collection_spec.rb
@@ -98,6 +98,11 @@ module AWS
             perm.groups[1].owner_id.should == 'grp2-user-id'
           end
 
+          it 'should properly execute include?' do
+            perm = collection.to_a.first
+            collection.include?(perm).should be(true)
+          end
+
           context 'vpc security group without ports' do
             
             let(:ip_permissions) do


### PR DESCRIPTION
When checking to see if a permission is included in the collection it failed because `egress` wasn't accessible and while `egress?` exists it is not called when `collection.include? IpPermissions` is called on the collection.
