### PR TITLE
Fix invalid bucket creation syntax in docs

### DIFF
--- a/lib/aws/s3/bucket_collection.rb
+++ b/lib/aws/s3/bucket_collection.rb
@@ -18,7 +18,7 @@ module AWS
     #
     # You can use this to create a bucket:
     #
-    #     s3.buckets.create(:name => "mybucket")
+    #     s3.buckets.create("mybucket")
     #
     # You can get a handle for a specific bucket with indifferent
     # access:


### PR DESCRIPTION
Using this syntax results in `ArgumentError: bucket_name may only contain uppercase letters, lowercase letters, numbers, periods (.), underscores (_), and dashes (-)` as the provided Hash doesn't validate as a proper String.
