### PR TITLE
Add termination_options to Auto Scaling group creation.

### DIFF
--- a/features/auto_scaling/step_definitions/groups.rb
+++ b/features/auto_scaling/step_definitions/groups.rb
@@ -29,6 +29,9 @@ When /^I create an auto scaling group$/ do
     :desired_capacity => 1,
     :health_check_grace_period => 10,
     :health_check_type => :ec2,
+    :termination_policies => [
+      "Default",
+    ],
     :tags => [
       { :key => 'k1' },
       { :key => 'k2', :value => 'v2' },

--- a/lib/aws/auto_scaling/group_options.rb
+++ b/lib/aws/auto_scaling/group_options.rb
@@ -61,6 +61,14 @@ module AWS
       #   Amazon EC2. For more information about cluster placement group, see
       #   [Using Cluster Instances](http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/using_cluster_computing.html).
       #
+      # @option options [Array<String>] :termination_policies
+      #   A standalone termination policy or a list of termination policies used
+      #   to select the instance to terminate. The policies are executed in the
+      #   order they are listed. For more information on creating a termination
+      #   policy for your Auto Scaling group, go to
+      #   [Instance Termination Policy for Your Auto Scaling Group](http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/us-termination-policy.html)
+      #   in the Auto Scaling Developer Guide.
+      #
       # @option options [Array<Hash>] :tags A list of tags to apply launched
       #   instances.  Each tag hash may have the following keys:
       #
@@ -102,6 +110,7 @@ module AWS
           :desired_capacity,
           :health_check_grace_period,
           :placement_group,
+          :termination_policies,
         ].each do |opt|
           group_opts[opt] = options[opt] if options.key?(opt)
         end

--- a/spec/aws/auto_scaling/group_collection_spec.rb
+++ b/spec/aws/auto_scaling/group_collection_spec.rb
@@ -168,6 +168,20 @@ module AWS
             :placement_group => 'abc'))
         end
 
+        it 'accepts termination policies' do
+          client.should_receive(:create_auto_scaling_group).with(hash_including(
+            :termination_policies => [
+              "Default",
+              "OldestInstance",
+            ]))
+          groups.create('name', create_opts.merge(
+            :termination_policies => [
+              "Default",
+              "OldestInstance",
+            ]))
+ 
+        end
+
         it 'accepts tags' do
 
           client.should_receive(:create_auto_scaling_group).with(hash_including(


### PR DESCRIPTION
Adds the optional parameter :termination_options to
AWS::AutoScaling::GroupCollection "create" method.
Includes documentation of the parameter, integration
tests, and a spec test.

Fixes #275
