### PR TITLE
Add -e option to aws-rb

### DIFF
--- a/bin/aws-rb
+++ b/bin/aws-rb
@@ -127,7 +127,7 @@ options[:require].each do |library|
 end
 
 unless options[:execute].empty?
-  options[:execute].each {|expression| eval(expression) }
+  eval(options[:execute].join("\n"))
   exit
 end
 


### PR DESCRIPTION
You can now execute commands using aws-rb.  Passing commands with the -e option will prevent the REPL from launching and will exit instead.  You can pass multiple -e options.

``` bash
$ aws-rb -e "puts AWS.s3.buckets.map(&:name)"
bucket1
bucket2
bucket3
$ 
```

The script above would put the name of each bucket to STDOUT and then exit.  The -q flag (quiet) disables logging.
