### PR TITLE
Added support for ENV['AWS_DEFAULT_REGION']

### DIFF
--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -483,7 +483,7 @@ module AWS
       add_option :session_token
 
       add_option :region do |cfg,region|
-        region || ENV['AWS_REGION'] || ENV['AMAZON_REGION'] || 'us-east-1'
+        region || ENV['AWS_REGION'] || ENV['AMAZON_REGION'] || ENV['AWS_DEFAULT_REGION'] ||  'us-east-1'
       end
 
       add_option_with_needs :credential_provider,

--- a/spec/aws/core/configuration_spec.rb
+++ b/spec/aws/core/configuration_spec.rb
@@ -344,11 +344,13 @@ module AWS::Core
       before(:each) do
         ENV.delete('AWS_REGION')
         ENV.delete('AMAZON_REGION')
+        ENV.delete('AWS_DEFAULT_REGION')
       end
 
       after(:each) do
         ENV.delete('AWS_REGION')
         ENV.delete('AMAZON_REGION')
+        ENV.delete('AWS_DEFAULT_REGION')
       end
 
       it 'defaults to us-east-1' do
@@ -365,12 +367,23 @@ module AWS::Core
         Configuration.new.region.should eq('region2')
       end
 
-      it 'prefers up ENV["AWS_REGION"] over ENV["AMAZON_REGION"]' do
+      it 'picks up ENV["AWS_DEFAULT_REGION"]' do
+        ENV['AWS_DEFAULT_REGION'] = 'region3'
+        Configuration.new.region.should eq('region3')
+      end
+
+      it 'prefers ENV["AWS_REGION"] over ENV["AMAZON_REGION"] and ENV["AWS_DEFAULT_REGION"]' do
         ENV['AWS_REGION'] = 'region1'
         ENV['AMAZON_REGION'] = 'region2'
+        ENV['AWS_DEFAULT_REGION'] = 'region3'
         Configuration.new.region.should eq('region1')
       end
 
+      it 'prefers ENV["AMAZON_REGION"] over ENV["AWS_DEFAULT_REGION"]' do
+        ENV['AMAZON_REGION'] = 'region1'
+        ENV['AWS_DEFAULT_REGION'] = 'region2'
+        Configuration.new.region.should eq('region1')
+      end
     end
 
   end


### PR DESCRIPTION
Support environment variable used by Amazon Command Line Interface.

The unified awscli uses the following environment variables:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION

The first two are supported by aws-sdk-ruby and this change adds support for the region.

This makes aws-sdk-ruby based scripts easier for users familiar with awscli.

http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence
