### PR TITLE
Support the "Expect" header and "100-continue" responses

### DIFF
--- a/features/s3/100_continue.feature
+++ b/features/s3/100_continue.feature
@@ -1,0 +1,24 @@
+
+# Copyright 2011-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# language: en
+@s3 @100continue @objects
+Feature: Expect and 100-continue
+
+  @foo
+  Scenario: Put an Object using 100-continue
+    Given I monkey-patch Net::HTTP to work with 100-continue
+    And I configure S3 with a 1MB http_continue_threshold and 5 second continue timeout
+    When I put an object that is 2MB large
+    Then the request headers should have "Expect" set to "100-continue"

--- a/lib/aws/core.rb
+++ b/lib/aws/core.rb
@@ -258,6 +258,25 @@ module AWS
     #   true, AWS::DynamoDB::Errors::ProvisionedThroughputExceededException
     #   errors will be retried.
     #
+    # @option options [Float] :http_continue_timeout (1) The number of
+    #   seconds to wait for a "100-continue" response before sending the request
+    #   payload.  **This option has no effect unless the `:http_continue_threshold`
+    #   is configured to a positive integer and the payload exeedes the
+    #   threshold.** NOTE: currently there is a bug in Net::HTTP.
+    #   You must call `AWS.patch_net_http_100_continue!` for this feature to work.
+    #   Not supported in Ruby < 1.9.
+    #
+    # @option options [Integer,false] :http_continue_threshold (false) If a request
+    #   body exceedes the `:http_continue_threshold` size (in bytes), then
+    #   an "Expect" header will be added to the request with the value of
+    #   "100-continue".  This will cause the SDK to wait up to
+    #   `:http_continue_timeout` seconds for a 100 Contiue HTTP response
+    #   before sending the request payload.  By default, this feature
+    #   is disbled.  Set this option to a positive number of bytes
+    #   to enable 100 continues.  NOTE: currently there is a bug in Net::HTTP.
+    #   You must call `AWS.patch_net_http_100_continue!` for this feature to work.
+    #   Not supported in Ruby < 1.9.
+    #
     # @option options [Object] :http_handler (AWS::Core::Http::NetHttpHandler)
     #   The http handler that sends requests to AWS.
     #
@@ -570,6 +589,13 @@ module AWS
           end
         end
       end
+    end
+
+    # Patches Net::HTTP, fixing a bug in how it handles non 100-continue
+    # responses while waiting for a 100-continue.
+    def patch_net_http_100_continue!
+      require 'net/http/connection_pool'
+      Net::HTTP.patch_net_http_100_continue!
       nil
     end
 

--- a/lib/aws/core/client.rb
+++ b/lib/aws/core/client.rb
@@ -466,6 +466,7 @@ module AWS
                 cached_response.cached = true
                 cached_response
               else
+
                 # process the http request
                 options[:async] ?
                 make_async_request(response, &read_block) :
@@ -524,6 +525,18 @@ module AWS
         send("configure_#{name}_request", http_request, opts)
 
         http_request.headers["user-agent"] = user_agent_string
+
+        if
+          @config.http_continue_threshold and
+          http_request.headers['content-length'] and
+          http_request.headers['content-length'].to_i > @config.http_continue_threshold
+        then
+          http_request.headers["expect"] = "100-continue"
+          http_request.continue_timeout = @config.http_continue_timeout
+        else
+          http_request.continue_timeout = nil
+        end
+
         http_request.add_authorization!(credential_provider)
 
         http_request

--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -75,6 +75,25 @@ module AWS
     #   true, AWS::DynamoDB::Errors::ProvisionedThroughputExceededException
     #   errors will be retried.
     #
+    # @attr_reader [Float] http_continue_timeout (1) The number of
+    #   seconds to wait for a "100-continue" response before sending the request
+    #   payload.  **This option has no effect unless the {#http_continue_threshold}
+    #   is configured to a positive integer and the payload exeedes the
+    #   threshold.** NOTE: currently there is a bug in Net::HTTP.
+    #   You must call `AWS.patch_net_http_100_continue!` for this feature to work.
+    #   Not supported in Ruby < 1.9.
+    #
+    # @attr_reader [Integer,false] http_continue_threshold (false) If a request
+    #   body exceedes the {#http_continue_threshold} size (in bytes), then
+    #   an "Expect" header will be added to the request with the value of
+    #   "100-continue".  This will cause the SDK to wait up to
+    #   {#http_continue_timeout} seconds for a 100 Contiue HTTP response
+    #   before sending the request payload.  By default, this feature
+    #   is disbled.  Set this option to a positive number of bytes
+    #   to enable 100 continues.  NOTE: currently there is a bug in Net::HTTP.
+    #   You must call `AWS.patch_net_http_100_continue!` for this feature to work.
+    #   Not supported in Ruby < 1.9.
+    #
     # @attr_reader [Object] http_handler The http handler that sends requests
     #   to AWS.  Defaults to an HTTP handler built on net/http.
     #
