### PR TITLE
Add AWS::S3::Client Bucket Logging Methods

### DIFF
--- a/lib/aws/core/xml/sax_handlers/nokogiri.rb
+++ b/lib/aws/core/xml/sax_handlers/nokogiri.rb
@@ -29,6 +29,7 @@ module AWS
           def start_document; end
           def end_document; end
           def error(*args); end
+          def comment(*args); end
 
           def start_element_namespace element_name, attributes = [], *ignore
 

--- a/lib/aws/s3/client/xml.rb
+++ b/lib/aws/s3/client/xml.rb
@@ -71,6 +71,24 @@ module AWS
 
         end
 
+        GetBucketLogging = BaseGrammar.customize do
+          element("LoggingEnabled") do
+            element("TargetBucket") { }
+            element("TargetPrefix") { }
+            element("TargetGrants") do
+              list "Grant"
+              element("Grant") do
+                element("Grantee") do
+                  element("EmailAddress") { }
+                  element("ID") { }
+                  element("URI") { }
+                end
+                element("Permission") { }
+              end
+            end
+          end
+        end
+
         GetBucketVersioning = BaseGrammar.customize do
           default_value :status, :unversioned
           element("Status") do


### PR DESCRIPTION
Adds the following methods and associated tests:
AWS::S3::Client#get_bucket_logging
AWS::S3::Client#put_bucket_logging

Also adds a method to the Nokogiri Sax Handler to handle comments
in XML by ignoring them.

Resolves Issue #328
