### PR TITLE
s3 metadata request throws exception for objects pending restore from glacier

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1425,7 +1425,7 @@ module AWS
         if restore = resp.http_response.headers['x-amz-restore']
           if restore.first =~ /ongoing-request="(.+?)", expiry-date="(.+?)"/
             restoring = $1 == "true"
-            restore_date = DateTime.parse($2)
+            restore_date = $2 && DateTime.parse($2)
           elsif restore.first =~ /ongoing-request="(.+?)"/
             restoring = $1 == "true"
           end


### PR DESCRIPTION
When you store an object in glacier and then restore it (by moving between buckets with appropriate lifecycle rules), the requests for the object's metadata throws exceptions (the header parsing doesn't check for existence of expiry-date before attempting to parse it).
