### PR TITLE
Use double check locking for credentials lazy initializing in credential providers

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -37,12 +37,18 @@ module AWS
         #   `:access_key_id` or the `:secret_access_key` can not be found.
         #
         def credentials
-          @cached_credentials ||= begin
-            creds = get_credentials
-            unless creds[:access_key_id] and creds[:secret_access_key]
-              raise Errors::MissingCredentialsError
+          @cache_mutex ||= Mutex.new
+
+          unless @cached_credentials
+            @cache_mutex.synchronize do
+              @cached_credentials ||= begin
+                creds = get_credentials
+                unless creds[:access_key_id] and creds[:secret_access_key]
+                  raise Errors::MissingCredentialsError
+                end
+                creds
+              end
             end
-            creds
           end
           @cached_credentials.dup
         end

--- a/spec/mock_ec2_metadata_server.rb
+++ b/spec/mock_ec2_metadata_server.rb
@@ -41,13 +41,15 @@ class MockEC2MetadataServer
   # @private
   attr_accessor :request_count
 
+  attr_writer :response_delay
+
   def start
 
     @threads << Thread.new do
       loop do
         @threads << Thread.start(@tcp_server.accept) do |socket|
           loop do
-
+            sleep @response_delay if @response_delay
             uri = read_request(socket).split(/ /)[1]
 
             path = '/latest/meta-data/iam/security-credentials/'


### PR DESCRIPTION
This is to make sure EC2 credential provider does not hit metadata service too many times in a highly concurrent environment.

We have a server runs on EC2 using instance profile for AWS authentication. The server is for background processing and every-time it boots up there are 35 threads start fetching messages from SQS. Thus resulting in about 30 requests hitting EC2 metadata server (169.254.169.254) at same time. Metadata server returns 429 (Too Many Requests) for some threads, and set back an empty credential ({}) as cached value. If broken threads finished first and its result get cached, MissingCredentialsError will be thrown.

This pull request solve the problem by putting a mutex around the caching logic. So if multiple threads come in at same time, the first one will fetch credentials and all the rest wait. Also this is a double check locking, so once credential get cached we do not need pay the cost of synchronize anymore.

-- wpc
