### PR TITLE
added create_read_replica support for elasticache (redis)

### DIFF
--- a/lib/aws/api_config/ElastiCache-2013-06-15.yml
+++ b/lib/aws/api_config/ElastiCache-2013-06-15.yml
@@ -212,6 +212,78 @@
                     :rename: :subnets
                     :list: true
             :ignore: true
+- :name: CreateCacheCluster
+  :method: :create_read_replica
+  :inputs:
+    CacheClusterId:
+    - :string
+    - :required
+    ReplicationGroupId:
+    - :string
+    - :required
+    PreferredAvailabilityZone:
+    - :string
+  :outputs:
+    :children:
+      CreateCacheClusterResult:
+        :ignore: true
+        :children:
+          CacheCluster:
+            :children:
+              ConfigurationEndpoint:
+                :children:
+                  Port:
+                    :type: :integer
+              NumCacheNodes:
+                :type: :integer
+              CacheClusterCreateTime:
+                :type: :time
+              PendingModifiedValues:
+                :children:
+                  NumCacheNodes:
+                    :type: :integer
+                  CacheNodeIdsToRemove:
+                    :ignore: true
+                    :children:
+                      CacheNodeId:
+                        :rename: :cache_node_ids_to_remove
+                        :list: true
+              CacheSecurityGroups:
+                :ignore: true
+                :children:
+                  CacheSecurityGroup:
+                    :rename: :cache_security_groups
+                    :list: true
+              CacheParameterGroup:
+                :children:
+                  CacheNodeIdsToReboot:
+                    :ignore: true
+                    :children:
+                      CacheNodeId:
+                        :rename: :cache_node_ids_to_reboot
+                        :list: true
+              CacheNodes:
+                :ignore: true
+                :children:
+                  CacheNode:
+                    :rename: :cache_nodes
+                    :list: true
+                    :children:
+                      CacheNodeCreateTime:
+                        :type: :time
+                      Endpoint:
+                        :children:
+                          Port:
+                            :type: :integer
+              AutoMinorVersionUpgrade:
+                :type: :boolean
+              SecurityGroups:
+                :ignore: true
+                :children:
+                  member:
+                    :rename: :security_groups
+                    :list: true
+            :ignore: true
 - :name: CreateReplicationGroup
   :method: :create_replication_group
   :inputs:


### PR DESCRIPTION
Essentially the same as https://github.com/boto/boto/pull/1711

> Amazon's documentation is incomplete in this regard, but after playing with the web interface and the API I figured out how it works.
> 
> If you launch a redis cache cluster with a replication_group_id, that cluster becomes a read-only replica cluster in the replication group. BUT if you do that, then you can't send up any other parameters, including the "required" ones (engine, num_nodes, and cache_node_type). The one exception I have found to that is the preferred_availability_zone parameter, which I was able to figure out only because it's an option on their web interface.
> 
> Since Amazon is essentially using the same endpoint for two logically different functions, I split the create_cache_cluster command into create_cache_cluster and create_replica_cluster to match. You could fix the behavior by not making engine, num_nodes, and cache_node_type required arguments, but I think that is significantly less clear.
