### PR TITLE
Adding ELB waiter for healthy instance

### DIFF
--- a/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
+++ b/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "waiters": {
+    "InstanceHealthy": {
+      "delay": 15,
+      "operation": "DescribeInstanceHealth",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "InService",
+          "matcher": "pathAny",
+          "state": "success",
+          "argument": "InstanceStates[].State"
+        }
+      ]
+    } 
+  }
+}

--- a/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
+++ b/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
@@ -8,11 +8,24 @@
       "acceptors": [
         {
           "expected": "InService",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "InstanceStates[].State"
+        }
+      ]
+    },
+    "AnyInstanceHealthy": {
+      "delay": 15,
+      "operation": "DescribeInstanceHealth",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": "InService",
           "matcher": "pathAny",
           "state": "success",
           "argument": "InstanceStates[].State"
         }
       ]
-    } 
+    }
   }
 }

--- a/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
+++ b/aws-sdk-core/apis/ElasticLoadBalancing.waiters.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "waiters": {
-    "InstanceHealthy": {
+    "InstanceInService": {
       "delay": 15,
       "operation": "DescribeInstanceHealth",
       "maxAttempts": 40,
@@ -14,7 +14,7 @@
         }
       ]
     },
-    "AnyInstanceHealthy": {
+    "AnyInstanceInService": {
       "delay": 15,
       "operation": "DescribeInstanceHealth",
       "maxAttempts": 40,

--- a/aws-sdk-core/lib/aws-sdk-core/elasticloadbalancing.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/elasticloadbalancing.rb
@@ -2,4 +2,5 @@ Aws.add_service(:ElasticLoadBalancing, {
   api: File.join(Aws::API_DIR, 'ElasticLoadBalancing.api.json'),
   docs: File.join(Aws::API_DIR, 'ElasticLoadBalancing.docs.json'),
   paginators: File.join(Aws::API_DIR, 'ElasticLoadBalancing.paginators.json'),
+  waiters: File.join(Aws::API_DIR, 'ElasticLoadBalancing.waiters.json'),
 })


### PR DESCRIPTION
Adding a waiter that takes an ELB name and list of instance_ids and returns success when at least one of them reports back as "InService".