### PR TITLE
Allow Nokogiri 1.6 when Ruby > 1.8

### DIFF
--- a/aws-sdk.gemspec
+++ b/aws-sdk.gemspec
@@ -12,7 +12,11 @@ Gem::Specification.new do |s|
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('uuidtools', '~> 2.1')
-  s.add_dependency('nokogiri', '>= 1.4.4', '< 1.6.0') # 1.6 no longer supports Ruby 1.8.7
+  if RUBY_VERSION[0,3] == "1.8"
+    s.add_dependency('nokogiri', '>= 1.4.4', '< 1.6.0') # 1.6 no longer supports Ruby 1.8.7
+  else
+    s.add_dependency("nokogiri", ">= 1.4.4")
+  end
   s.add_dependency('json', '~> 1.4')
 
   s.files = [


### PR DESCRIPTION
Potential temporary solution for #390 is to add a RUBY_VERSION check inside the gemspec.
