### PR TITLE
Route53 empty resource records

### DIFF
--- a/lib/aws/route_53/resource_record_set.rb
+++ b/lib/aws/route_53/resource_record_set.rb
@@ -228,7 +228,7 @@ module AWS
           options[:weight] = weight if weight
           options[:region] = region if region
           options[:ttl] = ttl if ttl
-          options[:resource_records] = resource_records if resource_records
+          options[:resource_records] = resource_records if resource_records && !resource_records.empty?
         end
         options
       end


### PR DESCRIPTION
I'm not super familiar with what's going on here, so I'm not sure this is the right place to solve the issue. Passing an empty list as in `:resource_records => []` fails, since the `:resource_records` parameter should probably have been omitted. This change causes the `ChangeRequest` objects to be created without it, though it seems plausible to me that `ResourceRecordSet#resource_records` should return `nil` rather than `[]`.

This pulls in the two commits from #173 due to indentation changes.

Example logs showing the issue:

```
>> batch << rrset.new_delete_request
I, [2013-02-26T19:36:30.353518 #28203]  INFO -- aws-api: [AWS Route53 200 0.40468 0 retries] list_resource_record_sets(:hosted_zone_id=>"ABCDEFGHIJKLM",:start_record_name=>"example.com.",:start_record_type=>"A")
=> [#<AWS::Route53::DeleteRequest:0x7f1090e01418 @change_options={:type=>"A", :resource_records=>[], :alias_target=>{:dns_name=>"vips.example.com.", :evaluate_target_health=>true, :hosted_zone_id=>"ABCDEFGHIJKLM"}, :name=>"example.com."}, type"A", action"DELETE", name"example.com."]
>> batch.call
I, [2013-02-26T19:37:06.469893 #28203]  INFO -- aws-api: [AWS Route53 400 0.202559 0 retries] change_resource_record_sets(:change_batch=>{:changes=>[{:action=>"DELETE",:resource_record_set=>{:alias_target=>{:dns_name=>"vips.example.com.",:evaluate_target_health=>true,:hosted_zone_id=>"ABCDEFGHIJKLM"},:name=>"example.com.",:resource_records=>[],:type=>"A"}}]},:hosted_zone_id=>"ABCDEFGHIJKLM") AWS::Route53::Errors::InvalidInput Invalid XML ; cvc-complex-type.2.4.a: Invalid content was found starting with element 'ResourceRecords'. One of '{"https://route53.amazonaws.com/doc/2012-12-12/":SetIdentifier, "https://route53.amazonaws.com/doc/2012-12-12/":AliasTarget, "https://route53.amazonaws.com/doc/2012-12-12/":TTL}' is expected.
AWS::Route53::Errors::InvalidInput: Invalid XML ; cvc-complex-type.2.4.a: Invalid content was found starting with element 'ResourceRecords'. One of '{"https://route53.amazonaws.com/doc/2012-12-12/":SetIdentifier, "https://route53.amazonaws.com/doc/2012-12-12/":AliasTarget, "https://route53.amazonaws.com/doc/2012-12-12/":TTL}' is expected.
```
