### PR TITLE
Added region to Aws::SharedCredentials

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -1,11 +1,15 @@
 module Aws
   class SharedCredentials < Credentials
 
+    # @return [String, nil]
+    attr_reader :region
+
     # @api private
     KEY_MAP = {
       'aws_access_key_id' => 'access_key_id',
       'aws_secret_access_key' => 'secret_access_key',
       'aws_session_token' => 'session_token',
+      'region' => 'region'
     }
 
     # Constructs a new SharedCredentials object. This will load AWS access

--- a/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -24,6 +24,7 @@ module Aws
       expect(creds.access_key_id).to eq('ACCESS_KEY_0')
       expect(creds.secret_access_key).to eq('SECRET_KEY_0')
       expect(creds.session_token).to eq('TOKEN_0')
+      expect(creds.region).to eq('REGION_0')
     end
 
     it 'supports fetching profiles from ENV' do
@@ -32,6 +33,7 @@ module Aws
       expect(creds.access_key_id).to eq('ACCESS_KEY_2')
       expect(creds.secret_access_key).to eq('SECRET_KEY_2')
       expect(creds.session_token).to eq('TOKEN_2')
+      expect(creds.region).to eq(nil)
     end
 
     it 'supports a manually specified profile' do
@@ -42,6 +44,7 @@ module Aws
       expect(creds.access_key_id).to eq('ACCESS_KEY_1')
       expect(creds.secret_access_key).to eq('SECRET_KEY_1')
       expect(creds.session_token).to eq('TOKEN_1')
+      expect(creds.region).to eq(nil)
     end
 
     it 'raises when a profile does not exist' do

--- a/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
+++ b/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
@@ -2,6 +2,7 @@
 aws_access_key_id = ACCESS_KEY_0
 aws_secret_access_key = SECRET_KEY_0
 aws_session_token = TOKEN_0
+region = REGION_0
 
 [fooprofile]
 aws_access_key_id = ACCESS_KEY_1


### PR DESCRIPTION
Shared credential ini style files can contain a region setting which is used as a default by tools like the AWS CLI. I'd like the Aws::SharedCredentials object to provide me with that optional region setting for use in my Ruby code.