### PR TITLE
Added require 'json' to ensure no failure when calling using AWS.config....

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -16,6 +16,7 @@ require 'net/http'
 require 'timeout'
 require 'thread'
 require 'time'
+require 'json'
 
 module AWS
   module Core


### PR DESCRIPTION
...credentials

https://github.com/aws/aws-sdk-ruby/issues/566
