### PR TITLE
Get EBS volume type and whether or not encryption is enabled without using AWS::EC2::Client#describe_volumes

### DIFF
--- a/lib/aws/ec2/volume.rb
+++ b/lib/aws/ec2/volume.rb
@@ -168,6 +168,23 @@ module AWS
         AttachmentCollection.new(self, :config => config)
       end
 
+      # @return [Boolean] True if the volume is encrypted.
+      def encrypted?
+        resp = client.describe_volumes(:filters => [
+          { :name => 'volume-id', :values => [id] }
+        ])
+        resp.volume_index[id].encrypted
+      end
+
+      # @return [String] Indicates whether the volume is a standard
+      #   (Magnetic), gp2 (General Purpose (SSD)) or io1 (Provisioned IOPS (SSD)) volume.
+      def type
+        resp = client.describe_volumes(:filters => [
+          { :name => 'volume-id', :values => [id] }
+        ])
+        resp.volume_index[id].volume_type
+      end
+
     end
 
   end


### PR DESCRIPTION
Its annoying to have to use the lower level client to have to check for these.

It wasn't clear how to handle the case where the volume didn't exist or how to add test cases to [volume_spec.rb](https://github.com/aws/aws-sdk-ruby/blob/master/spec/aws/ec2/volume_spec.rb) so if anyone has advice for how to do that I'd appreciate it.
