### PR TITLE
Update to speed up s3 etag lookup

### DIFF
--- a/lib/aws/s3/object_collection.rb
+++ b/lib/aws/s3/object_collection.rb
@@ -287,7 +287,7 @@ module AWS
       def each_member_in_page(page, &block)
         super
         page.contents.each do |content|
-          yield(S3Object.new(bucket, content.key, {'etag' => content.etag}))
+          yield(S3Object.new(bucket, content.key, {'etag' => content['etag']}))
         end
       end
 

--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -304,7 +304,7 @@ module AWS
       #
       # @return [String] Returns the object's ETag
       def etag
-        unless etag
+        unless @etag
           @etag = head.etag
         end
         @etag


### PR DESCRIPTION
This is a small change to enable the passing of the etag variable when doing a multipage query of objects in S3. 

S3 etag can be used for comparisons between buckets, and the only method to currently get them is one at a time. This just uses information that has already been pulled by adding it to the s3object.
