### PR TITLE
Added support for paging Amazon EC2 reserved instances offerings.

### DIFF
--- a/features/ec2/reserved_instances.feature
+++ b/features/ec2/reserved_instances.feature
@@ -25,6 +25,12 @@ Feature: EC2 Reserved Instances
     | TYPE  | NAME       | VALUE                              |
     | param | Action     | DescribeReservedInstancesOfferings |
 
+  Scenario: Paging reserved instance offerings
+    When I enumerate reserved instance offerings with a limit of 10 and batch size of 2
+    Then 5 requests should have been made like:
+    | TYPE  | NAME       | VALUE                              |
+    | param | Action     | DescribeReservedInstancesOfferings |
+
   @memoized
   Scenario: Describing reserved instance offerings with memoization
     Given I start a memoization block

--- a/features/ec2/step_definitions/reserved_instances.rb
+++ b/features/ec2/step_definitions/reserved_instances.rb
@@ -49,3 +49,8 @@ end
 When /^I count the reservations I have purchased$/ do
   @ec2.reserved_instances.inject(0) { |count, ri| count + 1 }
 end
+
+When(/^I enumerate reserved instance offerings with a limit of (\d+) and batch size of (\d+)$/) do |limit, batch_size|
+  offerings = @ec2.reserved_instances_offerings
+  offerings.enumerator(:limit => limit.to_i, :batch_size => batch_size.to_i).to_a
+end

--- a/lib/aws/ec2/reserved_instances_offering_collection.rb
+++ b/lib/aws/ec2/reserved_instances_offering_collection.rb
@@ -16,14 +16,19 @@ module AWS
     class ReservedInstancesOfferingCollection < Collection
 
       include TaggedCollection
+      include Core::Collection::WithLimitAndNextToken
 
       def member_class
         ReservedInstancesOffering
       end
 
-      def each &block
-        response = filtered_request(:describe_reserved_instances_offerings)
-        response.reserved_instances_offerings_set.each do |item|
+      protected
+
+      def _each_item(next_token, max_results, options = {}, &block)
+        options[:next_token] = next_token if next_token
+        options[:max_results] = max_results if max_results
+        resp = filtered_request(:describe_reserved_instances_offerings, options)
+        resp.reserved_instances_offerings_set.each do |item|
 
           reserved_instance_offering = ReservedInstancesOffering.new_from(
             :describe_reserved_instances_offerings, item,
@@ -32,6 +37,7 @@ module AWS
           yield(reserved_instance_offering)
 
         end
+        resp[:next_token]
       end
 
     end


### PR DESCRIPTION
The DescribeInstancesOfferings Amazon EC2 API changed a while back to be paginated.  This pull request updates the related collection class to be page through the multiple responses.  Calling #each will now make multiple requests.  You can also pass `:limit` and `:batch_size` options.

``` ruby
AWS.ec2.reserved_instances_offerings.each do |offering|
  # makes multiple requests to yield all offerings now
end
```

You can additionally page the results in batches.  If you need the next token, this is returned by the enumerable methods `#each`, `#each_batch`, etc.

``` ruby
offerings = AWS.ec2.reserved_instances_offerings
options = { :limit => 100, :batch_size => 10 }

begin
  next_token = offerings.each_batch(options.merge(:next_token => next_token)) do |batch|
    # batch will be an array of up to 10 items
  end
end while next_token
```
