### PR TITLE
The required option :namespace, for AWS::CloudWatch#update isn't documented

### DIFF
--- a/lib/aws/cloud_watch/alarm.rb
+++ b/lib/aws/cloud_watch/alarm.rb
@@ -161,6 +161,9 @@ module AWS
       #     * 'LessThanThreshold'
       #     * 'LessThanOrEqualToThreshold'
       #
+      # @option options [String,required] :namespace The namespace for the
+      #   alarm's associated metric.
+      #
       # @option options [Integer,required] :evaluation_periods The number
       #   of periods over which data is compared to the specified threshold.
       #


### PR DESCRIPTION
Calling AWS::CloudWatch#update without passing a namespace results in:

```
/Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/option_grammar.rb:593:in `block in validate': missing required option namespace (ArgumentError)
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/option_grammar.rb:592:in `each'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/option_grammar.rb:592:in `validate'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/option_grammar.rb:601:in `request_params'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/query_request_builder.rb:37:in `populate_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:737:in `block (2 levels) in define_client_method'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:557:in `build_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:490:in `block (3 levels) in client_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/response.rb:171:in `call'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/response.rb:171:in `build_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/response.rb:111:in `initialize'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:203:in `new'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:203:in `new_response'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:489:in `block (2 levels) in client_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:390:in `log_client_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:476:in `block in client_request'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:372:in `return_or_raise'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/core/client.rb:475:in `client_request'
    from (eval):3:in `put_metric_alarm'
    from /Users/uraboje/.rvm/gems/ruby-2.0.0-p247/gems/aws-sdk-1.38.0/lib/aws/cloud_watch/alarm.rb:215:in `update'
```

But the [AWS::CloudWatch#update's documentation](http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/CloudWatch/Alarm.html#update-instance_method) doesn't show that :namespace is required. I'd like to fix this. Thanks!
