### PR TITLE
Fix nokogiri dependency: demand ~> 1.5.10 instead of < 1.6.0

### DIFF
--- a/aws-sdk.gemspec
+++ b/aws-sdk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('uuidtools', '~> 2.1')
-  s.add_dependency('nokogiri', '< 1.6.0') # 1.6 no longer supports Ruby 1.8.7
+  s.add_dependency('nokogiri', '~> 1.5.10') # 1.6 no longer supports Ruby 1.8.7
   s.add_dependency('json', '~> 1.4')
 
   s.files = [


### PR DESCRIPTION
The previous nokogiri dependency (`< 1.6.0`) gave issues in our projects in combination with capybara, possibly due to a dependency resolving bug in Bundler. This has been mentioned in https://github.com/aws/aws-sdk-ruby/issues/273, https://github.com/bundler/bundler/issues/2122, and https://github.com/bundler/bundler/issues/2593.

This PR demands version `~> 1.5.10`, which is effectively the same as demanding anything `< 1.6.0`, but after applying this PR our projects can `bundle update` normally with capybara and aws-sdk in the `Gemfile`.
