### PR TITLE
Resolved an issue with AWS::IAM::VirtualMFADevice#enable.

### DIFF
--- a/lib/aws/iam/virtual_mfa_device.rb
+++ b/lib/aws/iam/virtual_mfa_device.rb
@@ -120,7 +120,7 @@ module AWS
 
       protected
       def format_auth_code(code)
-        sprintf("%06d", code)
+        code.is_a?(Integer) ? sprintf("%06d", code) : code
       end
 
       protected

--- a/spec/aws/iam/virtual_mfa_device_spec.rb
+++ b/spec/aws/iam/virtual_mfa_device_spec.rb
@@ -87,6 +87,14 @@ module AWS
           device.enable(User.new("username"), 12345, 654321)
         end
 
+        it 'accepts input like "099999"' do
+          client.should_receive(:enable_mfa_device).with(hash_including(
+            :authentication_code_1 => '099999',
+            :authentication_code_2 => '098765'
+          ))
+          device.enable('username', '099999', '098765')
+        end
+
         it 'should use the user name directly if passed as a string' do
           client.should_receive(:enable_mfa_device).
             with(hash_including(:user_name => "username"))


### PR DESCRIPTION
Passing in string values for a code like '099999' were raising
runtime errors from sprintf.  This change prevents string values
from getting passed through sprintf.  Added a test to cover this
behavior.

Fixes #288
