### PR TITLE
Add Header Options to AWS::S3::Client#head_object

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1,4 +1,4 @@
-# Copyright 2011-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2011-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -1484,13 +1484,59 @@ module AWS
       #   @option options [required,String] :bucket_name
       #   @option options [required,String] :key
       #   @option options [String] :version_id
+      #   @option options [Time] :if_modified_since If specified, the
+      #     response will contain an additional `:modified` value that
+      #     returns true if the object was modified after the given
+      #     time.  If `:modified` is false, then the response
+      #     `:data` value will be `nil`.
+      #   @option options [Time] :if_unmodified_since If specified, the
+      #     response will contain an additional `:unmodified` value
+      #     that is true if the object was not modified after the
+      #     given time.  If `:unmodified` returns false, the `:data`
+      #     value will be `nil`.
+      #   @option options [String] :if_match If specified, the response
+      #     will contain an additional `:matches` value that is true
+      #     if the object ETag matches the value for this option.  If
+      #     `:matches` is false, the `:data` value of the
+      #     response will be `nil`.
+      #   @option options [String] :if_none_match If specified, the
+      #     response will contain an additional `:matches` value that
+      #     is true if and only if the object ETag matches the value for
+      #     this option.  If `:matches` is true, the `:data` value
+      #     of the response will be `nil`.
+      #   @option options [Range<Integer>] :range A byte range of data to request.
       #   @return [Core::Response]
-      object_method(:head_object, :head) do
+      object_method(:head_object, :head,
+                    :header_options => {
+                      :if_modified_since => "If-Modified-Since",
+                      :if_unmodified_since => "If-Unmodified-Since",
+                      :if_match => "If-Match",
+                      :if_none_match => "If-None-Match"
+                    }) do
 
         configure_request do |req, options|
           super(req, options)
           if options[:version_id]
             req.add_param('versionId', options[:version_id])
+          end
+
+          ["If-Modified-Since",
+           "If-Unmodified-Since"].each do |date_header|
+            case value = req.headers[date_header]
+            when DateTime
+              req.headers[date_header] = Time.parse(value.to_s).rfc2822
+            when Time
+              req.headers[date_header] = value.rfc2822
+            end
+          end
+
+          if options[:range]
+            range = options[:range]
+            if range.is_a?(Range)
+              offset = range.exclude_end? ? -1 : 0
+              range = "bytes=#{range.first}-#{range.last + offset}"
+            end
+            req.headers['Range'] = range
           end
         end
 

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2011-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2011-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -1694,6 +1694,31 @@ module AWS
         it_should_behave_like "returns last_modified"
 
         it_should_behave_like "returns server_side_encryption"
+
+        it_should_behave_like "sends option as header", :range, "Range"
+        it_should_behave_like "sends option as header", :if_modified_since, "If-Modified-Since"
+        it_should_behave_like "sends option as header", :if_unmodified_since, "If-Unmodified-Since"
+        it_should_behave_like "sends option as header", :if_match, "If-Match"
+        it_should_behave_like "sends option as header", :if_none_match, "If-None-Match"
+
+        it_should_behave_like "formats date header", :if_modified_since, "If-Modified-Since"
+        it_should_behave_like "formats date header", :if_unmodified_since, "If-Unmodified-Since"
+
+        context ':range option' do
+          it 'calculates the correct range for an inclusive Range object' do
+            http_handler.should_receive(:handle).with do |req, resp|
+              req.headers["range"].should == "bytes=3-10"
+            end
+            client.head_object(opts.merge(:range => (3..10)))
+          end
+
+          it 'calculates the correct range for an exclusive Range object' do
+            http_handler.should_receive(:handle).with do |req, resp|
+              req.headers["range"].should == "bytes=3-9"
+            end
+            client.head_object(opts.merge(:range => (3...10)))
+          end
+        end
 
         context 'response' do
 


### PR DESCRIPTION
The #head_object operation is supposed to parallel the #get_object
operation for all input headers, but this was not the case due to an
omission in the hand coding. This change adds the remaining input
headers and the associated test.

Resolves issue #495.
