### PR TITLE
OpenSSL::Digest::Digest is deprecated; use OpenSSL::Digest

### DIFF
--- a/lib/aws/core/signers/base.rb
+++ b/lib/aws/core/signers/base.rb
@@ -36,7 +36,7 @@ module AWS
         # @param [String] digest ('sha256')
         # @return [String]
         def hmac key, value, digest = 'sha256'
-          OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new(digest), key, value)
+          OpenSSL::HMAC.digest(OpenSSL::Digest.new(digest), key, value)
         end
         module_function :hmac
 

--- a/lib/aws/core/signers/version_4.rb
+++ b/lib/aws/core/signers/version_4.rb
@@ -219,7 +219,7 @@ module AWS
         end
 
         def sha256_digest
-          OpenSSL::Digest::Digest.new('sha256')
+          OpenSSL::Digest.new('sha256')
         end
 
       end

--- a/lib/aws/core/signers/version_4/chunk_signed_stream.rb
+++ b/lib/aws/core/signers/version_4/chunk_signed_stream.rb
@@ -145,7 +145,7 @@ module AWS
           end
 
           def sign value
-            @digest ||= OpenSSL::Digest::Digest.new('sha256')
+            @digest ||= OpenSSL::Digest.new('sha256')
             OpenSSL::HMAC.hexdigest(@digest, @key, value)
           end
 

--- a/lib/aws/glacier/archive_collection.rb
+++ b/lib/aws/glacier/archive_collection.rb
@@ -101,8 +101,8 @@ module AWS
       # but that requires reading the data a 2nd time. :(
       def compute_checksums data
 
-        digest = OpenSSL::Digest::Digest.new('sha256')
-        tree_digest = OpenSSL::Digest::Digest.new('sha256')
+        digest = OpenSSL::Digest.new('sha256')
+        tree_digest = OpenSSL::Digest.new('sha256')
         tree_parts = []
 
         until data.eof?
@@ -123,7 +123,7 @@ module AWS
 
       def compute_tree_hash hashes
 
-        digest = OpenSSL::Digest::Digest.new('sha256')
+        digest = OpenSSL::Digest.new('sha256')
 
         until hashes.count == 1
           hashes = hashes.each_slice(2).map do |h1,h2|


### PR DESCRIPTION
When using aws-sdk with Ruby 2.1.0-rc1, many "Digest::Digest is deprecated; use Digest" warnings are printed.
Even in Ruby 1.8.7-p374, OpenSSL::Digest::Digest is only provided for backward compatibility.
