### PR TITLE
Fix AWS Support endpoint.

### DIFF
--- a/lib/aws/support/config.rb
+++ b/lib/aws/support/config.rb
@@ -13,6 +13,6 @@
 
 AWS::Core::Configuration.module_eval do
 
-  add_service 'Support', 'support', 'support.%s.amazonaws.com'
+  add_service 'Support', 'support', 'support.us-east-1.amazonaws.com'
 
 end


### PR DESCRIPTION
AWS Support has a single endpoint. AWS::Support currently breaks in the face of (e.g.)

```
AWS.config(:region => 'eu-west-1') 
```

http://docs.aws.amazon.com/general/latest/gr/rande.html#awssupport_region
