### PR TITLE
fixed issue #427 in order to be able to set dynamo db api version

### DIFF
--- a/lib/aws/dynamo_db.rb
+++ b/lib/aws/dynamo_db.rb
@@ -129,7 +129,7 @@ module AWS
     def initialize options = {}
       options = options.dup
       options[:dynamo_db] ||= {}
-      options[:dynamo_db][:api_version] = '2011-12-05'
+      options[:dynamo_db][:api_version] ||= '2011-12-05'
       super(options)
     end
 


### PR DESCRIPTION
When I create a DynamoDB object, even if I set an api version, initialize method override this variable. Because of this, '2012-08-10' version cannot be used. 
