### PR TITLE
Mention global stubbing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ ec2.instances['i-12345678'].tags.to_h
 
 See the [API Documentation](http://docs.aws.amazon.com/AWSRubySDK/latest/frames.html) for more examples.
 
+## Testing
+
+All HTTP requests to live services can be globally mocked (e.g. from within the `spec_helper.rb` file):
+
+```
+AWS.stub!
+```
+
 ## Links of Interest
 
 * [API Documentation](http://docs.aws.amazon.com/AWSRubySDK/latest/frames.html)


### PR DESCRIPTION
It looks to me like something that should be in the README...
