### PR TITLE
Fixed issue with pagination in S3.

### DIFF
--- a/features/s3/high_level/objects.feature
+++ b/features/s3/high_level/objects.feature
@@ -423,3 +423,18 @@ Feature: CRUD Objects (High Level)
     | field   | value                                                            |
     | code    | InvalidObjectState                                               |
     | message | Restore is not allowed, as object's storage class is not GLACIER |
+
+  @list_objects @paginate @delimiter
+  Scenario: Properly paginate when using a delimiter
+    Given I have a bucket with the following keys:
+    | key                     |
+    | videos/wedding.mkv      |
+    | videos/vacation.mkv     |
+    | photos/2009/family.jpg  |
+    | photos/2009/friends.jpg |
+    | photos/2010/family.jpg  |
+    When I ask for all objects using the delimiter "/", 1 at a time
+    Then I should get objects with the following prefixes:
+    | prefix  |
+    | videos/ |
+    | photos/ |

--- a/features/s3/high_level/step_definitions/objects.rb
+++ b/features/s3/high_level/step_definitions/objects.rb
@@ -119,6 +119,7 @@ When /^I ask for all objects (\d+) at a time$/ do |batch_size|
     @objects << obj
   end
 end
+
 Then /^the result should include the object with key "([^\"]*)"$/ do |key|
   @result.should have(1).item
   @result.first.should be_an S3::S3Object
@@ -380,5 +381,23 @@ Given /^I try to restore the object$/ do
     @object.restore
   rescue => e
     @exception = e
+  end
+end
+
+When(/^I ask for all objects using the delimiter "(.*?)", (\d+) at a time$/) do |delimiter, batch_size|
+  @objects = []
+  @bucket.objects.each(:batch_size => batch_size.to_i, :delimiter => delimiter) do |obj|
+    @objects << obj
+  end
+end
+
+Then(/^I should get objects with the following prefixes:$/) do |table|
+  prefixes = []
+  @objects.each do |obj|
+    prefixes << obj.prefix
+  end
+
+  table.hashes.each do |hash|
+    prefixes.should include(hash['prefix'])
   end
 end

--- a/lib/aws/s3/object_collection.rb
+++ b/lib/aws/s3/object_collection.rb
@@ -306,12 +306,15 @@ module AWS
       # @api private
       protected
       def next_markers page
-        marker = (last = page.contents.last and last.key)
-        if marker.nil?
-          raise 'Unable to find marker in S3 list objects response'
+        if page[:next_marker]
+          marker = page[:next_marker]
+        elsif page[:contents].size > 0
+          marker = page[:contents].last[:key]
         else
-          { :marker => marker }
+          raise 'Unable to find marker in S3 list objects response'
         end
+
+        { :marker => marker }
       end
 
       # processes items in batches of 1k items

--- a/spec/shared/s3/paginated_collection_examples.rb
+++ b/spec/shared/s3/paginated_collection_examples.rb
@@ -52,6 +52,7 @@ module AWS
       it 'should request the next page for a truncated response' do
         truncated_resp = client.new_stub_for(list_method)
         truncated_resp.data[:truncated] = true
+        truncated_resp.data[:next_marker] = nil
         stub_markers(truncated_resp, "first")
         client.should_receive(list_method).
           and_return(truncated_resp)
@@ -65,6 +66,7 @@ module AWS
 
         before(:each) do
           truncated_resp.data[:truncated] = true
+          truncated_resp.data[:next_marker] = nil
           stub_markers(truncated_resp, "first")
         end
 
@@ -95,6 +97,10 @@ module AWS
         results[1].data[:truncated] = true
         results[2].data[:truncated] = false
 
+        results.each do |result|
+          result.data[:next_marker] = nil
+        end
+        
         ["first", "second", "third"].zip(results).each do |name, result|
           stub_markers(result, name)
         end


### PR DESCRIPTION
The next_markers method in object_collection.rb for S3 did not reference the
"next_marker" property, causing issues when the contents.last value was
missing.

Added Cucumber/RSpec tests to cover this case, added a check for next_marker
to object_collection.rb, and refactored the marker selection logic to be more
readable.

Fixes #247
