### PR TITLE
Adding a note to the change_resource_record_sets method to avoid errors

### DIFF
--- a/lib/aws/route_53/client.rb
+++ b/lib/aws/route_53/client.rb
@@ -24,6 +24,8 @@ module AWS
 
       # @!method change_resource_record_sets(options = {})
       # Calls the POST ChangeResourceRecordSets API operation.
+      # Note: For each +:resource_record_set+, one of +:set_identifier+,
+      # +:alias_target+ or +:ttl+ is expected.
       # @param [Hash] options
       # * +:hosted_zone_id+ - *required* - (String) Alias resource record sets
       #   only: The value of the hosted zone ID, CanonicalHostedZoneNameId, for


### PR DESCRIPTION
To avoid these errors

```
 AWS::Route53::Errors::InvalidInput:
   Invalid XML ; cvc-complex-type.2.4.a: Invalid content was found starting with element 'ResourceRecords'. One of '{"https://route53.amazonaws.com/doc/2012-02-29/":SetIdentifier, "https://route53.amazonaws.com/doc/2012-02-29/":AliasTarget, "https://route53.amazonaws.com/doc/2012-02-29/":TTL}' is expected.
```

it would be nice to have a little note in the comments, so this adds it.
