### PR TITLE
Clarify log_level configuration docs

### DIFF
--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -116,7 +116,8 @@ module AWS
     #
     # @attr_reader [Logger,nil] logger (nil) The logging interface.
     #
-    # @attr_reader [Symbol] log_level (:info) The log level.
+    # @attr_reader [Symbol] log_level (:info) The log level to use when
+    #   logging every API call.  Does not set the `:logger`'s log_level.
     #
     # @attr_reader [LogFormatter] log_formatter The log message formatter.
     #


### PR DESCRIPTION
As is, I think the log_level config option can be misunderstood to mean the log_level at which to set the logger, not the log_level method to call the logger with for logging all API calls
