### PR TITLE
Change HTTP handler to whitelist network errors

### DIFF
--- a/lib/aws/core/http/net_http_handler.rb
+++ b/lib/aws/core/http/net_http_handler.rb
@@ -27,7 +27,7 @@ module AWS
         NETWORK_ERRORS = [
           SocketError, EOFError, IOError, Timeout::Error,
           Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
-          Errno::EINVAL, Errno::ETIMEDOUT,
+          Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError,
         ]
 
         # (see ConnectionPool.new)

--- a/spec/aws/core/http/net_http_handler_spec.rb
+++ b/spec/aws/core/http/net_http_handler_spec.rb
@@ -262,6 +262,7 @@ module AWS::Core::Http
       it_behaves_like(:traps_certain_errors_as_networking_errors, Errno::EINVAL)
       it_behaves_like(:traps_certain_errors_as_networking_errors, Timeout::Error)
       it_behaves_like(:traps_certain_errors_as_networking_errors, Errno::ETIMEDOUT)
+      it_behaves_like(:traps_certain_errors_as_networking_errors, OpenSSL::SSL::SSLError)
 
     end
   end


### PR DESCRIPTION
Instead of (dangerously) whitelisting errors to reraise, this changes the HTTP handler to explicitly list the raised exceptions for which the exceptions should be swallowed.

Fundamentally, this changes handling of unknown errors (such as any Java error in JRuby) to not be swallowed.
