### PR TITLE
Use Object#to_enum instead of Enumerator.new without a block

### DIFF
--- a/lib/aws/core/collection.rb
+++ b/lib/aws/core/collection.rb
@@ -99,7 +99,7 @@ module AWS
       #   collection.
       #
       def enum options = {}
-        Enumerator.new(self, :each, options)
+        to_enum(:each, options)
       end
       alias_method :enumerator, :enum
 


### PR DESCRIPTION
Fix warning
warning: Enumerator.new without a block is deprecated; use Object#to_enum
