### PR TITLE
Modified document of `option[:instance_tenancy]`

### DIFF
--- a/lib/aws/ec2/vpc_collection.rb
+++ b/lib/aws/ec2/vpc_collection.rb
@@ -30,7 +30,7 @@ module AWS
       #
       # @param [Hash] options
       #
-      # @option options [Boolean] :instance_tenancy (:default)
+      # @option options [Symbol] :instance_tenancy (:default)
       #   The allowed tenancy of instances launched into the VPC. A value of
       #   `:default` means instances can be launched with any tenancy; a value
       #   of `:dedicated` means all instances launched into the VPC will be launched with


### PR DESCRIPTION
Hi.

I modified documentation of `AWS::EC2::VPCCollection`.
`option[:instance_tenecy]` specify Symbol in the sample code.
