### PR TITLE
add to_s method, because Rails.version of edge rails is Gem::Version obj...

### DIFF
--- a/lib/aws/rails.rb
+++ b/lib/aws/rails.rb
@@ -151,7 +151,7 @@ module AWS
     #
     def self.add_action_mailer_delivery_method name = :amazon_ses, options = {}
 
-      if ::Rails.version.to_f >= 3
+      if ::Rails.version.to_s.to_f >= 3
         ActiveSupport.on_load(:action_mailer) do
           self.add_delivery_method(name, AWS::SimpleEmailService, options)
         end


### PR DESCRIPTION
Rails.version of edge rails returns Gem::Version object.
