### PR TITLE
Add documentation for setting Content-Disposition in copy_from

### DIFF
--- a/lib/aws/s3/s3_object.rb
+++ b/lib/aws/s3/s3_object.rb
@@ -810,6 +810,10 @@ module AWS
       #   the copied object.  Defaults to the source object's content
       #   type.
       #
+      # @option options [String] :content_disposition The presentational
+      #   information for the object. Defaults to the source object's
+      #   content disposition.
+      #
       # @option options [Boolean] :reduced_redundancy (false) If true the
       #   object is stored with reduced redundancy in S3 for a lower cost.
       #


### PR DESCRIPTION
#66 added support for setting the Content-Disposition header in `copy_from`, but the documentation didn't reflect that this new option was available.
