### PR TITLE
AWS::S3::Client#put_bucket_website now omits empty routing rules.

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -181,7 +181,8 @@ module AWS
                 end
               end
 
-              if rules = options[:routing_rules]
+              rules = options[:routing_rules]
+              if rules.is_a?(Array) && !rules.empty?
                 xml.RoutingRules do
                   rules.each do |rule|
                     xml.RoutingRule do

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -95,6 +95,33 @@ module AWS
 
       end
 
+      context '#put_bucket_website' do
+
+        let(:xml) { <<-XML.strip.xml_cleanup }
+<WebsiteConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+  <IndexDocument>
+    <Suffix>index.html</Suffix>
+  </IndexDocument>
+  <ErrorDocument>
+    <Key>error.html</Key>
+  </ErrorDocument>
+</WebsiteConfiguration>
+        XML
+
+        it 'does not serialize empty routing rules' do
+          body = nil
+          client.with_http_handler do |req, resp|
+            body = req.body.xml_cleanup
+          end.put_bucket_website(
+            :bucket_name => 'bucket',
+            :index_document => { :suffix => 'index.html' },
+            :error_document => { :key => 'error.html' },
+            :routing_rules => []
+          )
+          body.should eq(xml)
+        end
+      end
+
       context 'cors', :cors => true do
   
         let(:xml) { <<-XML.strip.xml_cleanup }


### PR DESCRIPTION
This resolves an issue where passing `:routing_rules => []` to the
client would result in an error returned from Amazon S3.  S3 does
not accept `<RoutingRules/>`.

Fixes #308
