### PR TITLE
Handle autoloading when embedded in a jar

### DIFF
--- a/lib/aws/core.rb
+++ b/lib/aws/core.rb
@@ -146,9 +146,18 @@ module AWS
   ].inject({}) { |h,svc| h[svc.class_name] = svc; h }
 
   # @api private
-  ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
 
-  SRC = ROOT + '/lib/aws'
+  # Handle being embedded in a jar (for certain jruby users)
+  if __FILE__.start_with?('jar:file:')
+    # Examples, for reference:
+    # __FILE__ = jar:file:/opt/company/library.jar!/aws/core.rb
+    # File.dirname(__FILE__) = jar:file:/opt/company/library.jar!/aws
+    ROOT = File.dirname(__FILE__)
+    SRC = ROOT
+  else
+    ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+    SRC = ROOT + '/lib/aws'
+  end
 
   autoload :Errors, "#{SRC}/errors"
   autoload :Record, "#{SRC}/record"


### PR DESCRIPTION
When this gem is embedded in a jar the ROOT and SRC paths are not working.

We use rawr to create our jars, and it was creating it with a structure that this PR satisfies. If someone else is using warbler or another method, it may put it in yet another structure. So I can't guarantee this works for all jars. Happy to discuss though.
