### PR TITLE
Remove warning, Enumerator.new without a blokc is deprecated

### DIFF
--- a/lib/aws/record/scope.rb
+++ b/lib/aws/record/scope.rb
@@ -140,7 +140,7 @@ module AWS
         if block_given?
           _each_object(&block)
         else
-          Enumerator.new(self, :"_each_object")
+          to_enum(:"_each_object")
         end
       end
 


### PR DESCRIPTION
use Object#to_enum
