### PR TITLE
Allow getting a secure url for the bucket

### DIFF
--- a/lib/aws/s3/bucket.rb
+++ b/lib/aws/s3/bucket.rb
@@ -238,11 +238,12 @@ module AWS
 
       # Returns the url for this bucket.
       # @return [String] url to the bucket
-      def url
+      def url(options = {})
+        protocol = options.fetch(:secure, false) ? "https://" : "http://"
         if client.dns_compatible_bucket_name?(name)
-          "http://#{name}.s3.amazonaws.com/"
+          "#{protocol}#{name}.s3.amazonaws.com/"
         else
-          "http://s3.amazonaws.com/#{name}/"
+          "#{protocol}s3.amazonaws.com/#{name}/"
         end
       end
 

--- a/spec/aws/s3/bucket_spec.rb
+++ b/spec/aws/s3/bucket_spec.rb
@@ -55,6 +55,13 @@ module AWS
           end
         end
 
+        context 'with secure options' do
+          it 'should return https and the bucket name in the host' do
+            bucket = Bucket.new('bucket-name', :config => config)
+            bucket.url(secure: true).should == "https://bucket-name.s3.amazonaws.com/"
+          end
+        end
+
       end
 
       context '#lifecycle_configuration' do


### PR DESCRIPTION
The SDK allows having a secure URL for `s3_objects` but it wasn't available for the bucket.  This PR adds that functionality.
