### PR TITLE
Expose failover and health check id in Route53's ChangeRequest

### DIFF
--- a/lib/aws/route_53/change_batch.rb
+++ b/lib/aws/route_53/change_batch.rb
@@ -114,7 +114,7 @@ module AWS
       # @return [String]
       attr_reader :type
 
-      # Build query fro change request.
+      # Build query for change request.
       # @return [Hash]
       def to_hash
         q = {}
@@ -128,6 +128,8 @@ module AWS
         q[:resource_record_set][:ttl] = @change_options[:ttl] if @change_options[:ttl]
         q[:resource_record_set][:resource_records] = @change_options[:resource_records] if @change_options[:resource_records]
         q[:resource_record_set][:alias_target] = @change_options[:alias_target] if @change_options[:alias_target]
+        q[:resource_record_set][:failover] = @change_options[:failover] if @change_options[:failover]
+        q[:resource_record_set][:health_check_id] = @change_options[:health_check_id] if @change_options[:health_check_id]
         q
       end
     end


### PR DESCRIPTION
The latest version of the Route53 API has support for failover and health checks, but the high-level API doesn't offer any support for it yet. While this is by no means the right high-level API, hopefully it's a step in the right direction
