### PR TITLE
Request Payer

### DIFF
--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1420,6 +1420,9 @@ module AWS
       #   @param [Hash] options
       #   @option options [required,String] :bucket_name
       #   @option options [required,String] :key
+	  #   @option options [String] :request_payer If specified, the request
+	  #     will contain the specified String value in the x-amz-request-payer
+	  #     header. This is required for Requester Pays enabled buckets.
       #   @option options [Time] :if_modified_since If specified, the
       #     response will contain an additional `:modified` value that
       #     returns true if the object was modified after the given
@@ -1457,7 +1460,8 @@ module AWS
       #
       object_method(:get_object, :get,
                     :header_options => {
-                      :if_modified_since => "If-Modified-Since",
+                      :request_payer => "x-amz-request-payer",
+					  :if_modified_since => "If-Modified-Since",
                       :if_unmodified_since => "If-Unmodified-Since",
                       :if_match => "If-Match",
                       :if_none_match => "If-None-Match",

--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1461,7 +1461,7 @@ module AWS
       object_method(:get_object, :get,
                     :header_options => {
                       :request_payer => "x-amz-request-payer",
-					  :if_modified_since => "If-Modified-Since",
+                      :if_modified_since => "If-Modified-Since",
                       :if_unmodified_since => "If-Unmodified-Since",
                       :if_match => "If-Match",
                       :if_none_match => "If-None-Match",

--- a/lib/aws/s3/client.rb
+++ b/lib/aws/s3/client.rb
@@ -1420,9 +1420,9 @@ module AWS
       #   @param [Hash] options
       #   @option options [required,String] :bucket_name
       #   @option options [required,String] :key
-	  #   @option options [String] :request_payer If specified, the request
-	  #     will contain the specified String value in the x-amz-request-payer
-	  #     header. This is required for Requester Pays enabled buckets.
+      #   @option options [String] :request_payer If specified, the request
+      #     will contain the specified String value in the x-amz-request-payer
+      #     header. This is required for Requester Pays enabled buckets.
       #   @option options [Time] :if_modified_since If specified, the
       #     response will contain an additional `:modified` value that
       #     returns true if the object was modified after the given

--- a/spec/aws/s3/client_spec.rb
+++ b/spec/aws/s3/client_spec.rb
@@ -1599,6 +1599,7 @@ module AWS
         it_should_behave_like "sends option as header", :if_unmodified_since, "If-Unmodified-Since"
         it_should_behave_like "sends option as header", :if_match, "If-Match"
         it_should_behave_like "sends option as header", :if_none_match, "If-None-Match"
+		it_should_behave_like "sends option as header", :request_payer, "x-amz-request-payer"
 
         it_should_behave_like "sends option as header", :sse_customer_algorithm, "x-amz-server-side-encryption-customer-algorithm"
         it_should_behave_like "sends option as header", :sse_customer_key, "x-amz-server-side-encryption-customer-key"


### PR DESCRIPTION
Adding an option to include the x-amz-request-payer header into the S3 Client get_object() method.

This is defined here for downloads:
http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html

Should fix #694 