### PR TITLE
Fix typo/NoMethodError in ResourceRecordSet#update

### DIFF
--- a/lib/aws/route_53/resource_record_set.rb
+++ b/lib/aws/route_53/resource_record_set.rb
@@ -153,8 +153,10 @@ module AWS
       # @return [ResourceRecordSet] New resource record set with current value.
       def update options = {}
         batch = new_change_batch(options)
-        batch << new_delete_request
-        batch << new_create_request
+        AWS.memoize do
+          batch << new_delete_request
+          batch << new_create_request
+        end
 
         @change_info = batch.call()
         @name = @create_options[:name]
@@ -220,12 +222,14 @@ module AWS
       # @return [Hash]
       def delete_options
         options = {:name => name, :type => type}
-        options[:set_identifier] = set_identifier if set_identifier
-        options[:alias_target] = alias_target if alias_target
-        options[:weight] = weight if weight
-        options[:region] = region if region
-        options[:ttl] = ttl if ttl
-        options[:resource_records] = resource_records if resource_records
+        AWS.memoize do
+          options[:set_identifier] = set_identifier if set_identifier
+          options[:alias_target] = alias_target if alias_target
+          options[:weight] = weight if weight
+          options[:region] = region if region
+          options[:ttl] = ttl if ttl
+          options[:resource_records] = resource_records if resource_records
+        end
         options
       end
     end


### PR DESCRIPTION
Fix a nomethoderror and also memoize list calls when fetching info for change batches so that only one API list call is needed.
