### PR TITLE
Add the :allow_blank option to validations of AWS::Record that can support it.

### DIFF
--- a/lib/aws/record/validations.rb
+++ b/lib/aws/record/validations.rb
@@ -42,7 +42,8 @@ module AWS
     #
     #     validates_length_of :summary, 
     #       :max => 500,
-    #       :allow_nil => true
+    #       :allow_nil => true,
+    #       :allow_blank => true
     #
     #   end
     #
@@ -217,6 +218,8 @@ module AWS
       #     +:message+ is "must be accepted".
       #   @option options [Boolean] :allow_nil (true) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (true) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -265,7 +268,8 @@ module AWS
       # This validator works only with single-valued attributes.
       # It should not be used on attributes that have array or set values.
       #
-      # @note This validation method does not accept the +:allow_nil+ option.
+      # @note This validation method does not accept the +:allow_nil+ or the
+      # +:allow_blank+ options.
       #
       # @overload validates_confirmation_of(*attributes, options = {}, &block)
       #   @param attributes A list of attribute names to validate.
@@ -393,6 +397,8 @@ module AWS
       #   @param [Hash] options
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -439,6 +445,8 @@ module AWS
       #     +:message+ is "is reserved".
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -488,6 +496,8 @@ module AWS
       #     +:message+ is "is reserved".
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -525,6 +535,8 @@ module AWS
       #     +:message+ is "is not included in the list".
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -586,6 +598,8 @@ module AWS
       #     length (should be %{exactly} characters"</code>
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -636,6 +650,8 @@ module AWS
       #     +:message+ is "is not a number".
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol] :on (:save) When this validation is run.
       #     Valid values include:
       #     * +:save+
@@ -672,6 +688,8 @@ module AWS
       #     * +:update+
       #   @option options [Boolean] :allow_nil (false) Skip validation if the
       #     attribute value is +nil+.
+      #   @option options [Boolean] :allow_blank (false) Skip validation if the
+      #     attribute value is +blank+.
       #   @option options [Symbol,String,Proc] :if Specifies a method or proc
       #     to call.  The validation will only be run if the return value is
       #     of the method/proc is true (e.g. +:if => :name_changed?+ or

--- a/lib/aws/record/validator.rb
+++ b/lib/aws/record/validator.rb
@@ -97,8 +97,17 @@ module AWS
       def validate_attributes record
         attribute_names.each do |attribute_name|
           value = read_attribute_for_validation(record, attribute_name)
-          next if value.nil? and options[:allow_nil]
+          next if (value.nil? && options[:allow_nil]) || (blank?(value) && options[:allow_blank])
           validate_attribute(record, attribute_name, value)
+        end
+      end
+
+      def blank? value
+        case value
+        when nil        then true
+        when String     then value !~ /\S/
+        else
+          !value
         end
       end
 

--- a/lib/aws/record/validators/acceptance.rb
+++ b/lib/aws/record/validators/acceptance.rb
@@ -19,7 +19,7 @@ module AWS
     # @private
     class AcceptanceValidator < Validator
 
-      ACCEPTED_OPTIONS = [:accept, :message, :allow_nil, :on, :if, :unless]
+      ACCEPTED_OPTIONS = [:accept, :message, :allow_nil, :allow_blank, :on, :if, :unless]
 
       def setup record_class
         set_default(:allow_nil, true)

--- a/lib/aws/record/validators/block.rb
+++ b/lib/aws/record/validators/block.rb
@@ -19,7 +19,7 @@ module AWS
     # @private
     class BlockValidator < Validator
 
-      ACCEPTED_OPTIONS = [:allow_nil, :on, :if, :unless]
+      ACCEPTED_OPTIONS = [:allow_nil, :allow_blank, :on, :if, :unless]
 
       def initialize *args, &block
         @block = block

--- a/lib/aws/record/validators/exclusion.rb
+++ b/lib/aws/record/validators/exclusion.rb
@@ -19,7 +19,7 @@ module AWS
     # @private
     class ExclusionValidator < InclusionValidator
 
