### PR TITLE
Don't overwrite api_version argument at DynamoDB.new

### DIFF
--- a/lib/aws/dynamo_db.rb
+++ b/lib/aws/dynamo_db.rb
@@ -128,7 +128,7 @@ module AWS
     def initialize options = {}
       options = options.dup
       options[:dynamo_db] ||= {}
-      options[:dynamo_db][:api_version] = '2011-12-05'
+      options[:dynamo_db][:api_version] ||= '2011-12-05'
       super(options)
     end
 

--- a/spec/aws/dynamo_db_spec.rb
+++ b/spec/aws/dynamo_db_spec.rb
@@ -26,6 +26,25 @@ module AWS
     it_behaves_like 'a class that accepts configuration',
       :dynamo_db_client
 
+    context '#new' do
+
+      context 'with api_version' do
+        let(:dynamo_db) { DynamoDB.new(:dynamo_db => { :api_version => api_version }) }
+
+        context '"2011-12-05" should return V20111205' do
+          let(:api_version) { '2011-12-05' }
+          it { expect(client).to be_a(AWS::DynamoDB::Client::V20111205) }
+        end
+
+        context '"2012-08-10" should return V20120810' do
+          let(:api_version) { '2012-08-10' }
+          it { expect(client).to be_a(AWS::DynamoDB::Client::V20120810) }
+        end
+
+      end
+
+    end
+
     context '#tables' do
 
       it 'should return a tables collection' do


### PR DESCRIPTION
Currently, `:api_version` is overwritten with `'2011-12-05'` forcefully at `DynamoDB.new`.

``` ruby
pry(main)> AWS::DynamoDB.new(dynamo_db: {api_version: '2012-08-10'}).client
=> #<AWS::DynamoDB::Client::V20111205>
```

I guess it's expected to return a client which is specified by `:api_version` argument.
