### PR TITLE
Convert milliseconds to microseconds before passing to Time::utc

### DIFF
--- a/lib/aws/core/xml/frame.rb
+++ b/lib/aws/core/xml/frame.rb
@@ -231,6 +231,7 @@ module AWS
           # that AWS uses almost (??) everywhere.
           if @text.tr(*TRANSLATE_DIGITS) == EASY_FORMAT
             parts = @text.tr(*DATE_PUNCTUATION).chop.split.map {|p| p.to_i }
+            parts[-1] = parts[-1] * 1000
             klass.send(parts_constructor, *parts)
           else
             # fallback in case we have to handle another date format

--- a/spec/aws/core/xml/parser_spec.rb
+++ b/spec/aws/core/xml/parser_spec.rb
@@ -207,7 +207,7 @@ module AWS
 
             it 'can convert the standard amazon format to a time object' do
               data.date_time_like_element.should be_a(Time)
-              data.date_time_like_element.to_s.should == Time.parse(time_string).to_s
+              data.date_time_like_element.strftime('%s.%6N').should == Time.parse(time_string).strftime('%s.%6N')
             end
 
             it 'can convert non standard amazon formats to time objects' do


### PR DESCRIPTION
e.g. given (from the CloudFormation api) a response including

<LastUpdatedTime>2014-07-02T13:40:04.141Z</LastUpdatedTime>

then the last_updated_time comes back with a seconds fractional part of .000141 (where it should be .141).

This is because the SDK currently takes the integer fractional part (141) - which is milliseconds, because the parser is hard-wired to three digits - and then passes it to Time::utc, which actually expects microseconds.

The bug wasn't spotted before because Time#to_s doesn't include fractional parts of a second.
