### PR TITLE
Don't nuke attributes on ResourceRecordSet update

### DIFF
--- a/lib/aws/route_53/resource_record_set.rb
+++ b/lib/aws/route_53/resource_record_set.rb
@@ -159,9 +159,9 @@ module AWS
         end
 
         @change_info = batch.call()
-        @name = @create_options[:name]
-        @type = @create_options[:type]
-        @set_identifier = @create_options[:set_identifier]
+        @name = @create_options[:name] || @name
+        @type = @create_options[:type] || @type
+        @set_identifier = @create_options[:set_identifier] || @set_identifier
         @create_options = {}
         self
       end


### PR DESCRIPTION
Previously, if you were not changing the name, type, or set identifier, they
would be destructively removed from the ResourceRecordSet on update.
