### PR TITLE
Changed String to Boolean with type of :dynamo_db_retry_throughput_errors

### DIFF
--- a/lib/aws/core.rb
+++ b/lib/aws/core.rb
@@ -249,7 +249,7 @@ module AWS
     # @option options [String] :dynamo_db_endpoint ('dynamodb.amazonaws.com')
     #   The service endpoint for Amazon DynamoDB.
     #
-    # @option options [String] :dynamo_db_retry_throughput_errors (true) When
+    # @option options [Boolean] :dynamo_db_retry_throughput_errors (true) When
     #   true, AWS::DynamoDB::Errors::ProvisionedThroughputExceededException
     #   errors will be retried.
     #
@@ -258,7 +258,7 @@ module AWS
     #
     # @option options [String] :elasticache_endpoint ('elasticache.us-east-1.amazonaws.com')
     #
-    # @option options [String] :elastic_beanstalk_endpoint ('elasticbeanstalk.us-east-1.amazonaws.com') 
+    # @option options [String] :elastic_beanstalk_endpoint ('elasticbeanstalk.us-east-1.amazonaws.com')
     #   The service endpoint for AWS Elastic Beanstalk.
     #
     # @option options [String] :elb_endpoint ('elasticloadbalancing.us-east-1.amazonaws.com')

--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -87,7 +87,7 @@ module AWS
     # @attr_reader [String] dynamo_db_endpoint ('dynamodb.us-east-1.amazonaws.com')
     #   The service endpoint for Amazon DynamoDB.
     #
-    # @attr_reader [String] dynamo_db_retry_throughput_errors (true) When
+    # @attr_reader [Boolean] dynamo_db_retry_throughput_errors (true) When
     #   true, AWS::DynamoDB::Errors::ProvisionedThroughputExceededException
     #   errors will be retried.
     #
@@ -96,7 +96,7 @@ module AWS
     #
     # @attr_reader [String] elasticache_endpoint ('elasticache.us-east-1.amazonaws.com')
     #
-    # @attr_reader [String] elastic_beanstalk_endpoint ('elasticbeanstalk.us-east-1.amazonaws.com') 
+    # @attr_reader [String] elastic_beanstalk_endpoint ('elasticbeanstalk.us-east-1.amazonaws.com')
     #   The service endpoint for AWS Elastic Beanstalk.
     #
     # @attr_reader [String] elb_endpoint ('elasticloadbalancing.us-east-1.amazonaws.com')


### PR DESCRIPTION
:dynamo_db_retry_throughput_errors type should be Boolean. But AWS::Client & AWS::Config Documentation show String.
