### PR TITLE
Fix for infinite paging loop on CloudWatchLogs::Client#get_log_events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Issue - Aws::CloudWatchLogs - Resolved an issue that would cause an infinite
+  loop when paginating `Aws::CloudWatchLogs#get_log_events`.
+  Resolves [GitHub issue #712](https://github.com/aws/aws-sdk-ruby/issues/712).
+
 2.0.29 (2015-03-04)
 ------------------
 

--- a/aws-sdk-core/lib/aws-sdk-core/paging/pager.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/paging/pager.rb
@@ -24,13 +24,23 @@ module Aws
         end
       end
 
+      # @api private
+      def prev_tokens(response)
+        @tokens.each.with_object({}) do |(_, target), tokens|
+          value = JMESPath.search(target, response.context.params)
+          tokens[target.to_sym] = value unless empty_value?(value)
+        end
+      end
+
       # @param [Seahorse::Client::Response] response
       # @return [Boolean]
       def truncated?(response)
         if @more_results
           JMESPath.search(@more_results, response.data)
         else
-          !next_tokens(response).empty?
+          next_tokens = self.next_tokens(response)
+          prev_tokens = self.prev_tokens(response)
+          !(next_tokens.empty? || next_tokens == prev_tokens)
         end
       end
 

--- a/aws-sdk-core/spec/aws/cloud_watch_logs/client_spec.rb
+++ b/aws-sdk-core/spec/aws/cloud_watch_logs/client_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+module Aws
+  module CloudWatchLogs
+    describe Client do
+
+      let(:client) { Client.new(stub_responses:true) }
+
+      describe '#get_log_events' do
+
+        it 'stops paginating when the next tokens are fixed' do
+          json = []
+          json << (<<-JSON)
+{
+  "events": [
+    {
+      "ingestionTime": 1396035394997,
+      "timestamp": 1396035378988,
+      "message": "Example Event 1"
+    }
+  ],
+  "nextForwardToken": "abc"
+}
+          JSON
+          json << (<<-JSON)
+{
+  "events": [
+    {
+      "ingestionTime": 1396035394997,
+      "timestamp": 1396035378988,
+      "message": "Example Event 2"
+    }
+  ],
+  "nextForwardToken": "mno"
+}
+          JSON
+          json << (<<-JSON)
+{
+  "events": [],
+  "nextForwardToken": "mno"
+}
+          JSON
+          client.handle(step: :send) do |context|
+            context.http_response.signal_headers(200, {})
+            context.http_response.signal_data(json.shift)
+            context.http_response.signal_done
+            Seahorse::Client::Response.new(context:context)
+          end
+
+          yield_count = 0
+          params = { log_group_name:'name', log_stream_name:'name' }
+          client.get_log_events(params).each { |resp| yield_count += 1 }
+          expect(yield_count).to eq(3)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See related issue #712