### PR TITLE
Method to return sqs message body as a hash

### DIFF
--- a/lib/aws/sqs/received_sns_message.rb
+++ b/lib/aws/sqs/received_sns_message.rb
@@ -106,7 +106,11 @@ module AWS
         }
       end
 
-    end
+      # @return [Hash] Returns the decoded message body as a hash.
+      def body_message_as_h
+        @body_message_as_h ||= JSON.parse(to_h[:body])
+      end
 
+    end
   end
 end


### PR DESCRIPTION
A lot of times, an SQS message body will contain structured JSON data.  For instance, when Auto-Scale sends a scaling activity notification via an SQS queue, the message body (stored internally as data[:body]["Message"]) is in JSON.   

Unfortunately, the current methods only return this JSON as a string.   Every message then has to be parsed.  This seems like a pretty common use case.   

This pull request adds that functionality through a method called body_message_as_h.  This name is consistent with the internal data structure data[:body]["Message"].
