### PR TITLE
Fix bug with MFA codes that look like invalid octal numbers

### DIFF
--- a/lib/aws/iam/virtual_mfa_device.rb
+++ b/lib/aws/iam/virtual_mfa_device.rb
@@ -120,7 +120,7 @@ module AWS
 
       protected
       def format_auth_code(code)
-        sprintf("%06d", code)
+        sprintf("%06d", Integer(code, 10))
       end
 
       protected


### PR DESCRIPTION
Always treat MFA code as a base 10 integer. Otherwise if you enter codes like 099999, it will try to parse it as an
octal number and raise an ArgumentError in sprintf.

```
>> sprintf('%06d', '099999')
ArgumentError: invalid value for Integer(): "099999"
    from (irb):12:in `sprintf'
    from (irb):12
    from /home/andy/.rbenv/versions/1.9/bin/irb:12:in `<main>'
```
