### PR TITLE
Support uri unsafe characters in proxy_uri

### DIFF
--- a/lib/aws/core/http/connection_pool.rb
+++ b/lib/aws/core/http/connection_pool.rb
@@ -277,8 +277,18 @@ module AWS
           args << endpoint.port
           args << proxy_uri.host
           args << proxy_uri.port
-          args << proxy_uri.user
-          args << proxy_uri.password
+          
+          if proxy_uri.user
+            args << URI::decode(proxy_uri.user)
+          else
+            args << nil
+          end
+          
+          if proxy_uri.password
+            args << URI::decode(proxy_uri.password)
+          else 
+            args << nil
+          end
 
           http = Net::HTTP.new(*args.compact)
           http.extend(SessionExtensions)


### PR DESCRIPTION
Allow the user to use unsafe characters (@, :, / for instance) in the proxy_uri through the use of URI::decode for the username and password components of the URI. 

This change is particularly critical for users of proxies with Windows domain style (domain/user) usernames.

I'm sure there is a cleaner way to do this in ruby, but ruby is not my primary language.
