### PR TITLE
Allow for setting Content-Disposition as part of copy operations

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1087,6 +1087,7 @@ module AWS
         :cache_control => 'Cache-Control',
         :metadata_directive => 'x-amz-metadata-directive',
         :content_type => 'Content-Type',
+        :content_disposition => 'Content-Disposition',
       }) do
 
         configure_request do |req, options|

--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -809,6 +809,11 @@ module AWS
           end
         end
 
+        if options[:content_disposition]
+          copy_opts[:content_disposition] = options[:content_disposition]
+          copy_opts[:metadata_directive] = "REPLACE"
+        end
+
         if options[:content_type]
           copy_opts[:content_type] = options[:content_type]
           copy_opts[:metadata_directive] = "REPLACE"

--- a/spec/aws/s3/s3_object/copy_spec.rb
+++ b/spec/aws/s3/s3_object/copy_spec.rb
@@ -85,6 +85,14 @@ module AWS
           obj1.copy_from('bucket/key', :metadata => { 'foo' => 'bar' })
         end
 
+        it 'allows you to change content disposition' do
+          client.should_receive(:copy_object).with(hash_including(
+            :metadata_directive => 'REPLACE',
+            :content_disposition => "inline"
+          ))
+          obj1.copy_from("bucket/key", :content_disposition => "inline")
+        end
+
         it 'allows you to change content type' do
           client.should_receive(:copy_object).with(hash_including(
             :metadata_directive => 'REPLACE',


### PR DESCRIPTION
Currently, you can only set Content-Disposition as part of a write() operation. This patch allows it to be set as part of a copy or move operation.

Credit due to: http://stackoverflow.com/questions/11138336/how-to-add-change-content-disposition-of-existing-s4-object
