### PR TITLE
Speed up s3 etag retrieval

### DIFF
--- a/lib/aws/s3/object_collection.rb
+++ b/lib/aws/s3/object_collection.rb
@@ -287,7 +287,7 @@ module AWS
       def each_member_in_page(page, &block)
         super
         page.contents.each do |content|
-          yield(S3Object.new(bucket, content.key, {'etag' => content.etag}))
+          yield(S3Object.new(bucket, content.key, {'etag' => content['etag']}))
         end
       end
 

--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -304,7 +304,7 @@ module AWS
       #
       # @return [String] Returns the object's ETag
       def etag
-        unless etag
+        unless @etag
           @etag = head.etag
         end
         @etag


### PR DESCRIPTION
Ran rake tasks this time, and they all passed. 

This modification just uses the information that is passed back from the request to populate the etag entry for an s3 object. It sets the value to whatever is passed, but leaves as nul if it is not present.

The get etag feature will pull from the object itself, or if it is not present, it will then do a head request. 
