### PR TITLE
CORSRuleCollection delete_if can delete all rules

### DIFF
--- a/lib/aws/s3/cors_rule_collection.rb
+++ b/lib/aws/s3/cors_rule_collection.rb
@@ -148,11 +148,7 @@ module AWS
         self.each do |rule|
           rules << rule unless yield(rule)
         end
-        if rules.any?
-          self.set(*rules)
-        else
-          self.clear
-        end
+        self.set(rules)
       end
 
       # Removes all CORS rules attached to this bucket.


### PR DESCRIPTION
If CORSRuleCollection#delete_if matched all the rules, you'd get:

```
  ArgumentError - expected one or more rules:
    (gem) aws-sdk-1.8.3.1/lib/aws/s3/cors_rule_collection.rb:101:in `set'
```

So if all the rules are deleted, call #clear instead.
