### PR TITLE
Fix bug: default credential provider hides sub credential provider's fetching credentials error

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -116,7 +116,10 @@ module AWS
 
         def credentials
           providers.each do |provider|
-            return provider.credentials rescue Errors::MissingCredentialsError
+            begin
+              return provider.credentials
+            rescue Errors::MissingCredentialsError
+            end
           end
           raise Errors::MissingCredentialsError
         end

--- a/spec/aws/core/credential_providers_spec.rb
+++ b/spec/aws/core/credential_providers_spec.rb
@@ -97,6 +97,17 @@ module AWS
             :session_token => 'token-2'
           }
         end
+
+        it 'should not hide real error of fetching credentials' do
+          dp = DefaultProvider.new
+          ec2_provider = dp.providers[0] = EC2Provider.new
+          ec2_provider.stub(:credentials) do
+            raise "Something wrong"
+          end
+          lambda {
+            dp.credentials
+          }.should raise_error('Something wrong')
+        end
       end
 
       describe StaticProvider do


### PR DESCRIPTION
The default credential provider will try to rescue sub provider's
MissingCredentialsError for looking up the right credential provider.
However, the way using 'rescue' keyword is not correct, and it
actually rescued all the StandardError raised from sub provider's
credentials method.

The fix corrects the syntax of using rescue with a begin block to ignore MissingCredentialsError
