### PR TITLE
Fix Client.operations

### DIFF
--- a/lib/aws/core/client.rb
+++ b/lib/aws/core/client.rb
@@ -581,8 +581,12 @@ module AWS
         # @return [Array<Symbol>] Returns a list of service operations as
         #   method names supported by this client.
         # @api private
-        def operations
-          @operations ||= []
+        def operations(options = {})
+          if name.match(/V\d{8}$/)
+            @operations ||= []
+          else
+            client_class(options).operations
+          end
         end
 
         # @api private

--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -24,8 +24,10 @@ module AWS
 
     # Client class for Amazon Simple Storage Service (S3).
     class Client < Core::Client
-
       API_VERSION = '2006-03-01'
+    end
+
+    class Client::V20060301 < Client
 
       XMLNS = "http://s3.amazonaws.com/doc/#{API_VERSION}/"
 
@@ -1811,8 +1813,6 @@ module AWS
       extend Validators
 
     end
-
-    class Client::V20060301 < Client; end
 
   end
 end


### PR DESCRIPTION
Non-versioned client classes (like `AWS::EC2::Client`) were returning an empty list of operations:

``` ruby
# bad
AWS::EC2::Client.operations #=> []
```

However, if you construct the versioned client, it returns the correct list

``` ruby
# good
AWS::EC2::Client::V20130715.operations #=> [...]
```

This patch causes the client class to ask the default versioned client class for its list of operations.
