### PR TITLE
Configure from current ENV variable names: AWS_ACCESS_KEY / AWS_SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ AWS.config(access_key_id: '...', secret_access_key: '...', region: 'us-west-2')
 
 You can also specify these values via `ENV`:
 
-    export AWS_ACCESS_KEY='...'
-    export AWS_SECRET_KEY='...'
+    export AWS_ACCESS_KEY_ID='...'
+    export AWS_SECRET_ACCESS_KEY='...'
     export AWS_REGION='us-west-2'
 
 ## Basic Usage

--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -30,13 +30,14 @@ module AWS
     # You can also export them into your environment and they will be picked up
     # automatically:
     #
-    #     export AWS_ACCESS_KEY='YOUR_KEY_ID_HERE'
-    #     export AWS_SECRET_KEY='YOUR_SECRET_KEY_HERE'
+    #     export AWS_ACCESS_KEY_ID='YOUR_KEY_ID_HERE'
+    #     export AWS_SECRET_ACCESS_KEY='YOUR_SECRET_KEY_HERE'
     #
-    # Previous variable names are also checked:
+    # For compatability with other AWS gems, the credentials can also be
+    # exported like:
     #
-    #     AMAZON_ACCESS_KEY_ID / AMAZON_SECRET_ACCESS_KEY
-    #     AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+    #     export AMAZON_ACCESS_KEY_ID='YOUR_KEY_ID_HERE'
+    #     export AMAZON_SECRET_ACCESS_KEY='YOUR_SECRET_KEY_HERE'
     #
     # ## Modifying a Configuration
     #

--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -101,7 +101,8 @@ module AWS
       #   * Static credentials from AWS.config (e.g. AWS.config.access_key_id,
       #     AWS.config.secret_access_key)
       #
-      #   * The environment (ENV['AWS_ACCESS_KEY'] and ENV['AWS_SECRET_KEY']
+      #   * The environment (e.g. ENV['AWS_ACCESS_KEY_ID'] or
+      #     ENV['AMAZON_ACCESS_KEY_ID'])
       #
       #   * EC2 metadata service (checks for credentials provided by
       #     roles for instances).
@@ -114,8 +115,8 @@ module AWS
         def initialize static_credentials = {}
           @providers = []
           @providers << StaticProvider.new(static_credentials)
-          @providers << ENVProvider.new('AWS', :access_key_id => 'ACCESS_KEY', :secret_access_key => 'SECRET_KEY', :session_token => 'SESSION_TOKEN')
           @providers << ENVProvider.new('AWS')
+          @providers << ENVProvider.new('AWS', :access_key_id => 'ACCESS_KEY', :secret_access_key => 'SECRET_KEY', :session_token => 'SESSION_TOKEN')
           @providers << ENVProvider.new('AMAZON')
           @providers << EC2Provider.new
         end


### PR DESCRIPTION
http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/set-up-ec2-cli-linux.html

Current standard ENV variables are AWS_ACCESS_KEY / AWS_SECRET_KEY. Adding support to read those while keeping backward compatibility for all previous values.
