### PR TITLE
Cloud Watch metric class with error

### DIFF
--- a/lib/aws/cloud_watch/metric.rb
+++ b/lib/aws/cloud_watch/metric.rb
@@ -106,7 +106,7 @@ module AWS
         options[:period] ||= 60
 
         resp = client.get_metric_statistics(options)
-        
+
         MetricStatistics.new(self, resp[:label], resp[:datapoints])
 
       end
@@ -120,8 +120,8 @@ module AWS
 
       def resource_identifiers
         [
-          [:namespace, namespace], 
-          [:metric_item, metric_name], 
+          [:namespace, namespace],
+          [:metric_name, metric_name],
           [:dimensions, dimensions],
         ]
       end


### PR DESCRIPTION
## Error

``` Ruby
metric = AWS::CloudWatch::Metric.new('Tracking', 'showcase_time')
metric.exists?
```

ArgumentError: unexpected option metric_item
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/option_grammar.rb:587:in `block in validate'
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/option_grammar.rb:584:in`each'
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/option_grammar.rb:584:in `validate'
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/option_grammar.rb:600:in`request_params'
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/query_request_builder.rb:37:in `populate_request'
    from /usr/local/rvm/gems/ruby-1.9.2-p320/gems/aws-sdk-1.6.9/lib/aws/core/client.rb:607:in`block (2 levels) in define_client_method'
(...)
## Cause

In Metric Class implementation resource_identifiers was responding:

``` ruby
def resource_identifiers
  [
    [:namespace, namespace], 
    [:metric_item, metric_name],  # metric_name expected! :D
    [:dimensions, dimensions],
  ]
end
```

but _metric_name_ was expected
