### PR TITLE
Fixed typo in docs citing non-existent method..

### DIFF
--- a/lib/aws/s3/bucket.rb
+++ b/lib/aws/s3/bucket.rb
@@ -188,7 +188,7 @@ module AWS
     #
     #   bucket.versioning_enabled? #=> false
     #   bucket.enable_versioning
-    #   # there is also a #disable_versioning method
+    #   # there is also a #suspend_versioning method
     #
     #   obj = bucket.objects['my-obj']
     #   obj.write('a')


### PR DESCRIPTION
Specifically, S3::Bucket#disable_versioning.
In reality, it's #suspend_versioning.

This is viewable in the code diff, as well as at http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/Bucket.html under the "Bucket Versioning" section.

![Class_AWS_S3_Bucket AWS SDK for Ruby_20130309-015014](https://f.cloud.github.com/assets/599767/239366/9bbac754-8885-11e2-8069-b227add72c10.png)
