### PR TITLE
fix interface name in documentation

### DIFF
--- a/lib/aws/cloud_watch.rb
+++ b/lib/aws/cloud_watch.rb
@@ -35,7 +35,7 @@ module AWS
   #       :access_key_id => 'YOUR_ACCESS_KEY_ID',
   #       :secret_access_key => 'YOUR_SECRET_ACCESS_KEY')
   #
-  # Or you can set them directly on the AWS::Route53 interface:
+  # Or you can set them directly on the AWS::CloudWatch interface:
   #
   #     cw = AWS::CloudWatch.new(
   #       :access_key_id => 'YOUR_ACCESS_KEY_ID',


### PR DESCRIPTION
change Route53 to CloudWatch (yes, a bit pedantic...)
