### PR TITLE
Fixes millisecond parsing in custom DateTime parser

### DIFF
--- a/lib/aws/core/xml/frame.rb
+++ b/lib/aws/core/xml/frame.rb
@@ -231,7 +231,8 @@ module AWS
           # that AWS uses almost (??) everywhere.
           if @text.tr(*TRANSLATE_DIGITS) == EASY_FORMAT
             parts = @text.tr(*DATE_PUNCTUATION).chop.split.map {|p| p.to_i }
-            parts[-1] = parts[-1] * 1000
+            milliseconds = parts.pop
+            parts[-1] = parts[-1] + "0.#{milliseconds}".to_f
             klass.send(parts_constructor, *parts)
           else
             # fallback in case we have to handle another date format


### PR DESCRIPTION
Calling the parser would result in the milliseconds being discarded by DateTime#civil:

```
1.9.3-p547 :003 > DateTime.civil(2010,1,1,1,2,3,123000)
 => #<DateTime: 2010-01-01T01:02:03+00:00 ((2455198j,3723s,0n),+0s,2299161j)>
```

Now they are correctly set:

```
1.9.3-p547 :004 > DateTime.civil(2010,1,1,1,2,3.123)
 => #<DateTime: 2010-01-01T01:02:03+00:00 ((2455198j,3723s,123000000n),+0s,2299161j)>
```

As an added bonus, this also works around a bug in the JRuby implementation of DateTime#civil, where the last argument **must** be the timezone offset. Whereas MRI just ignores an incorrect offset argument.
