### PR TITLE
Enable access to LastModified element for AWS::S3::ObjectVersion

### DIFF
--- a/lib/aws/s3/bucket_version_collection.rb
+++ b/lib/aws/s3/bucket_version_collection.rb
@@ -53,7 +53,9 @@ module AWS
         super
         page.versions.each do |version|
           object_version = ObjectVersion.new(bucket.objects[version.key],
-            version.version_id, :delete_marker => version.delete_marker?)
+                                             version.version_id, 
+                                             :delete_marker => version.delete_marker?, 
+                                             :last_modified => version.last_modified)
           yield(object_version)
         end
       end

--- a/lib/aws/s3/object_version.rb
+++ b/lib/aws/s3/object_version.rb
@@ -28,15 +28,21 @@ module AWS
       # @param [Hash] options
       # @option options [Boolean] :delete_marker Is this version a
       #   delete marker?
+      # @option options [DateTime] :last_modified Date and time the
+      #   object was last modified.
       def initialize(object, version_id, options = {})
         @object = object
         @version_id = version_id
         @delete_marker = options[:delete_marker]
+        @last_modified = options[:last_modified]
         super
       end
 
       # @return [S3Object] the object this is a version of.
       attr_reader :object
+
+      # @return [DateTime] timestamp of this version
+      attr_reader :last_modified
 
       def bucket
         object.bucket


### PR DESCRIPTION
Added a way to access the LastModified field for S3 object versions. This was already in the hash after parsing the xml, just not available in the ruby object.
