### PR TITLE
Add MFA credential support to S3 object version delete methods.

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -953,8 +953,9 @@ module AWS
       #   @option options [required,String] :bucket_name
       #   @option options [required,String] :key
       #   @option options [String] :version_id
+      #   @option options [String] :mfa
       #   @return [Core::Response]
-      object_method(:delete_object, :delete) do
+      object_method(:delete_object, :delete, :header_options => { :mfa => "x-amz-mfa" }) do
 
         configure_request do |req, options|
           super(req, options)

--- a/lib/aws/s3/object_version.rb
+++ b/lib/aws/s3/object_version.rb
@@ -94,9 +94,14 @@ module AWS
       end
 
       # Deletes this object version from S3.
+      # @option options [String] :mfa The serial number and current token code of
+      #   the Multi-Factor Authentication (MFA) device for the user. Format
+      #   is "SERIAL TOKEN" - with a space between the serial and token.
       # @return (see S3Object#delete)
-      def delete
-        object.delete(:version_id => @version_id)
+      def delete(options = {})
+        object.delete(:version_id => @version_id,
+                      :mfa        => options[:mfa]
+                     )
       end
 
       # @return [Boolean] Returns this if this is the latest version of

--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -361,9 +361,12 @@ module AWS
       #   if you use client-side encryption and the encryption materials
       #   were stored in a separate object in S3 (key.instruction).
       #
+      # @option [String] :mfa The serial number and current token code of
+      #   the Multi-Factor Authentication (MFA) device for the user. Format
+      #   is "SERIAL TOKEN" - with a space between the serial and token.
+      #
       # @return [nil]
       def delete options = {}
-
         client.delete_object(options.merge(
           :bucket_name => bucket.name,
           :key => key))

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -337,6 +337,27 @@ module AWS
 
       end
 
+      shared_examples_for "accepts mfa credentials" do
+
+        it 'adds no header when mfa is nil' do
+          req_headers = nil
+          opts.delete(:mfa)
+          client.with_http_handler do |req, resp|
+            req_headers = req.headers
+          end.send(method, opts)
+          req_headers['x-amz-mfa'].should == nil
+        end
+
+        it 'adds a header when mfa is passed' do
+          req_headers = nil
+          client.with_http_handler do |req, resp|
+            req_headers = req.headers
+          end.send(method, opts.merge(:mfa => '123456 7890'))
+          req_headers['x-amz-mfa'].should == '123456 7890'
+        end
+
+      end
+
       shared_examples_for "accepts version id" do
 
         it 'adds no param wheren version_id is nil' do
@@ -1532,6 +1553,7 @@ module AWS
 
         it_should_behave_like "accepts version id"
 
+        it_should_behave_like "accepts mfa credentials"
       end
 
       context '#delete_objects' do

--- a/spec/aws/s3/object_version_spec.rb
+++ b/spec/aws/s3/object_version_spec.rb
@@ -170,6 +170,12 @@ module AWS
           version.delete
         end
 
+        it 'should call delete on the object with mfa credentials if specified' do
+          object.should_receive(:delete).
+            with(hash_including(:mfa => '123456 7890'))
+          version.delete(:mfa => '123456 7890')
+        end
+
       end
 
       context '#read' do


### PR DESCRIPTION
Follows more or less the same pattern as per enabling MFA authentication to be used with bucket versioning methods.

It would be great to see some way of deleting multiple versions with the one token (e.g. using delete_objects rather than delete_object), since you are currently restricted to just one version to delete with a single token.
