### PR TITLE
[s3] Do not prepend metadata keys if they start with x-amz

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -139,7 +139,10 @@ module AWS
       def set_metadata request, options
         if metadata = options[:metadata]
           Array(metadata).each do |name, value|
-            request.headers["x-amz-meta-#{name}"] = value
+            # Do not add x-amz-meta- prefix to
+            # special metadata keys (like x-amz-webiste-redirect)
+            key =  name.start_with?("x-amz-") ?  name : "x-amz-meta-#{name}"
+            request.headers[key] = value
           end
         end
       end

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -89,14 +89,14 @@ module AWS
               lambda { client.send(method, opts) }.
                 should raise_error(klass)
             end
-  
+
             it "should raise an instance of #{kind}" do
               lambda { client.send(method, opts) }.
                 should raise_error(kind)
             end
-  
+
           end
-  
+
         end
 
       end
@@ -129,7 +129,7 @@ module AWS
       end
 
       context 'cors', :cors => true do
-  
+
         let(:xml) { <<-XML.strip.xml_cleanup }
 <CORSConfiguration>
   <CORSRule>
@@ -306,7 +306,7 @@ module AWS
             request.querystring.should eq('logging=')
 
           end
-          
+
         end
 
         context '#get_bucket_logging' do
@@ -1065,6 +1065,18 @@ module AWS
             color_header.should == 'red'
           end
 
+          context "When x-amz-* metadata is set" do
+            it "doesn't prefix special metadata keys" do
+              redirect_header = nil
+              client = with_http_handler do |req, resp|
+                redirect_header = req.headers['x-amz-website-redirect']
+              end
+
+              opts[:metadata] = { 'x-amz-website-redirect' => '/foo' }
+              client.send(method, opts)
+              redirect_header.should == '/foo'
+            end
+          end
         end
 
       end


### PR DESCRIPTION
According to
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html

to enable redirect on an S3 object it needs to have
'x-amz-website-redirect' metadata key with new location value.

When creating an object like so:

``` ruby

bucket.object['foo'].write('', metadata: { "x-amz-website-redirect" =>
"http://example.com" }, acl: :public_read )
```

`x-amz-website-redirect` gets prepended with `x-amz-meta-` prefix thus
breaking the redirect feature.

This also affects any other meta data key which starts with 'x-amz'.
