### PR TITLE
Use a lazy star match so whitespace is trimmed

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -91,7 +91,7 @@ module Aws
         if section
           current_section = section[1]
         elsif current_section
-          item = line.match(/^\s*(.+?)\s*=\s*(.+)\s*$/) unless line.nil?
+          item = line.match(/^\s*(.+?)\s*=\s*(.+?)\s*$/) unless line.nil?
           if item
             map[current_section] = map[current_section] || {}
             map[current_section][item[1]] = item[2]

--- a/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
+++ b/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
@@ -1,5 +1,5 @@
 [default]
-aws_access_key_id = ACCESS_KEY_0
+aws_access_key_id = ACCESS_KEY_0 
 aws_secret_access_key = SECRET_KEY_0
 aws_session_token = TOKEN_0
 


### PR DESCRIPTION
Fix for #702.  Not sure how to run your tests so the test change is guess work.  Also I think would ideally include a doc change.