### PR TITLE
Using base description when attribute description is null in docs

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/api/docstrings.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docstrings.rb
@@ -18,6 +18,9 @@ module Aws
         docs['shapes'].each do |shape_name, shape|
           api['shapes'][shape_name]['documentation'] = shape['base']
           shape['refs'].each do |ref,doc|
+            if doc.nil?
+              doc = shape['base']
+            end
             target_shape_name, member = ref.split('$')
             target_shape = api['shapes'][target_shape_name]
             case target_shape['type']


### PR DESCRIPTION
In the documentation there's a base description for an attribute data type, then you can also specify an explicit description.

For example:
```
    "Timestamp": {
      "base": "A point in time expressed as the number milliseconds since Jan 1, 1970 00:00:00 UTC.",
      "refs": {
        "GetLogEventsRequest$startTime": null,
        "GetLogEventsRequest$endTime": null,
        "InputLogEvent$timestamp": null,
        "LogGroup$creationTime": null,
        "LogStream$creationTime": null,
        "LogStream$firstEventTimestamp": null,
        "LogStream$lastEventTimestamp": null,
        "LogStream$lastIngestionTime": null,
        "MetricFilter$creationTime": null,
        "OutputLogEvent$timestamp": null,
        "OutputLogEvent$ingestionTime": null
      }
    },
```

https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/CloudWatchLogs.docs.json#L409

However, it seems currently the base description isn't used even if the attribute description is null, for example this is what the docs for an action using one of those attributes currently looks like:

![Current](http://i.imgur.com/wwnjk9z.png)

Note that the start_time and end_time have no description, they're described as an Integer but it doesn't explain for example that the value is a timestamp in milliseconds. However, this description is available in the base description which isn't used.

This pull request will use the base attribute description when the explicit description is null.

The result is that the example above now looks like:

![After](http://i.imgur.com/8Qn95Gh.png)

This makes a huge difference in some scenarios where there is currently very little explanation of attributes.

For example before:
![Current](http://i.imgur.com/bwHl9lE.png)

After:
![After](http://i.imgur.com/hfMgbCa.png)