### PR TITLE
Loosen json gem dependency.

### DIFF
--- a/aws-sdk.gemspec
+++ b/aws-sdk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('nokogiri', '>= 1.4.4')
-  s.add_dependency('json', '~> 1.4')
+  s.add_dependency('json', '>= 1.4', '< 1.9')
 
   s.files = [
     'ca-bundle.crt',


### PR DESCRIPTION
1.4.x is pretty old. Tests pass for me with current latest (1.8.1).

This loosens the dependency to include all versions in between, and any future 1.8.x release.
