### PR TITLE
Don't look for expiry-date when parsing headers of object with in-progress restore

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1419,13 +1419,16 @@ module AWS
         resp.data[:expiration_date] = exp_date if exp_date
         resp.data[:expiration_rule_id] = exp_rule_id if exp_rule_id
 
+        restoring = false
+        restore_date = nil
+
         if restore = resp.http_response.headers['x-amz-restore']
-          restore.first =~ /ongoing-request="(.+?)", expiry-date="(.+?)"/
-          restoring = $1 == "true"
-          restore_date = DateTime.parse($2)
-        else
-          restoring = false
-          restore_date = nil
+          if restore.first =~ /ongoing-request="(.+?)", expiry-date="(.+?)"/
+            restoring = $1 == "true"
+            restore_date = DateTime.parse($2)
+          elsif restore.first =~ /ongoing-request="(.+?)"/
+            restoring = $1 == "true"
+          end
         end
         resp.data[:restore_in_progress] = restoring
         resp.data[:restore_expiration_date] = restore_date if restore_date

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -1561,6 +1561,14 @@ module AWS
             r.restore_in_progress.should == true
           end
 
+          it 'parses x-amz-restore headers while restore is in-progress' do
+            r = client.with_http_handler do |req, resp|
+              resp.headers['x-amz-restore'] =
+                ['x-amz-restore: ongoing-request="true"']
+            end.head_object(opts)
+            r.restore_in_progress.should == true
+          end
+
         end
 
       end


### PR DESCRIPTION
Currently, if you try to request data about an object with an in-progress restore, you get an error when Ruby tries to parse a nil value as a DateTime. This happens because the headers sent from AWS for the object do not include an expiry-date value in the x-amz-restore header when the object is being restored.

This commit fixes the logic so it will fall back to just looking for the ongoing-request value if it can't find an expire-date in the header.
