### PR TITLE
Refs #575: Fixed issue in assigning metadata to S3 object

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -142,6 +142,9 @@ module AWS
           Array(metadata).each do |name, value|
             # Do not add x-amz-meta- prefix to
             # special metadata keys (like x-amz-webiste-redirect)
+            # Make sure name is always a string to prevent exception from
+            # start_with?
+            name = name.to_s
             key =  name.start_with?("x-amz-") ?  name : "x-amz-meta-#{name}"
             request.headers[key] = value
           end


### PR DESCRIPTION
While assigning metadata through `S3Object.write(data, options = {})`, name variable data in `set_metadata()` of lib/aws/s3/client.rb has to be a string for `start_with?` to work.

Signed-off-by: Gautam Sathe gautam@hemisphereinteractive.com
