### PR TITLE
bucket.objects[object].exists? should rescue Errors::Forbidden on non-existent object.

### DIFF
--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -269,7 +269,7 @@ module AWS
       # @return [Boolean] Returns +true+ if the object exists in S3.
       def exists?
         head
-      rescue Errors::NoSuchKey => e
+      rescue Errors::NoSuchKey, Errors::Forbidden
         false
       else
         true


### PR DESCRIPTION
bucket.objects[object].exists? should rescue Errors::Forbidden on non-existent object and result in false.

fixes #201

```
> bucket.objects["test.js"].exists?
=> true
> bucket.objects["test.js-nonexistent"].exists?
AWS::S3::Errors::Forbidden: AWS::S3::Errors::Forbidden
<stack trace>
```