@@ -401,6 +420,8 @@ module AWS
             :credential_provider,
             :http_handler,
             :http_read_timeout,
+            :http_continue_timeout,
+            :http_continue_threshold,
             :log_formatter,
             :log_level,
             :logger,
@@ -442,6 +463,10 @@ module AWS
       add_option :http_open_timeout, 15
 
       add_option :http_read_timeout, 60
+
+      add_option :http_continue_timeout, 1
+
+      add_option :http_continue_threshold, false
 
       add_option :http_idle_timeout, 60
 

--- a/lib/aws/core/http/net_http_handler.rb
+++ b/lib/aws/core/http/net_http_handler.rb
@@ -62,6 +62,7 @@ module AWS
 
             connection = pool.connection_for(request.host, options)
             connection.read_timeout = request.read_timeout
+            connection.continue_timeout = request.continue_timeout
 
             connection.request(build_net_http_request(request)) do |http_resp|
               response.status = http_resp.code.to_i

--- a/lib/aws/core/http/request.rb
+++ b/lib/aws/core/http/request.rb
@@ -105,6 +105,11 @@ module AWS
         #   requests if {#ssl_verify_peer?} is true.
         attr_accessor :ssl_ca_path
 
+        # @return [Float] timeout The number of seconds to wait for a
+        #   100-continue response before sending the HTTP request body.
+        # @private
+        attr_accessor :continue_timeout
+
         # @return [Integer] Returns the port the request will be made over.
         #   Defaults to 443 for SSL requests and 80 for non-SSL requests.
         def port

--- a/lib/net/http/connection_pool/connection.rb
+++ b/lib/net/http/connection_pool/connection.rb
@@ -74,6 +74,7 @@ class Net::HTTP::ConnectionPool
       end
 
       @read_timeout = options[:read_timeout] || 60
+      @continue_timeout = options[:continue_timeout] || 0
 
     end
 
@@ -112,6 +113,9 @@ class Net::HTTP::ConnectionPool
 
     # @return [Numeric,nil]
     attr_accessor :read_timeout
+
+    # @return [Numeric,nil]
+    attr_accessor :continue_timeout
 
     # @return [Boolean] Returns `true` if this connection requires SSL.
     def ssl?

--- a/lib/net/http/connection_pool/session.rb
+++ b/lib/net/http/connection_pool/session.rb
@@ -49,6 +49,17 @@ class Net::HTTP::ConnectionPool
       http_session.read_timeout = timeout
     end
 
+    # @param [Float,nil] timeout When set to a positive number of seconds,
+    #   and the 'expect' header contains '100-continue' then Net::HTTP
+    #   will wait +timeout+ number of seconds before sending the request
+    #   payload.  If the server returns a '100-continue' response before
+    #   +timeout+ seconds have passed, then it will send the payload sooner.
+    def continue_timeout= timeout
+      if http_session.respond_to?(:continue_timeout=)
+        http_session.continue_timeout = timeout
+      end
+    end
+
     # Makes a HTTP request.  See Net::HTTPSession#request documentation
     # from the Ruby standard library for information about argments.
     #

--- a/spec/aws/core/http/net_http_handler_spec.rb
+++ b/spec/aws/core/http/net_http_handler_spec.rb
@@ -33,6 +33,7 @@ module AWS::Core::Http
         :ssl_ca_file => '/ssl/ca',
         :ssl_ca_path => nil,
         :read_timeout => 60,
+        :continue_timeout => 1,
         :headers => { 'foo' => 'bar' })
     }
 


### PR DESCRIPTION
Added two new configuration options to AWS.config:
- :http_continue_timeout (time in seconds)
- :http_continue_threshold (size in bytes)

If a request body exceeds the :http_continue_threshold, then the
"Expect" header will be set to "100-continue".  The http client will
then wait for a "100 Continue" response or :http_continue_timeout
seconds before sending the body.

By default the `:http_continue_threshold` defaults to `false` (which disables this feature).  The `:http_continue_timeout` defaults to 1 second, but only takes effect when the request body exceedes the `:http_continue_threshold`.

Due to a bug in Net::HTTP, this feature will only work with a patch.  You can monkey patch Net::HTTP with the following:

```
AWS.patch_net_http_100_continue!
```

Please note, this feature does not work in Ruby < 1.9.3
