### PR TITLE
Fix comment on WorkflowExecutionCollection#with_status and #count

### DIFF
--- a/lib/aws/simple_workflow/workflow_execution_collection.rb
+++ b/lib/aws/simple_workflow/workflow_execution_collection.rb
@@ -212,7 +212,7 @@ module AWS
       #   * `:failed`
       #   * `:canceled`
       #   * `:terminated`
-      #   * `:continued`
+      #   * `:continued_as_new`
       #   * `:timed_out`
       #
       #   If `:status` is anything besides `:open` or `:closed` then
@@ -422,7 +422,7 @@ module AWS
       #   * `:failed`
       #   * `:canceled`
       #   * `:terminated`
-      #   * `:continued`
+      #   * `:continued_as_new`
       #   * `:timed_out`
       #
       # @option options [Time] :started_after Filters workflow executions


### PR DESCRIPTION
A correct value of `closeStatusFilter.status` is `continue_as_new` but `continue`.

``` ruby
swf=AWS::SimpleWorkflow.new(region: 'ap-northeast-1')
domain = swf.domains['TestDomain']
domain.workflow_executions.with_status(:continue).count
# => AWS::SimpleWorkflow::Errors::ValidationException 1 validation error detected: Value 'CONTINUE' at 'closeStatusFilter.status' failed to satisfy constraint: Member must satisfy enum value set: [TERMINATED, TIMED_OUT, COMPLETED, CONTINUED_AS_NEW, CANCELED, FAILED]
```
