### PR TITLE
x-amz-acl query string is case sensitive

### DIFF
--- a/lib/aws/s3/presign_v4.rb
+++ b/lib/aws/s3/presign_v4.rb
@@ -55,7 +55,7 @@ module AWS
         signed_headers = 'Host'
 
         if options[:acl]
-          request.add_param("X-Amz-Acl", options[:acl].to_s.gsub(/_/, '-'))
+          request.add_param("x-amz-acl", options[:acl].to_s.gsub(/_/, '-'))
         end
 
         # must be sent along with the PUT request headers


### PR DESCRIPTION
The Presigned v4 signatures generated for :put with the :acl option add 'X-Amz-Acl' into the query string. However, S3 expects it to be all lowercase 'x-amz-acl'. The URLs will still let you upload, but the acl on the object will be incorrect.
