### PR TITLE
fix docs for maximum delay_seconds

### DIFF
--- a/lib/aws/sqs/queue.rb
+++ b/lib/aws/sqs/queue.rb
@@ -486,8 +486,8 @@ module AWS
       #
       # You can also set an optional delay for all of the messages:
       #
-      #     # delay all messages 1 hour
-      #     queue.batch_send(msg1, msg2, :delay_seconds => 3600)
+      #     # delay all messages 15 minutes
+      #     queue.batch_send(msg1, msg2, :delay_seconds => 900)
       #
       # If you need to set a custom delay for each message you can pass
       # hashes:


### PR DESCRIPTION
The maximum delay_seconds on a message is actually 15 minutes, however the aws-sdk-ruby has an example in the documentation of batch_send with of 1 hour delay, which fails to run:

``` ruby
begin
  queue.batch_send("1", :delay_seconds => 3600)
rescue => ex
  ex.failures
end
=> [{:error_code=>"InvalidParameterValue", :error_message=>"Value 3600 for parameter DelaySeconds is invalid. Reason: DelaySeconds must be >= 0 and <= 900.", :sender_fault=>true}]
```
