### PR TITLE
Fixed example for creating a tag collection for an ec2 instance.

### DIFF
--- a/lib/aws/ec2/tag_collection.rb
+++ b/lib/aws/ec2/tag_collection.rb
@@ -50,7 +50,7 @@ module AWS
       #
       # @example tagging with names (keys) and values
       #
-      #   ec2.tags.create(instance, 'stage', 'production')
+      #   ec2.tags.create(instance, 'stage', :value => 'production')
       #
       # @param [Object] resource The item to tag.  This should be a taggable
       #   EC2 resource, like an instance, security group, etc.


### PR DESCRIPTION
I found a bug and I am not sure which is intended to be correct: the documentation or the method call, but this pull request corrects the documentation to show how to properly tag an EC2 instance with a key, value pair.  The example as shown will throw an exception.
