### PR TITLE
Add DBSecurityGroupName to AuthorizeDBSecurityGroupIngress

### DIFF
--- a/lib/aws/api_config/RDS-2013-09-09.yml
+++ b/lib/aws/api_config/RDS-2013-09-09.yml
@@ -66,6 +66,8 @@
 - :name: AuthorizeDBSecurityGroupIngress
   :method: :authorize_db_security_group_ingress
   :inputs:
+    DBSecurityGroupName:
+    - :string
     CIDRIP:
     - :string
     EC2SecurityGroupName:


### PR DESCRIPTION
This was regressed here: https://github.com/aws/aws-sdk-ruby/commit/93b6ddbd671ddcc0d43926b6762e595dcfe4b625

This should have just been made optional, not removed entirely. Currently, this fails if you try to use this option.

Example:

```
AWS::rds.client.authorize_db_security_group_ingress({cidrip: "#{ip_address}/32", db_security_group_name: "default"})
```

ArgumentError: unexpected option DBSecurityGroupName

it should have been made optional, not required
