### PR TITLE
auto refresh EC2 credential provider when the credential is expired

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -114,18 +114,17 @@ module AWS
         # @return [Array<Provider>]
         attr_reader :providers
 
-        def get_credentials
+        def credentials
           providers.each do |provider|
             return provider.credentials rescue Errors::MissingCredentialsError
           end
-          {}
+          raise Errors::MissingCredentialsError
         end
 
         def refresh
           providers.each do |provider|
             provider.refresh
           end
-          super
         end
       end
 

--- a/spec/aws/core/credential_providers_spec.rb
+++ b/spec/aws/core/credential_providers_spec.rb
@@ -66,11 +66,36 @@ module AWS
         it 'refreshes its provider chain' do
           p1 = double('provider-1')
           p1.should_receive(:refresh)
-          
+
           provider = DefaultProvider.new
           provider.providers.clear
           provider.providers << p1
           provider.refresh
+        end
+
+        it 'should not cache credentials as EC2Provider may refresh the credentials when the security token is expired' do
+          dp = DefaultProvider.new
+          ec2_provider = dp.providers[0] = EC2Provider.new
+          ec2_provider.stub(:credentials => {
+                              :access_key_id => 'akid-1',
+                              :secret_access_key => 'secret-1',
+                              :session_token => 'token-1'
+                            })
+          dp.credentials.should == {
+            :access_key_id => 'akid-1',
+            :secret_access_key => 'secret-1',
+            :session_token => 'token-1'
+          }
+          ec2_provider.stub(:credentials => {
+                              :access_key_id => 'akid-2',
+                              :secret_access_key => 'secret-2',
+                              :session_token => 'token-2'
+                            })
+          dp.credentials.should == {
+            :access_key_id => 'akid-2',
+            :secret_access_key => 'secret-2',
+            :session_token => 'token-2'
+          }
         end
       end
 


### PR DESCRIPTION
=== The problem ===

S3Object signs a url for accessing S3 file locally (S3Object#url_for), which does not fire any request to AWS service. When using the aws iam role instance credential on ec2 instance, the S3Object#url_for may return an security token expired url if the credential is expired.
The auto refresh credential basing on token expire error respond from server will not work well in this case because no request is sent out.
S3Object#exits? also return false when the temp credentials got from ec2 instance metadata is expired.

=== The fix ===

Base on document: http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/UsingIAM.html#UsingIAMrolesWithAmazonEC2Instances

"AWS access keys on an EC2 instance are rotated automatically multiple times a day. New access keys will be made available at least five minutes prior to the expiration of the old access keys."

Make EC2 credential provider refresh the cached credential when the credential is going to expired within 5 min.
The DefaultProvider is also caching the credential, so have to change it to not cache the credential.
