### PR TITLE
fix expired_credentials? expired token error code name for SQS

### DIFF
--- a/lib/aws/core/client.rb
+++ b/lib/aws/core/client.rb
@@ -309,7 +309,7 @@ module AWS
       def expired_credentials? response
         response.error and
         response.error.respond_to?(:code) and
-        response.error.code == 'ExpiredTokenException'
+        (response.error.code == 'ExpiredTokenException' || response.error.code == 'ExpiredToken')
       end
 
       def return_or_raise options, &block

--- a/spec/aws/sqs/client_spec.rb
+++ b/spec/aws/sqs/client_spec.rb
@@ -67,6 +67,22 @@ END
 
       end
 
+      context 'error handling' do
+        it 'should refresh credentials when it is expired' do
+          client.config.credential_provider.should_receive(:refresh).once
+          http_handler.should_receive(:handle) do |req, resp|
+            resp.body = <<END
+<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2009-02-01/"><Error><Type>Sender</Type><Code>ExpiredToken</Code><Message> The security token included in the request is expired</Message><Detail/></Error><RequestId>abc123</RequestId></ErrorResponse>
+END
+            resp.status = 400
+          end.ordered
+          http_handler.should_receive(:handle) do |req, resp|
+            resp.body = ""
+            resp.status = 200
+          end.ordered
+          client.list_queues
+        end
+      end
     end
 
   end


### PR DESCRIPTION
SQS service responses different error code (ExpiredToken) for iam role profile based temp credentials token expires error.
But the core/client only checks error code 'ExpiredTokenException' for auto refreshing credentials.

The change adds a new error code check for recognizing expired credentials response. Tested on my aws environment.