-      ACCEPTED_OPTIONS = [:in, :message, :allow_nil, :on, :if, :unless]
+      ACCEPTED_OPTIONS = [:in, :message, :allow_nil, :allow_blank, :on, :if, :unless]
 
       def setup record_class
         ensure_present(:in)

--- a/lib/aws/record/validators/format.rb
+++ b/lib/aws/record/validators/format.rb
@@ -21,7 +21,7 @@ module AWS
 
       ACCEPTED_OPTIONS = [
         :with, :without, 
-        :message, :allow_nil, :on, :if, :unless,
+        :message, :allow_nil, :allow_blank, :on, :if, :unless,
       ]
 
       def setup record_class

--- a/lib/aws/record/validators/inclusion.rb
+++ b/lib/aws/record/validators/inclusion.rb
@@ -19,7 +19,7 @@ module AWS
     # @private
     class InclusionValidator < Validator
 
-      ACCEPTED_OPTIONS = [:in, :message, :allow_nil, :on, :if, :unless]
+      ACCEPTED_OPTIONS = [:in, :message, :allow_nil, :allow_blank, :on, :if, :unless]
 
       def setup record_class
         ensure_present(:in)

--- a/lib/aws/record/validators/length.rb
+++ b/lib/aws/record/validators/length.rb
@@ -22,7 +22,7 @@ module AWS
       ACCEPTED_OPTIONS = [
         :exactly, :within, :minimum, :maximum,
         :too_long, :too_short, :wrong_length,
-        :allow_nil, :on, :if, :unless,
+        :allow_nil, :allow_blank, :on, :if, :unless,
       ]
 
       def setup record_class

--- a/lib/aws/record/validators/numericality.rb
+++ b/lib/aws/record/validators/numericality.rb
@@ -23,7 +23,7 @@ module AWS
         :greater_than, :greater_than_or_equal_to,
         :less_than, :less_than_or_equal_to,
         :equal_to, :only_integer, :odd, :even,
