### PR TITLE
Added missing target param on s3.get_object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # tells autotest to use rspec extensions
 /.rspec
+
+# ignore Vim .swp files
+*.swp

--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1413,8 +1413,12 @@ module AWS
       end
 
       # Gets the data for a key.
-      # @overload get_object(options = {})
+      # @overload get_object(options = {}, target)
       #   @param [Hash] options
+      #   @param [File] target
+      #     An optional file or path used to receive the object's data
+      #     (recommended for large objects). If this is not specified, the
+      #     object data will be returned in the body of the response object.
       #   @option options [required,String] :bucket_name
       #   @option options [required,String] :key
       #   @option options [Time] :if_modified_since If specified, the


### PR DESCRIPTION
This adds info about the target parameter as per:

http://ruby.awsblog.com/post/Tx354Y6VTZ421PJ/Downloading-Objects-from-Amazon-S3-using-the-AWS-SDK-for-Ruby

I've also added a .gitignore entry for Vim's .swp files. Yes, we do use Vim for documentation. ;)
