### PR TITLE
resource_identifiers should be protected

### DIFF
--- a/lib/aws/route_53/hosted_zone.rb
+++ b/lib/aws/route_53/hosted_zone.rb
@@ -96,7 +96,7 @@ module AWS
       end
       alias_method :rrsets, :resource_record_sets
 
-      private
+      protected
 
       def resource_identifiers
         [[:id, id], [:name, name], [:caller_reference, caller_reference]]

--- a/lib/aws/route_53/resource_record_set.rb
+++ b/lib/aws/route_53/resource_record_set.rb
@@ -211,9 +211,7 @@ module AWS
         DeleteRequest.new(options[:name], options[:type], options)
       end
 
-
-      private
-
+      protected
 
       def resource_identifiers
         [[:name, name], [:type, type], [:set_identifier, set_identifier]]
@@ -228,6 +226,8 @@ module AWS
 
         client.list_resource_record_sets(options)
       end
+
+      private
 
       # Format a hash of options that can be used to initialize a change
       # request.


### PR DESCRIPTION
Making it private breaks things like `#eql?`, and it seems to be protected everywhere else
