### PR TITLE
Add some docs for content_md5 in S3Object.write

### DIFF
--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -560,6 +560,9 @@ module AWS
       #     See
       #     http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
       #
+      #   @option options [String] :content_md5
+      #     The base64 encoded content md5 of the data.
+      #
       #   @option options :content_type A standard MIME type
       #     describing the format of the object data.
       #


### PR DESCRIPTION
Hopefully you can accept this doc change. Having it would have saved me about 15 minutes of having to download and poke through the code to figure out how/if I could get my md5 through the library to S3 :)