-        :message, :allow_nil, :on, :if, :unless,
+        :message, :allow_nil, :allow_blank, :on, :if, :unless,
       ]
 
       COMPARISONS = {

--- a/lib/aws/record/validators/presence.rb
+++ b/lib/aws/record/validators/presence.rb
@@ -19,7 +19,7 @@ module AWS
     # @private
     class PresenceValidator < Validator
 
-      ACCEPTED_OPTIONS = [:message, :allow_nil, :on, :if, :unless]
+      ACCEPTED_OPTIONS = [:message, :allow_nil, :allow_blank, :on, :if, :unless]
       
       def validate_attribute record, attribute_name, value
 

--- a/spec/aws/record/validations/acceptance_spec.rb
+++ b/spec/aws/record/validations/acceptance_spec.rb
@@ -68,6 +68,26 @@ module AWS
             
           end
 
+          context ':allow_blank' do
+
+            it 'defaults to false' do
+              klass.string_attr :confirmation
+              klass.validates_acceptance_of :confirmation
+              obj = klass.new :confirmation => " "
+              obj.confirmation.should == " "
+              obj.valid?.should == false
+            end
+
+            it 'skips the validation when set to true and the value is blank' do
+              klass.string_attr :confirmation
+              klass.validates_acceptance_of :confirmation, :allow_blank => true
+              obj = klass.new :confirmation => " "
+              obj.confirmation.should == " "
+              obj.valid?.should == true
+            end
+
+          end
+
           context ':accept' do
 
             it 'specifies an additional value that is valid' do

--- a/spec/aws/record/validations/confirmation_spec.rb
+++ b/spec/aws/record/validations/confirmation_spec.rb
@@ -19,7 +19,7 @@ module AWS
 
       context 'validates_confirmation_of' do
 
-        it_behaves_like("validation", :accepts_allow_nil => false) do
+        it_behaves_like("validation", :accepts_allow_nil => false, :accepts_allow_blank => false) do
 
           let(:validation_macro) { :validates_confirmation_of }
 

--- a/spec/aws/record/validations/count_spec.rb
+++ b/spec/aws/record/validations/count_spec.rb
@@ -19,7 +19,7 @@ module AWS
 
       context 'validates_confirmation_of' do
 
-        it_behaves_like("validation", :accepts_allow_nil => false) do 
+        it_behaves_like("validation", :accepts_allow_nil => false, :accepts_allow_blank => false) do 
 
           let(:validation_macro) { :validates_count_of }
 

--- a/spec/aws/record/validations/exclusion_spec.rb
+++ b/spec/aws/record/validations/exclusion_spec.rb
@@ -23,7 +23,7 @@ module AWS
 
           let(:validation_macro) { :validates_exclusion_of }
 
-          let(:opts) { { :in => %w(abc xyz) } }
+          let(:opts) { { :in => ['abc', 'xyz', ' '] } }
 
           let(:invalid_value) { 'abc' }
 

--- a/spec/aws/record/validations/length_spec.rb
+++ b/spec/aws/record/validations/length_spec.rb
@@ -23,7 +23,7 @@ module AWS
 
           let(:validation_macro) { :validates_length_of }
 
-          let(:opts) { { :minimum => 1 } }
+          let(:opts) { { :minimum => 2 } }
           
           let(:message_opt) { :too_short }
 

--- a/spec/aws/record/validations/numericality_spec.rb
+++ b/spec/aws/record/validations/numericality_spec.rb
@@ -638,6 +638,24 @@ module AWS
 
           end
 
+          context ':allow_blank' do
+
+            it 'skips validation when true and the value is blank' do
+              klass.send(:attr_accessor, :value)
+              klass.validates_numericality_of :value, :allow_blank => true
+              obj.value = ""
+              obj.valid?.should == true
+            end
+
+            it 'defaults to false' do
+              klass.send(:attr_accessor, :value)
+              klass.validates_numericality_of :value
+              obj.value = ""
+              obj.valid?.should == false
+            end
+
+          end
+
           context 'multiple errors' do
 
             it 'can add multiple error messages' do

--- a/spec/shared/record/validation_examples.rb
+++ b/spec/shared/record/validation_examples.rb
@@ -48,7 +48,7 @@ module AWS
       unless test_opts[:accepts_allow_nil] == false
 
         context ':allow_nil' do
-    
+
           it 'skips validation when :allow_nil and it has a nil value' do
             klass.send(validation_macro, :value, opts.merge(:allow_nil => true))
             obj = klass.new
@@ -59,6 +59,27 @@ module AWS
           it 'adds an error message when :allow_nil is false and it is invalid' do
             klass.send(validation_macro, :value, opts.merge(:allow_nil => false))
             obj.value = invalid_value
+            obj.valid?.should == false
+            obj.errors[:value].should_not be_empty
+          end
+
+        end
+      end
+
+      unless test_opts[:accepts_allow_blank] == false
+
+        context ':allow_blank' do
+
+          it 'skips validation when :allow_blank and it has a blank value' do
+            klass.send(validation_macro, :value, opts.merge(:allow_blank => true))
+            obj = klass.new :value => " "
+            obj.value.should == " "
+            obj.valid?.should == true
+          end
+
+          it 'adds an error message when :allow_blank is false and it is invalid' do
+            klass.send(validation_macro, :value, opts.merge(:allow_blank => false))
+            obj.value = " "
             obj.valid?.should == false
             obj.errors[:value].should_not be_empty
           end


### PR DESCRIPTION
This PR adds the :allow_blank option to a number of the validators in `AWS::Record`.  This allows for better compatibility with libraries that expect the validations provided by `ActiveModel` and allows for `AWS::Record` to be more of a ready drop in replacement for `ActiveRecord`.  

For instance Devise expects to be able to pass `:allow_blank => true` to `validates_uniqueness_of` and `validates_length_of`.  Without that option it is only possible to update a `User` record by resetting the `password` and the `password_confirmation` each time.
