### PR TITLE
Replace nokogiri '< 1.6.0' dependency with '~> 1.6.0'

### DIFF
--- a/aws-sdk.gemspec
+++ b/aws-sdk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('uuidtools', '~> 2.1')
-  s.add_dependency('nokogiri', '< 1.6.0') # 1.6 no longer supports Ruby 1.8.7
+  s.add_dependency('nokogiri', '~> 1.6.0')
   s.add_dependency('json', '~> 1.4')
 
   s.files = [


### PR DESCRIPTION
Ruby 1.8.7 is officially retired, see:
http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
