### PR TITLE
Fix undefined method 'version_id' during multipart upload

### DIFF
--- a/lib/aws/s3/multipart_upload.rb
+++ b/lib/aws/s3/multipart_upload.rb
@@ -242,8 +242,8 @@ module AWS
         raise "no parts uploaded" if complete_opts[:parts].empty?
 
         resp = client.complete_multipart_upload(complete_opts)
-        if resp.version_id
-          ObjectVersion.new(object, resp.version_id)
+        if resp.data[:version_id]
+          ObjectVersion.new(object, resp.data[:version_id])
         else
           object
         end


### PR DESCRIPTION
I got the following error when a large file got automatically uploaded via multipart-upload to S3:

```
NoMethodError: undefined method `version_id' for #<Hash:0x00000006b94b40>
    from //shared/bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/core/data.rb:101:in `method_missing'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/core/data.rb:121:in `method_missing'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/core/response.rb:193:in `method_missing'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/s3/multipart_upload.rb:245:in `complete'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/s3/multipart_upload.rb:267:in `close'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/s3/s3_object.rb:707:in `multipart_upload'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/s3/s3_object.rb:1619:in `write_with_multipart'
    from //bundle/ruby/1.9.1/gems/aws-sdk-1.8.1.1/lib/aws/s3/s3_object.rb:598:in `write'
```

Comparing how a single-part upload was handled I made a change in how the `version_id` is handled from the response. This patch solved the issue for me.

The related spec does not fail without the patch, this could be due the response being a stub. But I'm not sure of this. Also I could not find any specs for a multipart-upload to a versioned bucket.
