### PR TITLE
Added support to AWS::SQS::Queue::SentMessage for request ID.

### DIFF
--- a/lib/aws/sqs/queue.rb
+++ b/lib/aws/sqs/queue.rb
@@ -77,6 +77,9 @@ module AWS
 
         alias_method :id, :message_id
 
+        # @return [String] Returns the request ID.
+        attr_accessor :request_id
+
         # @return [String] Returns an MD5 digest of the message body
         #   string.  You can use this to verify that SQS received your
         #   message correctly.
@@ -123,6 +126,7 @@ module AWS
         
         msg = SentMessage.new
         msg.message_id = response[:message_id]
+        msg.request_id = response[:response_metadata][:request_id]
         msg.md5 = response[:md5_of_message_body]
 
         verify_send_message_checksum body, msg.md5


### PR DESCRIPTION
Request IDs are useful when working with AWS Support.
