### PR TITLE
Add compatibility with deliver!

### DIFF
--- a/lib/aws/simple_email_service.rb
+++ b/lib/aws/simple_email_service.rb
@@ -350,6 +350,7 @@ module AWS
     # for compatability with ActionMailer
     alias_method :deliver, :send_raw_email
     alias_method :deliver!, :send_raw_email
+    def settings; {}; end
 
     # @example
     #


### PR DESCRIPTION
Add a stub `settings` method to `SimpleEmailService` to improve compatibility with ActionMailer. Fixes #246.
