### PR TITLE
Added additional header (expires) returned by AWS::S3::Client#head_object and #get_object

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1466,6 +1466,7 @@ module AWS
           'content-type' => :content_type,
           'content-encoding' => :content_encoding,
           'cache-control' => :cache_control,
+          'expires' => :expires,
           'etag' => :etag,
           'x-amz-website-redirect-location' => :website_redirect_location,
           'accept-ranges' => :accept_ranges,

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -1324,6 +1324,7 @@ module AWS
             resp.headers['content-type'] = ['text/plain']
             resp.headers['content-encoding'] = ['gzip']
             resp.headers['cache-control'] = ['max-age=1296000']
+            resp.headers['expires'] = ['Sat, 22 Mar 2014 14:14:21 GMT']
             resp.headers['accept-ranges'] = ['bytes']
             resp.headers['x-amz-meta-Color'] = ['red']
             resp.headers['x-amz-meta-foo'] = 'bar'
@@ -1512,6 +1513,7 @@ module AWS
               resp.headers['content-type'] = ['text/plain']
               resp.headers['content-encoding'] = ['gzip']
               resp.headers['cache-control'] = ['max-age=1296000']
+              resp.headers['expires'] = ['Sat, 22 Mar 2014 14:14:21 GMT']
               resp.headers['accept-ranges'] = ['bytes']
               resp.headers['x-amz-meta-Color'] = ['red']
               resp.headers['x-amz-meta-foo'] = 'bar'
@@ -1519,6 +1521,7 @@ module AWS
             r[:content_type].should eq('text/plain')
             r[:content_encoding].should eq('gzip')
             r[:cache_control].should eq('max-age=1296000')
+            r[:expires].should eq('Sat, 22 Mar 2014 14:14:21 GMT')
             r[:accept_ranges].should eq('bytes')
             r[:meta].should eq('Color' => 'red', 'foo' => 'bar')
           end


### PR DESCRIPTION
Further to the headers added as a result of [issue 86](https://github.com/aws/aws-sdk-ruby/issues/86), I've added support for reading the Expires header and making it accessible in the same way as was done in commit https://github.com/aws/aws-sdk-ruby/commit/19b3864bfcd76892b6b1230621c4079a4ce372c9.
