### PR TITLE
Updated the documentation for R53 HostedZoneCollection to reflect the required use of ID over name

### DIFF
--- a/lib/aws/route_53/hosted_zone_collection.rb
+++ b/lib/aws/route_53/hosted_zone_collection.rb
@@ -24,7 +24,8 @@ module AWS
     # # Find existing hosted zone
     #
     #     r53 = AWS::Route53.new
-    #     hosted_zone = r53.hosted_zones['example.com.']
+    #     # to lookup a route53 hosted zone, you need to use the zone id (i.e hosted_zone.id)
+    #     hosted_zone = r53.hosted_zones['Zabcdefghijklm']
     #
     class HostedZoneCollection
 


### PR DESCRIPTION
updated the documentation to reflect that you need to use the ID..

In the documentation it shows this example:

# Find existing hosted zone
r53 = AWS::Route53.new
hosted_zone = r53.hosted_zones['example.com.']

However I found it's more like this:

 r53 = AWS::Route53.new
 hosted_zone = r53.hosted_zones['example.com.']
# to lookup a route53 hosted zone, you need to use the zone id (i.e hosted_zone.id). It comes as a 14 character string starting with a Z. 
hosted_zone = r53.hosted_zones['ZABCDEFG123456']

I'll admit that I've not dug into the code too much but I don't see any lookups on the param to see if it's a domain or an ID. So i assumed this just a mistake in the documentation. 

Cheers,
Darius
