### PR TITLE
Support RawMessageDelivery on SNS subscriptions

### DIFF
--- a/lib/aws/sns/subscription.rb
+++ b/lib/aws/sns/subscription.rb
@@ -97,6 +97,22 @@ module AWS
         get_attributes['EffectiveDeliveryPolicy']
       end
 
+      # @return [Boolean] Returns true if the subscriptions has raw message delivery enabled.
+      def raw_message_delivery
+        raw_value = get_attributes['RawMessageDelivery']
+        raw_value.downcase == 'true'
+      end
+
+      # @param [Boolean] raw_delivery Whether to enable or disable raw message delivery.
+      def raw_message_delivery= raw_delivery
+        value = if raw_delivery
+          'true'
+        else
+          'false'
+        end
+        update_subscription_attribute('RawMessageDelivery', value)
+      end
+
       # @note This method requests the entire list of subscriptions
       #   for the topic (if known) or the account (if the topic is not
       #   known).  It can be expensive if the number of subscriptions
@@ -125,12 +141,17 @@ module AWS
       alias_method :==, :eql?
 
       protected
-      def update_delivery_policy policy_json
+      def update_subscription_attribute name, value
         client_opts = {}
         client_opts[:subscription_arn] = arn
-        client_opts[:attribute_name] = 'DeliveryPolicy'
-        client_opts[:attribute_value] = policy_json
+        client_opts[:attribute_name] = name
+        client_opts[:attribute_value] = value
         client.set_subscription_attributes(client_opts)
+      end
+
+      protected
+      def update_delivery_policy policy_json
+        update_subscription_attribute('DeliveryPolicy', policy_json)
       end
 
       protected

--- a/spec/aws/sns/subscription_spec.rb
+++ b/spec/aws/sns/subscription_spec.rb
@@ -112,6 +112,39 @@ module AWS
 
       end
 
+      context '#raw_message_delivery' do
+
+        def stub_raw_message_delivery value
+          client.stub(:get_subscription_attributes =>
+            double("Attributes", :attributes => {"RawMessageDelivery" => value}))
+        end
+
+        it 'returns true if the RawMessageDelivery attribute is true' do
+          stub_raw_message_delivery('true')
+          client.should_receive(:get_subscription_attributes)
+          subscription.raw_message_delivery.should == true
+        end
+
+        it 'returns false if the RawMessageDelivery is false' do
+          stub_raw_message_delivery('false')
+          client.should_receive(:get_subscription_attributes)
+          subscription.raw_message_delivery.should == false
+        end
+
+      end
+
+      context '#raw_message_delivery=' do
+
+        it 'updates the client with the RawMessageDelivery attribute' do
+          client.should_receive(:set_subscription_attributes).
+            with(:attribute_name => 'RawMessageDelivery',
+                 :attribute_value => 'true',
+                 :subscription_arn => arn)
+          subscription.raw_message_delivery = true
+        end
+
+      end
+
     end
   end
 end


### PR DESCRIPTION
Hi All,

I noticed that the AWS SDK did not support [RawMessageDelivery](http://docs.aws.amazon.com/sns/latest/dg/large-payload-raw-message.html) for SNS.

To fix this, I tried adding it analogous to the delivery policy code and re-factored that part a bit.

Please tell if you'd like me to change anything or add more or different test, etc.
