### PR TITLE
RequestSpotInstances does not accept MonitoringEnabled

### DIFF
--- a/lib/aws/api_config/EC2-2013-08-15.yml
+++ b/lib/aws/api_config/EC2-2013-08-15.yml
@@ -4082,8 +4082,11 @@
               NoDevice:
               - :string
         - :rename: blockDeviceMappings
-        MonitoringEnabled:
-        - :boolean
+        Monitoring:
+        - :structure:
+            Enabled:
+            - :boolean
+            - :required
         SubnetId:
         - :string
         NetworkInterface:

--- a/lib/aws/api_config/EC2-2013-10-01.yml
+++ b/lib/aws/api_config/EC2-2013-10-01.yml
@@ -4084,8 +4084,11 @@
               NoDevice:
               - :string
         - :rename: blockDeviceMappings
-        MonitoringEnabled:
-        - :boolean
+        Monitoring:
+        - :structure:
+            Enabled:
+            - :boolean
+            - :required
         SubnetId:
         - :string
         NetworkInterface:


### PR DESCRIPTION
Using ec2 request_spot_instances with :monitoring_enabled => true results in AWS::EC2::Errors::UnknownParameter: The parameter MonitoringEnabled is not recognized

Using :monitoring => {:enabled => true} does work, but it requires an update in the api_config yml. 
