### PR TITLE
Use OpenSSL::Digest where possible.

### DIFF
--- a/lib/aws/core/signers/version_4.rb
+++ b/lib/aws/core/signers/version_4.rb
@@ -192,7 +192,7 @@ module AWS
         # @param [String] value
         # @return [String]
         def hexdigest value
-          digest = Digest::SHA256.new
+          digest = OpenSSL::Digest::SHA256.new
           if value.respond_to?(:read)
             chunk = nil
             chunk_size = 1024 * 1024 # 1 megabyte

--- a/lib/aws/core/signers/version_4/chunk_signed_stream.rb
+++ b/lib/aws/core/signers/version_4/chunk_signed_stream.rb
@@ -150,7 +150,7 @@ module AWS
           end
 
           def hash value
-            Digest::SHA256.new.update(value).hexdigest
+            OpenSSL::Digest::SHA256.new.update(value).hexdigest
           end
 
           class << self

--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -236,7 +236,7 @@ module AWS
       end
 
       def md5 str
-        Base64.encode64(Digest::MD5.digest(str)).strip
+        Base64.encode64(OpenSSL::Digest::MD5.digest(str)).strip
       end
 
       def parse_copy_part_response resp
@@ -1015,7 +1015,7 @@ module AWS
       #     * `:permission` - (String) Logging permissions given to the Grantee
       #          for the bucket. The bucket owner is automatically granted FULL_CONTROL
       #          to all logs delivered to the bucket. This optional element enables
-      #          you grant access to others. Valid Values: FULL_CONTROL | READ | WRITE 
+      #          you grant access to others. Valid Values: FULL_CONTROL | READ | WRITE
       #   @return [Core::Response]
       bucket_method(:put_bucket_logging, :put) do
         configure_request do |req, options|
@@ -1062,7 +1062,7 @@ module AWS
           xml = xml.doc.root.to_xml
           req.body = xml
           req.headers['content-md5'] = md5(xml)
-          
+
           super(req, options)
 
         end


### PR DESCRIPTION
From the commit:

Per #525 it appears that the regular Digest module is not thread-safe. Testing
showed that OpenSSL::Digest on the other hand is working fine.

Currently the SQS related code still uses Digest in one place. I tried
replacing that but this triggered spec failures for unknown reasons. The
OpenSSL::Digest API should be identical to Digest so I'm not really sure what's
going on here.

Personal note: 

SQS should probably be moved over as well so that the `require 'digest'` can go. I'm basing these changes on the results of applying https://github.com/aws/aws-sdk-ruby/issues/525#issuecomment-41890170 and not seeing the error since.
