### PR TITLE
Explicitly adds exists? method to AWS::IAM::User

### DIFF
--- a/lib/aws/iam/user.rb
+++ b/lib/aws/iam/user.rb
@@ -104,6 +104,9 @@ module AWS
         resp[:users].find{|u| u[:user_name] == name }
       end
 
+      # (see Resource#exists?)
+      def exists?; super; end
+
       # Deletes this user.
       # @return [nil]
       def delete


### PR DESCRIPTION
Being a subclass of `Resource`, the `exists?` method exists in `AWS::IAM::User`, but is not documented.  Following the lead of `AWS::IAM::Group`, I added the `exists?` method explicitly in the `User` class so that it will appear in generated documentation.
