### PR TITLE
AWS::Record::HashModel replace reference to id attribute with call to ha...

### DIFF
--- a/lib/aws/record/hash_model.rb
+++ b/lib/aws/record/hash_model.rb
@@ -149,7 +149,7 @@ module AWS
       # @api private
       private
       def dynamo_db_item
-        dynamo_db_table.items[id]
+        dynamo_db_table.items[hash_key]
       end
 
       # @return [SimpleDB::Domain] Returns the domain this record is


### PR DESCRIPTION
...sh_key

When a developer defines a hash key attribute not named "id", retrieving an existing item fails at dynamo_db_item:152 with: AWS::Record::UndefinedAttributeError: id.  Replacing the reference to id attribute with call to instance method hash_key (line 31) fixes this error as the hash_key method utilizes the attribute that was defined with option :hash_key.
