### PR TITLE
Don't force simplecov presence

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require 'simplecov'
-SimpleCov.start
+begin
+  require 'simplecov'
+  SimpleCov.start
+rescue LoadError
+end
 
 $: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
 


### PR DESCRIPTION
For Gentoo packaging for instance we don't want to know how much of
the code is covered by the tests, we just want to make sure that the
tests pass properly.
