### PR TITLE
Duplicate frozen strings before forcing the encoding to prevent a RuntimeError

### DIFF
--- a/lib/aws/s3/data_options.rb
+++ b/lib/aws/s3/data_options.rb
@@ -71,6 +71,7 @@ module AWS
         if block_given?
           options[:data] = IOProxy.new(block)
         elsif data.is_a?(String)
+          data = data.dup if data.frozen?
           data.force_encoding("BINARY") if data.respond_to?(:force_encoding)
           options[:data] = StringIO.new(data)
         elsif data.is_a?(Pathname)

--- a/spec/aws/s3/s3_object_spec.rb
+++ b/spec/aws/s3/s3_object_spec.rb
@@ -170,6 +170,13 @@ module AWS
 
         end
 
+        context 'with a frozen string' do
+          it 'should not raise an Exception' do
+            client.should_receive(:put_object).and_return(client.stub_for(:put_object))
+            expect { object.write("HELLO".freeze) }.to_not raise_error
+          end
+        end
+
         context 'with a file path' do
 
           it 'should call put_object with the bucket, key and data' do


### PR DESCRIPTION
This is a fix for #375
