### PR TITLE
SQS documentation formatting fix.

### DIFF
--- a/lib/aws/sqs/queue.rb
+++ b/lib/aws/sqs/queue.rb
@@ -95,12 +95,12 @@ module AWS
       #   characters not included in the list, your request will be
       #   rejected.
       #
-      #   * #x9
-      #   * #xA
-      #   * #xD
-      #   * #x20 to #xD7FF
-      #   * #xE000 to #xFFFD
-      #   * #x10000 to #x10FFFF
+      #   * `#x9`
+      #   * `#xA`
+      #   * `#xD`
+      #   * `#x20` to `#xD7FF`
+      #   * `#xE000` to `#xFFFD`
+      #   * `#x10000` to `#x10FFFF`
       #
       # @param [Hash] options
       #


### PR DESCRIPTION
Used to show up as large headings. Tested with rake docs; yard server and checked that it looked good :-)
