### PR TITLE
Added the ability to skip validations when saving AWS::Record::Model instances.

### DIFF
--- a/lib/aws/record/abstract_base.rb
+++ b/lib/aws/record/abstract_base.rb
@@ -130,9 +130,12 @@ module AWS
           !persisted?
         end
   
+        # @param [Hash] opts Pass :validate => false to skip validations
         # @return [Boolean] Returns true if this record has no validation errors.
-        def valid?
-          run_validations
+        def valid? opts = {}
+          opts = {} if opts.nil?
+          opts = {:validate => true}.merge(opts)
+          run_validations if opts[:validate]
           errors.empty?
         end
   
@@ -141,10 +144,11 @@ module AWS
         end
   
         # Creates new records, updates existing records.
+        # @param [Hash] opts Pass :validate => false to skip validations
         # @return [Boolean] Returns true if the record saved without errors,
         #   false otherwise.
-        def save
-          if valid?
+        def save opts = {}
+          if valid?(opts)
             persisted? ? update : create
             clear_changes!
             true

--- a/spec/aws/record/model/instance_methods_spec.rb
+++ b/spec/aws/record/model/instance_methods_spec.rb
@@ -485,6 +485,28 @@ module AWS
 
             end
 
+            context ':validate' do
+              before(:each) do
+                klass.string_attr :category
+                @obj = klass.new(:category => "test")
+              end
+              it '=> false should skip validations and just save' do
+                @obj.should_not_receive(:run_validations)
+                @obj.should_receive(:create)
+                @obj.save(:validate => false)
+              end
+              it '=> true should run validations not save' do
+                @obj.should_receive(:run_validations)
+                @obj.should_receive(:create)
+                @obj.save(:validate => true)
+              end
+              it 'should default to running validataions' do
+                @obj.should_receive(:run_validations)
+                @obj.should_receive(:create)
+                @obj.save()
+              end
+            end
+
           end
         end
       end


### PR DESCRIPTION
When you have an instance of a class inheriting from AWS::Record::Model you can skip validations by calling:

``` ruby
    my_obj.save(:validate => false)
```

The implementation is backwards compatible.  Specs are included.
