### PR TITLE
Hey Guys, could you pick up this change? It fixes a typo on line:123 of lib\aws\s3\s3_object.rb.

### DIFF
--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -120,7 +120,7 @@ module AWS
     # Amazon S3 provides server side encryption for an additional cost.
     # You can specify to use server side encryption when writing an object.
     #
-    #   obj.write('data', :server_size_encryption => :aes256)
+    #   obj.write('data', :server_side_encryption => :aes256)
     #
     # You can also make this the default behavior.
     #


### PR DESCRIPTION
Fix typo: server_size_encryption should be server_side_encryption
