### PR TITLE
Cloud Front Docs: target_origin_id must match id

### DIFF
--- a/lib/aws/cloud_front/client.rb
+++ b/lib/aws/cloud_front/client.rb
@@ -140,7 +140,8 @@ module AWS
       #     * `:target_origin_id` - *required* - (String) The value of ID for
       #       the origin that you want CloudFront to route requests to when a
       #       request matches the path pattern either for a cache behavior or
-      #       for the default cache behavior.
+      #       for the default cache behavior. This value must match an id
+      #       specified in an origin item.
       #     * `:forwarded_values` - *required* - (Hash) A complex type that
       #       specifies how CloudFront handles query strings.
       #       * `:query_string` - *required* - (Boolean) Indicates whether you
@@ -203,7 +204,8 @@ module AWS
       #       * `:target_origin_id` - *required* - (String) The value of ID for
       #         the origin that you want CloudFront to route requests to when a
       #         request matches the path pattern either for a cache behavior or
-      #         for the default cache behavior.
+      #         for the default cache behavior.  This value must match an id
+      #         specified in an origin item.
       #       * `:forwarded_values` - *required* - (Hash) A complex type that
       #         specifies how CloudFront handles query strings.
       #         * `:query_string` - *required* - (Boolean) Indicates whether
@@ -1003,7 +1005,8 @@ module AWS
       #     * `:target_origin_id` - *required* - (String) The value of ID for
       #       the origin that you want CloudFront to route requests to when a
       #       request matches the path pattern either for a cache behavior or
-      #       for the default cache behavior.
+      #       for the default cache behavior.  This value must match an id
+      #       specified in an origin item.
       #     * `:forwarded_values` - *required* - (Hash) A complex type that
       #       specifies how CloudFront handles query strings.
       #       * `:query_string` - *required* - (Boolean) Indicates whether you
@@ -1066,7 +1069,8 @@ module AWS
       #       * `:target_origin_id` - *required* - (String) The value of ID for
       #         the origin that you want CloudFront to route requests to when a
       #         request matches the path pattern either for a cache behavior or
-      #         for the default cache behavior.
+      #         for the default cache behavior.  This value must match an id
+      #         specified in an origin item.
       #       * `:forwarded_values` - *required* - (Hash) A complex type that
       #         specifies how CloudFront handles query strings.
       #         * `:query_string` - *required* - (Boolean) Indicates whether


### PR DESCRIPTION
The target_origin_id value of both `default_cache_behavior` and `cache_behaviors` must match an id specified under origins[:items].map(&:id), while this is documented in that section:

```
 * `:id` - *required* - (String) A unique identifier for the
   origin. The value of Id must be unique within the distribution.
   You use the value of Id when you create a cache behavior. The
   Id identifies the origin that CloudFront routes a request to
   when the request matches the path pattern for that cache
```

It is not documented in `target_origin_id`. If you try to specify a `target_origin_id` that does not exist in an origins items id you will get a somewhat cryptic error:

```
AWS::CloudFront::Errors::NoSuchOrigin: One or more of your origins do not exist.
```

After receiving this error it looks like the Origin Item is configured properly when it really means you've specified cache behavior that points at a nonexistent origin id.

This documentation change brings the required knowledge closer to the field where it is needed.
