### PR TITLE
httparty security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@
 source 'http://rubygems.org'
 
 gem 'uuidtools', '~> 2.1'
-gem 'httparty', '~> 0.7'
+gem 'httparty', '~> 0.10.0'
 gem 'nokogiri', '>= 1.4.4'
 gem 'json', '>= 1.4.6'
 


### PR DESCRIPTION
The gem httparty needs to be upgraded to 0.10.0 to avoid the parameter parsing vulnerability.

More on this issue can be found here: 

https://support.cloud.engineyard.com/entries/22915701-january-14-2013-security-vulnerabilities-httparty-extlib-crack-nori-update-these-gems-immediately
