### PR TITLE
Let the nokogiri requirement be more future proof.

### DIFF
--- a/aws-sdk.gemspec
+++ b/aws-sdk.gemspec
@@ -12,7 +12,11 @@ Gem::Specification.new do |s|
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('uuidtools', '~> 2.1')
-  s.add_dependency('nokogiri', '~> 1.4')
+  if RUBY_VERSION >= '1.9'
+    s.add_dependency('nokogiri', '~> 1.4')
+  else
+    s.add_dependency('nokogiri', '< 1.6.0')
+  end
   s.add_dependency('json', '~> 1.4')
 
   s.files = [


### PR DESCRIPTION
I'm using Ruby 2.0 and some libraries are using a newer nokogiri. This
lets the library work with a wider variety of nokogiri requirements.
