### PR TITLE
Added a documentation for cloud_watch_endpoint

### DIFF
--- a/lib/aws/core.rb
+++ b/lib/aws/core.rb
@@ -209,6 +209,9 @@ module AWS
     # @option options [String] :cloud_formation_endpoint ('cloudformation.us-east-1.amazonaws.com')
     #   The service endpoint for AWS CloudFormation.
     #
+    # @option options [String] :cloud_watch_endpoint ('monitoring.us-east-1.amazonaws.com')
+    #   The service endpoint for Amazon CloudWatch.
+    #
     # @option options [String] :dynamo_db_endpoint ('dynamodb.amazonaws.com')
     #   The service endpoint for Amazon DynamoDB.
     #

--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -69,6 +69,9 @@ module AWS
     # @attr_reader [String] cloud_formation_endpoint ('cloudformation.us-east-1.amazonaws.com')
     #   The service endpoint for AWS CloudFormation.
     #
+    # @attr_reader [String] cloud_watch_endpoint ('monitoring.us-east-1.amazonaws.com')
+    #   The service endpoint for Amazon CloudWatch.
+    #
     # @attr_reader [String] dynamo_db_endpoint ('dynamodb.us-east-1.amazonaws.com')
     #   The service endpoint for Amazon DynamoDB.
     #


### PR DESCRIPTION
I couldn't find a documentation for cloud_watch_endpoint.
I added it!
