### PR TITLE
Added end attribute - The time when the Reserved Instance expires.

### DIFF
--- a/lib/aws/ec2/reserved_instances.rb
+++ b/lib/aws/ec2/reserved_instances.rb
@@ -29,6 +29,7 @@ module AWS
         :recurring_charges,
         :offering_type,
         :state,
+        :end,
       ]
 
       include TaggedItem


### PR DESCRIPTION
AWS::EC2::ReservedInstances was missing support for the 'end' attribute described in the REST API:

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeReservedInstances.html

I've added in that attribute.
