### PR TITLE
fix: AWS::Core::CredentialProviders::Provider#set? return boolean

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -52,8 +52,8 @@ module AWS
               @cached_credentials ||= get_credentials
             end
           end
-          @cached_credentials[:access_key_id] &&
-            @cached_credentials[:secret_access_key]
+          !!(@cached_credentials[:access_key_id] &&
+            @cached_credentials[:secret_access_key])
         end
 
         # @return [String] Returns the AWS access key id.


### PR DESCRIPTION
Fix this.

```
c = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(profile_name: 'default')
c.credentials # => { :access_key_id => "AKxxxxxxxxxxxxxxxxxx", :secret_access_key =>  "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" }
c.set? #=> true
```
