### PR TITLE
Add missing require time lib in credential_providers.rb

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -15,6 +15,7 @@ require 'set'
 require 'net/http'
 require 'timeout'
 require 'thread'
+require 'time'
 
 module AWS
   module Core


### PR DESCRIPTION
Add missing require time lib for Time.parse is used in EC2Provider;
The test was passed because an example loaded inside spec_helper required the time lib.
