### PR TITLE
add public IP address option for instances in VPC

### DIFF
--- a/lib/aws/ec2/instance_collection.rb
+++ b/lib/aws/ec2/instance_collection.rb
@@ -278,8 +278,8 @@ module AWS
           end
           network_interface[:associate_public_ip_address] = true
           network_interface[:device_index] = 0
-          options.delete(:associate_public_ip_address)
         end
+        options.delete(:associate_public_ip_address)
 
         options[:network_interfaces] = [network_interface] unless network_interface.empty?
 


### PR DESCRIPTION
allows you to pass :associate_public_ip_address to InstanceCollection#create, and applies this value to the network interface options.
NOTE: in order for this to work, a couple of other options have to be moved out of the base and into the network interface: private_ip_address, subnet, and security_group_ids
related to: https://forums.aws.amazon.com/thread.jspa?threadID=137014&tstart=0
