### PR TITLE
Implement :hash_key => true

### DIFF
--- a/lib/aws/record/hash_model.rb
+++ b/lib/aws/record/hash_model.rb
@@ -84,9 +84,9 @@ module AWS
 
         # @return [DynamoDB::Table]
         # @api private
-        def dynamo_db_table shard_name = nil, options = {}
+        def dynamo_db_table shard_name = nil
           hash_key = :id
-          hash_key = options[:hash_key] unless options[:hash_key].nil?
+          hash_key = self.hash_key unless self.hash_key.nil?
           table = dynamo_db.tables[dynamo_db_table_name(shard_name)]
           table.hash_key = [hash_key, :string]
           table
@@ -110,7 +110,7 @@ module AWS
       end
       
       def self.hash_key= key
-        @hash_key = key
+        @hash_key = key unless !@hash_key.nil? and @hash_key != :id
       end
       
       def self.add_attribute attribute
@@ -130,7 +130,7 @@ module AWS
       #   persisted to or will be persisted to.
       private
       def dynamo_db_table
-        self.class.dynamo_db_table(shard, self.hash_key)
+        self.class.dynamo_db_table(shard)
       end
 
       private

--- a/spec/aws/record/hash_model_spec.rb
+++ b/spec/aws/record/hash_model_spec.rb
@@ -22,6 +22,7 @@ module AWS
       it "should contain an assignable hash key" do
         model = Class.new(AWS::Record::HashModel)
         model.string_attr :hashname, :hash_key => true
+        model.string_attr :foo
         model.hash_key.should == "hashname"
 
         


### PR DESCRIPTION
I've been using the AWS SDK for accessing dynamoDB and I noticed that if the hash key on my table was named something besides "id" the .each iterator for scopes wouldn't work, instead raising errors about the hash_key being missing in the put_item response.

I put together this quick hack that lets users do

``` ruby
string_attr :foo, :hash_key => true
```

and have that value act as the hash_key for the table.
