### PR TITLE
Curb Performance: Use an array of strings instead of a StringIO object.

### DIFF
--- a/lib/aws/core/http/curb_handler.rb
+++ b/lib/aws/core/http/curb_handler.rb
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 require 'thread'
-require 'stringio'
 
 module AWS
   module Core
@@ -123,7 +122,7 @@ module AWS
             curl.delete = true
           end
 
-          buffer = StringIO.new
+          buffer = []
 
           if read_block
             curl.on_body do |chunk|
@@ -140,8 +139,7 @@ module AWS
           curl.on_complete do
             response.status = curl.response_code
             unless read_block
-              buffer.rewind
-              response.body = buffer.read
+              response.body = buffer.join("")
             end
             thread.run if thread
           end


### PR DESCRIPTION
Using an array is about twice as fast because it doesn't have to keep reallocating the underlying string.

```
require 'benchmark'
require 'stringio'

S = "a" * (32*1024)
N = 1000
Benchmark.bm do |x|
  x.report("StringIO") do
    buffer = StringIO.new
    N.times do
      buffer << S
    end
    buffer.rewind
    body = buffer.read
  end

  x.report("Array") do
    buffer = []
    N.times do
      buffer << S
    end
    body = buffer.join
  end
end

#        user     system      total        real
#        StringIO  0.040000   0.020000   0.060000 (  0.056341)
#        Array  0.010000   0.020000   0.030000 (  0.028745)
#
```
