### PR TITLE
Fix re-use of stale temporary credentials.

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -121,6 +121,12 @@ module AWS
           {}
         end
 
+        def refresh
+          providers.each do |provider|
+            provider.refresh
+          end
+          super
+        end
       end
 
       # Static credentials are provided directly to config via

--- a/spec/aws/core/credential_providers_spec.rb
+++ b/spec/aws/core/credential_providers_spec.rb
@@ -60,6 +60,15 @@ module AWS
 
         end
 
+        it 'refreshes its provider chain' do
+          p1 = double('provider-1')
+          p1.should_receive(:refresh)
+          
+          provider = DefaultProvider.new
+          provider.providers.clear
+          provider.providers << p1
+          provider.refresh
+        end
       end
 
       describe StaticProvider do


### PR DESCRIPTION
When temporary credentials (i.e. from EC2Provider) expire,
the SDK refreshes the credential provider and tries again.
Unfortunately, only DefaultProvider has its cached credentials
cleared; it does not propagate this to the sub-providers.
The next time the credentials are accessed, DefaultProvider's
credentials are re-cached from the stale sub-provider credentials.

This is fixed by making DefaultProvider#refresh also call #refresh
on all of its sub-providers.
