### PR TITLE
[RDS::DBInstance] fix: #exists? return true when id is ""

### DIFF
--- a/lib/aws/rds/db_instance.rb
+++ b/lib/aws/rds/db_instance.rb
@@ -193,7 +193,7 @@ module AWS
 
       # @return [Boolean] Returns `true` if the db instance exists.
       def exists?
-        fail AWS::RDS::Errors::DBInstanceNotFound if id.empty?
+        fail AWS::RDS::Errors::DBInstanceNotFound if id.to_s.empty?
         get_resource
         true
       rescue AWS::RDS::Errors::DBInstanceNotFound


### PR DESCRIPTION
Fix this.

```
def rds
  @rds ||= AWS::RDS.new
end

rds.instances[nil].exists? #=> true
rds.instances[""].exists? #=> true
```
