### PR TITLE
Allow arguments in bucket.lifecycle_configuration.update

### DIFF
--- a/lib/aws/s3/bucket_lifecycle_configuration.rb
+++ b/lib/aws/s3/bucket_lifecycle_configuration.rb
@@ -242,10 +242,10 @@ module AWS
       #
       # @return [nil]
       #
-      def update &block
+      def update arg = {}, &block
         begin
           @batching = true
-          instance_eval(&block) if block_given?
+          instance_exec(arg, &block) if block_given?
           persist(true)
         ensure
           @batching = false

--- a/spec/aws/s3/bucket_lifecycle_configuration_spec.rb
+++ b/spec/aws/s3/bucket_lifecycle_configuration_spec.rb
@@ -238,6 +238,41 @@ module AWS
 
         end
 
+
+       it 'can used arguments' do
+            xml = <<-XML.xml_cleanup
+<LifecycleConfiguration>
+  <Rule>
+    <ID>#{uuid}</ID>
+    <Prefix>foo/bar</Prefix>
+    <Status>Enabled</Status>
+    <Expiration>
+      <Days>10</Days>
+    </Expiration>
+  </Rule>
+  <Rule>
+    <ID>abc-xyz</ID>
+    <Prefix>bar/foo</Prefix>
+    <Status>Disabled</Status>
+    <Expiration>
+      <Days>11</Days>
+    </Expiration>
+  </Rule>
+</LifecycleConfiguration>
+            XML
+
+          client.should_receive(:set_bucket_lifecycle_configuration) do |hash|
+            hash[:bucket_name].should eq(bucket.name)
+            hash[:lifecycle_configuration].xml_cleanup.should eq(xml)
+          end
+
+          lifecycle.update({id: 'abc-xyz'}) do |args|
+            add_rule 'foo/bar', 10
+            add_rule 'bar/foo', 11, :id => args[:id], :disabled => true
+          end
+
+        end
+
       end
 
       context '#replace' do


### PR DESCRIPTION
Allows user to optionally pass in variables to lifecycle.update through arguments by changing instance_eval to instance_exec.

Example

@keep_days = 30
bucket.lifecycle_configuration.update({keep_days: @keep_days}) do |args|
      add_rule 'bar/foo', 11, expiration_time: args[:keep_days]
end
