### PR TITLE
Set API version from options in DynamoDB ctor.

### DIFF
--- a/lib/aws/dynamo_db.rb
+++ b/lib/aws/dynamo_db.rb
@@ -128,7 +128,7 @@ module AWS
     def initialize options = {}
       options = options.dup
       options[:dynamo_db] ||= {}
-      options[:dynamo_db][:api_version] = '2011-12-05'
+      options[:dynamo_db][:api_version] ||= '2011-12-05'
       super(options)
     end
 


### PR DESCRIPTION
1.9.3-p484 :069 > AWS::DynamoDB.new.client
 => #AWS::DynamoDB::Client::V20111205 
1.9.3-p484 :068 > AWS::DynamoDB.new( dynamo_db: { api_version: '2012-08-10' } ).client
 => #AWS::DynamoDB::Client::V20120810 
