### PR TITLE
Make possible to use without ActionMailer

### DIFF
--- a/lib/aws/rails.rb
+++ b/lib/aws/rails.rb
@@ -155,7 +155,7 @@ module AWS
         ActiveSupport.on_load(:action_mailer) do
           self.add_delivery_method(name, AWS::SimpleEmailService, options)
         end
-      else
+      elsif defined?(::ActionMailer)
         amb = ::ActionMailer::Base
         amb.send(:define_method, "perform_delivery_#{name}") do |mail|
           AWS::SimpleEmailService.new(options).send_raw_email(mail)


### PR DESCRIPTION
I use aws-sdk with background uploading queue, so it makes sense to turn off any unused Rails libraries. It's possible to turn off every Rails specific libraries except ActionMailer, so it works:

``` ruby
config.frameworks -= [ :active_record, :active_resource, :action_controller, :action_view]
```

But it doesn't work

``` ruby
config.frameworks -= [:action_mailer]
```

The fix makes sure that you load ActionMailer to use it with SNS
