### PR TITLE
Added Aws::SQS::QueuePoller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::SQS - Added `Aws::SQS::QueuePoller`, a utility class for
+  long polling and processing messages from a queue.
+
+  ```ruby
+  poller = Aws::SQS::QueuePoller.new(queue_url)
+  poller.poll do |msg|
+    puts msg.body
+  end # message deleted here
+  ```
+
+  See the [API reference documentation](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/QueuePoller.html) for more examples.
+
 * Issue - Query Protocol - No longer returning nil for empty maps in
   query responses. `Aws::SQS::Client#get_queue_attributes` will always
   have a hash a `resp.attributes` instead of a possible `nil` value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Issue - Query Protocol - No longer returning nil for empty maps in
+  query responses. `Aws::SQS::Client#get_queue_attributes` will always
+  have a hash a `resp.attributes` instead of a possible `nil` value.
+
 * Issue - Aws::EC2 - Fixed an issue with constructing `PlacementGroup`
   resources and added a missing `#delete` method to `RouteTable`.
   See related [GitHub pull request #737](https://github.com/aws/aws-sdk-ruby/issues/712).

--- a/FEATURE_REQUESTS.md
+++ b/FEATURE_REQUESTS.md
@@ -68,10 +68,6 @@ The version 1 SDK has support for generating a pre-signed POST request. This ret
 
 See [related GitHub issue #720](https://github.com/aws/aws-sdk-ruby/issues/720).
 
-### Amazon SQS Queue Poller
-
-Add a utility class that can poll an Amazon SQS Queue for messages. This should do a better than than the version 1 SDK in handling errors raised inside the polling logic.  Ideally, users should be able to fail a message, causing it to not delete, but without terminating the polling abstraction. This should be opt-in to avoid draining a queue of messages without succeeding any.
-
 ### Aws::ElasticBeanstalk::Client Waiters
 
 There are currently no waiters for `Aws::ElasticBeanstalk::Client`. Particular useful would be environment states.
@@ -80,6 +76,6 @@ See [related GitHub issue aws/aws-sdk-core-ruby#216](https://github.com/aws/aws-
 
 ### Progress callbacks for Amazon S3 Object uploads
 
-To enable users to track file upload process, it would be helpful to support a progress callback for `Aws::S3::Object#upload_file`.  
+To enable users to track file upload process, it would be helpful to support a progress callback for `Aws::S3::Object#upload_file`.
 
 See [related Github issue #648](https://github.com/aws/aws-sdk-ruby/issues/648#issuecomment-78246370).

--- a/aws-sdk-core/features/sqs/step_definitions.rb
+++ b/aws-sdk-core/features/sqs/step_definitions.rb
@@ -1,12 +1,8 @@
 Before("@sqs") do
   @client = Aws::SQS::Client.new
-  @sqs_created_queues = []
 end
 
 After("@sqs") do
-  @sqs_created_queues.each do |url|
-    @client.delete_delete_queue(queue_url: url)
-  end
 end
 
 Given(/^I create a queue in "(.*?)"$/) do |region|
@@ -25,5 +21,3 @@ end
 Then(/^the request should be made against "(.*?)"$/) do |region|
   expect(@response.context.http_request.endpoint.to_s).to include(region)
 end
-
-

--- a/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -34,6 +34,8 @@ module Aws
             target[member_name] = parse_shape(member_shape, values[value_key])
           elsif member_shape.is_a?(Seahorse::Model::Shapes::List)
             target[member_name] = DefaultList.new
+          elsif member_shape.is_a?(Seahorse::Model::Shapes::Map)
+            target[member_name] = {}
           end
         end
         target

--- a/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -321,7 +321,7 @@ module Aws
 
       describe 'non-flattened maps' do
 
-        it 'returns missing maps as nil' do
+        it 'returns missing maps as {}' do
           definition['members'] = {
             'Attributes' => {
               'type' => 'map',
@@ -330,7 +330,7 @@ module Aws
             }
           }
           xml = "<xml/>"
-          expect(parse(xml)[:attributes]).to be(nil)
+          expect(parse(xml)[:attributes]).to eq({})
         end
 
         it 'returns empty maps as {}' do
@@ -423,7 +423,7 @@ module Aws
 
       describe 'flattened maps' do
 
-        it 'returns missing maps as nil' do
+        it 'returns missing maps as {}' do
           definition['members'] = {
             'Attributes' => {
               'type' => 'map',
@@ -433,7 +433,7 @@ module Aws
             }
           }
           xml = "<xml/>"
-          expect(parse(xml)[:attributes]).to be(nil)
+          expect(parse(xml)[:attributes]).to eq({})
         end
 
         it 'returns empty maps as {}' do

--- a/aws-sdk-resources/features/sqs/queue_poller.feature
+++ b/aws-sdk-resources/features/sqs/queue_poller.feature
@@ -1,0 +1,10 @@
+# language: en
+@sqs @queue_poller
+Feature: Amazon SQS Queue Poller
+
+  @slow
+  Scenario: Making a basic request
+    Given I have have a queue
+    And I send 10 messages to the queue
+    When I poll 5 messages at a time with a 2 second idle timeout
+    Then I should have received all 10 messages

--- a/aws-sdk-resources/features/sqs/step_definitions.rb
+++ b/aws-sdk-resources/features/sqs/step_definitions.rb
@@ -1,0 +1,39 @@
+Before("@sqs") do
+  @sqs_client = Aws::SQS::Client.new
+  @sqs_created_queues = []
+end
+
+After("@sqs") do
+  @sqs_created_queues.each do |url|
+    @sqs_client.delete_queue(queue_url: url)
+  end
+end
+
+Given(/^I have have a queue$/) do
+  @queue_name = "aws-sdk-integration-#{Time.now.to_i}-#{rand(10000)}"
+  @queue_url = @sqs_client.create_queue(queue_name: @queue_name).queue_url
+  @sqs_created_queues << @queue_url
+end
+
+Given(/^I send (\d+) messages to the queue$/) do |count|
+  count.to_i.times do |n|
+    @sqs_client.send_message(queue_url:@queue_url, message_body:"msg-#{n}")
+    puts 'sent'
+  end
+end
+
+When(/^I poll (\d+) messages at a time with a (\d+) second idle timeout$/) do |max, idle|
+  poller = Aws::SQS::QueuePoller.new(@queue_url, {
+    client: @sqs_client,
+    max_number_of_messages: max.to_i,
+    idle_timeout: idle.to_i,
+  })
+  @received_messages = []
+  @stats = poller.poll do |messages|
+    @received_messages += messages
+  end
+end
+
+Then(/^I should have received all (\d+) messages$/) do |count|
+  expect(@received_messages.count).to eq(count.to_i)
+end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/sqs.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/sqs.rb
@@ -1,0 +1,7 @@
+module Aws
+  module SQS
+
+    autoload :QueuePoller, 'aws-sdk-resources/services/sqs/queue_poller'
+
+  end
+end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
@@ -516,21 +516,6 @@ module Aws
         end
 
       end
-
-      # @api private
-      class PollerRequestParams < Hash
-
-        DEFAULTS = {
-        }
-
-        def initialize(options)
-          super(nil)
-          DEFAULTS.each do |key, default|
-            self[key] = options.key?(key) ? options[key] : default
-          end
-        end
-
-      end
     end
   end
 end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
@@ -1,0 +1,536 @@
+require 'set'
+
+module Aws
+  module SQS
+
+    # A utility class for long polling messages in a loop. **Messages are
+    # automatically deleted from the queue at the end of the given block.**
+    #
+    #     poller = Aws::SQS::QueuePoller.new(queue_url)
+    #
+    #     poller.poll do |msg|
+    #       puts msg.body
+    #     end
+    #
+    # ## Long Polling
+    #
+    # By default, messages are received using long polling. This
+    # method will force a default `:wait_time_seconds` of 20 seconds.
+    # If you prefer to use the queue default wait time, then pass
+    # a `nil` value for `:wait_time_seconds`.
+    #
+    #     # disables 20 second default, use queue ReceiveMessageWaitTimeSeconds
+    #     poller.poll(wait_time_seconds:nil) do |msg|
+    #       # ...
+    #     end
+    #
+    # When disabling `:wait_time_seconds` by passing `nil`, you must
+    # ensure the queue `ReceiveMessageWaitTimeSeconds` attribute is
+    # set to a non-zero value, or you will be short-polling.
+    # This will trigger significantly more API calls.
+    #
+    # ## Batch Receiving Messages
+    #
+    # You can specify a maximum number of messages to receive with
+    # each polling attempt via `:max_number_of_messages`. When this is
+    # set to a positive value, greater than 1, the block will receive
+    # an array of messages, instead of a single message.
+    #
+    #     # receives and yields 1 message at a time
+    #     poller.poll do |msg|
+    #       # ...
+    #     end
+    #
+    #     # receives and yields up to 10 messages at a time
+    #     poller.poll(max_number_of_messages:10) do |messages|
+    #       messages.each do |msg|
+    #         # ...
+    #       end
+    #     end
+    #
+    # The maximum value for `:max_number_of_messages` is enforced by
+    # Amazon SQS.
+    #
+    # ## Visibility Timeouts
+    #
+    # When receiving messages, you have a fixed amount of time to process
+    # and delete the message before it is added back into the queue. This
+    # is the visibility timeout. By default, the queue's `VisibilityTimeout`
+    # attribute is used. You can provide an alternative visibility timeout
+    # when polling.
+    #
+    #     # queue default VisibilityTimeout
+    #     poller.poll do |msg|
+    #     end
+    #
+    #     # custom visibility timeout
+    #     poller.poll(visibility_timeout:10) do |msg|
+    #     end
+    #
+    #
+    # You can reset the visibility timeout of a single message by calling
+    # {#change_message_visibility_timeout}. This is useful when you need
+    # more time to finish processing the message.
+    #
+    #     poller.poll do |msg|
+    #
+    #       # do work ...
+    #
+    #       # need more time for processing
+    #       poller.change_message_visibility_timeout(msg, 60)
+    #
+    #       # finish work ...
+    #
+    #     end
+    #
+    # If you change the visibility timeout of a message to zero, it will
+    # return to the queue immediately.
+    #
+    # ## Deleting Messages
+    #
+    # Messages are deleted from the queue when the block returns normally.
+    #
+    #     poller.poll do |msg|
+    #       # do work
+    #     end # messages deleted here
+    #
+    # You can skip message deletion by passing `skip_delete: true`.
+    # This allows you to manually delete the messages using
+    # {#delete_message}, or {#delete_messages}.
+    #
+    #     # single message
+    #     poller.poll(skip_delete: true) do |msg|
+    #       poller.delete_message(msg) # if successful
+    #     end
+    #
+    #     # batch delete messages
+    #     poller.poll(skip_delete: true, max_number_of_messages:10) do |messages|
+    #       poller.delete_messages(messages)
+    #     end
+    #
+    # Another way to manage message deletion is to throw `:skip_delete`
+    # from the poll block. You can use this to choose when a message, or
+    # message batch is deleted on an individual basis. This can be very
+    # useful when you are capturing temporal errors and wish for the
+    # message to timeout.
+    #
+    #     poller.poll do |msg|
+    #       begin
+    #         # do work
+    #       rescue
+    #         # unexpected error occurred while processing messages,
+    #         # log it, and skip delete so it can be re-processed later
+    #         throw :skip_delete
+    #       end
+    #     end
+    #
+    # ## Terminating the Polling Loop
+    #
+    # By default, polling will continue indefinitely. You can stop
+    # the poller by providing an idle timeout or by throwing `:stop_polling`
+    # from the {#before_request} callback.
+    #
+    # ### `:idle_timeout` Option
+    #
+    # This is a configurable, maximum number of seconds to wait for a
+    # new message before the polling loop exists. By default, there is
+    # no idle timeout.
+    #
+    #     # stops polling after a minute of no received messages
+    #     poller.poll(idle_timeout: 60) do |msg|
+    #       # ...
+    #     end
+    #
+    # ### Throw `:stop_polling`
+    #
+    # If you want more fine grained control, you can configure a
+    # before request callback to trigger before each long poll. Throwing
+    # `:stop_polling` from this callback will cause the poller to exit
+    # normally without making the next request.
+    #
+    #     # stop after processing 100 messages
+    #     poller.before_request do |stats|
+    #       throw :stop_polling if stats.receive_message_count >= 100
+    #     end
+    #
+    #     poller.poll do |msg|
+    #       # do work ...
+    #     end
+    #
+    # ## Tracking Progress
+    #
+    # The poller will automatically track a few statistics client-side in
+    # a {PollerStats} object. You can access the poller stats
+    # three ways:
+    #
+    # * The first block argument of {#before_request}
+    # * The second block argument of {#poll}.
+    # * The return value from {#poll}.
+    #
+    # Here are examples of accessing the statistics.
+    #
+    # * Configure a {#before_request} callback.
+    #
+    #   ```
+    #   poller.before_reqeust do |stats|
+    #     logger.info("requests: #{stats.request_count}")
+    #     logger.info("messages: #{stats.received_message_count}")
+    #     logger.info("last-timestamp: #{stats.last_message_received_at}")
+    #   end
+    #   ```
+    #
+    # * Accept a 2nd argument in the poll block, for example:
+    #
+    #   ```
+    #   poller.poll do |msg, stats|
+    #     logger.info("requests: #{stats.request_count}")
+    #     logger.info("messages: #{stats.received_message_count}")
+    #     logger.info("last-timestamp: #{stats.last_message_received_at}")
+    #   end
+    #   ```
+    #
+    # * Return value:
+    #
+    #   ```
+    #   stats = poller.poll(idle_timeout:10) do |msg|
+    #     # do work ...
+    #   end
+    #   logger.info("requests: #{stats.request_count}")
+    #   logger.info("messages: #{stats.received_message_count}")
+    #   logger.info("last-timestamp: #{stats.last_message_received_at}")
+    #   ```
+    #
+    class QueuePoller
+
+      # @param [String] queue_url
+      # @option options [Client] :client
+      # @option (see #poll)
+      def initialize(queue_url, options = {})
+        @queue_url = queue_url
+        @client = options.delete(:client) || Client.new
+        @default_config = PollerConfig.new(options)
+      end
+
+      # @return [String]
+      attr_reader :queue_url
+
+      # @return [Client]
+      attr_reader :client
+
+      # @return [PollerConfig]
+      attr_reader :default_config
+
+      # Registers a callback that is invoked once before every polling
+      # attempt.
+      #
+      #     poller.before_reqeust do |stats|
+      #       logger.info("requests: #{stats.request_count}")
+      #       logger.info("messages: #{stats.received_message_count}")
+      #       logger.info("last-timestamp: #{stats.last_message_received_at}")
+      #     end
+      #
+      #     poller.poll do |msg|
+      #       # do work ...
+      #     end
+      #
+      # ## `:stop_polling`
+      #
+      # If you throw `:stop_polling` from the {#before_request} callback,
+      # then the poller will exit normally before making the next long
+      # poll request.
+      #
+      #     poller.before_reqeust do |stats|
+      #       throw :stop_polling if stats.received_messages >= 100
+      #     end
+      #
+      #     # at most 100 messages will be yielded
+      #     poller.poll do |msg|
+      #       # do work ...
+      #     end
+      #
+      # @yieldparam [PollerStats] stats An object that tracks a few
+      #   client-side statistics about the queue polling.
+      #
+      # @return [void]
+      def before_request(&block)
+        @default_config = @default_config.with(before_request: Proc.new)
+      end
+
+      # Polls the queue, yielded a message, or an array of messages.
+      # Messages are automatically deleted from the queue at the
+      # end of the given block. See the class documentation on
+      # {QueuePoller} for more examples.
+      #
+      # @example Basic example, loops indefinitely
+      #
+      #   poller.poll do |msg|
+      #     # ...
+      #   end
+      #
+      # @example Receives and deletes messages as a batch
+      #
+      #   poller.poll(max_number_of_messages:10) do |messages|
+      #     messages.each do |msg|
+      #       # ...
+      #     end
+      #   end
+      #
+      # @option options [Integer] :wait_time_seconds (20) The
+      #   long polling interval. Messages are yielded as soon as they are
+      #   received. The `:wait_time_seconds` option specifies the max
+      #   duration for each polling attempt before a new request is
+      #   sent to receive messages.
+      #
+      # @option options [Integer] :max_number_of_messages (1) The maximum
+      #   number of messages to yield from each polling attempt.
+      #   Values can be from 1 to 10.
+      #
+      # @option options [Integer] :visibility_timeout (nil)
+      #   The number of seconds you have to process a message before
+      #   it is put back into the queue and can be received again.
+      #   By default, the queue's
+      #
+      # @option opitons [Array<String>] :attribute_names ([])
+      #   The list of attributes that need to be returned along with each
+      #   message. Valid attribute names include:
+      #
+      #   * `All` - All attributes.
+      #   * `ApproximateFirstReceiveTimestamp` - The time when the message
+      #      was first received from the queue (epoch time in milliseconds).
+      #   * `ApproximateReceiveCount` - The number of times a message has
+      #      been received from the queue but not deleted.
+      #   * `SenderId` - The AWS account number (or the IP address, if
+      #      anonymous access is allowed) of the sender.
+      #   * `SentTimestamp` - The time when the message was sent to the
+      #      queue (epoch time in milliseconds).
+      #
+      # @option options [Array<String>] :message_attribute_names ([])
+      #   A list of message attributes to receive. You can receive
+      #   all messages by using `All` or `.*`. You can also use
+      #   `foo.*` to return all message attributes starting with the
+      #   `foo` prefix.
+      #
+      # @option options [Integer] :idle_timeout (nil) Polling terminates
+      #   gracefully when `:idle_timeout` seconds have passed without
+      #   receiving any messages.
+      #
+      # @option options [Boolean] :skip_delete (false) When `true`, messages
+      #   are not deleted after polling block. If you wish to delete
+      #   received messages, you will need to call `#delete_message` or
+      #   `#delete_messages` manually.
+      #
+      # @option options [Proc] :before_request (nil) Called before each
+      #   polling attempt. This proc receives a single argument, an
+      #   instance of {PollerStats}.
+      #
+      # @return [PollerStats]
+      def poll(options = {}, &block)
+        config = @default_config.with(options)
+        stats = PollerStats.new
+        catch(:stop_polling) do
+          loop do
+            messages = get_messages(config, stats)
+            if messages.empty?
+              check_idle_timeout(config, stats, messages)
+            else
+              process_messages(config, stats, messages, &block)
+            end
+          end
+        end
+        stats.polling_stopped_at = Time.now
+        stats
+      end
+
+      # @note This method should be called from inside a {#poll} block.
+      # @param [#receipt_handle] message An object that responds to
+      #   `#receipt_handle`.
+      # @param [Integer] seconds
+      def change_message_visibility_timeout(message, seconds)
+        @client.change_message_visibility_timeout({
+          queue_url: @queue_url,
+          receipt_handle: message.receipt_handle,
+          visibility_timeout: seconds,
+        })
+      end
+
+      # @note This method should be called from inside a {#poll} block.
+      # @param [#receipt_handle] message An object that responds to
+      #   `#receipt_handle`.
+      def delete_message(message)
+        @client.delete_message({
+          queue_url: @queue_url,
+          receipt_handle: message.receipt_handle,
+        })
+      end
+
+      # @note This method should be called from inside a {#poll} block.
+      # @param [Array<#message_id, #receipt_handle>] messages An array of received
+      #   messages. Each object must respond to `#message_id` and
+      #   `#receipt_handle`.
+      def delete_messages(messages)
+        @client.delete_message_batch(
+          queue_url: @queue_url,
+          entries: messages.map { |msg|
+            { id: msg.message_id, receipt_handle: msg.receipt_handle }
+          }
+        )
+      end
+
+      private
+
+      def get_messages(config, stats)
+        config.before_request.call(stats) if config.before_request
+        messages = send_request(config).messages
+        stats.request_count += 1
+        messages
+      end
+
+      def send_request(config)
+        params = config.request_params.merge(queue_url: @queue_url)
+        @client.receive_message(params)
+      end
+
+      def check_idle_timeout(config, stats, messages)
+        if config.idle_timeout
+          since = stats.last_message_received_at || stats.polling_started_at
+          idle_time = Time.now - since
+          throw :stop_polling if idle_time > config.idle_timeout
+        end
+      end
+
+      def process_messages(config, stats, messages, &block)
+        stats.received_message_count += messages.count
+        stats.last_message_received_at = Time.now
+        catch(:skip_delete) do
+          yield_messages(config, messages, stats, &block)
+          delete_messages(messages) unless config.skip_delete
+        end
+      end
+
+      def yield_messages(config, messages, stats, &block)
+        if config.request_params[:max_number_of_messages] == 1
+          messages.each do |msg|
+            yield(msg, stats)
+          end
+        else
+          yield(messages, stats)
+        end
+      end
+
+      # Statistics tracked client-side by the {QueuePoller}.
+      class PollerStats
+
+        def initialize
+          @request_count = 0
+          @received_message_count = 0
+          @last_message_received_at = nil
+          @polling_started_at = Time.now
+          @polling_stopped_at = nil
+        end
+
+        # @return [Integer]
+        attr_accessor :request_count
+
+        # @return [Integer]
+        attr_accessor :received_message_count
+
+        # @return [Time,nil]
+        attr_accessor :last_message_received_at
+
+        # @return [Time]
+        attr_accessor :polling_started_at
+
+        # @return [Time,nil]
+        attr_accessor :polling_stopped_at
+
+      end
+
+      # A read-only set of configuration used by the QueuePoller.
+      class PollerConfig
+
+        # @api private
+        CONFIG_OPTIONS = Set.new([
+          :idle_timeout,
+          :skip_delete,
+          :before_request,
+        ])
+
+        # @api private
+        PARAM_OPTIONS = Set.new([
+          :wait_time_seconds,
+          :max_number_of_messages,
+          :visibility_timeout,
+          :attribute_names,
+          :message_attribute_names,
+        ])
+
+        # @return [Integer,nil]
+        attr_reader :idle_timeout
+
+        # @return [Boolean]
+        attr_reader :skip_delete
+
+        # @return [Proc,nil]
+        attr_reader :before_request
+
+        # @return [Hash]
+        attr_reader :request_params
+
+        def initialize(options)
+          @idle_timeout = nil
+          @skip_delete = false
+          @before_request = nil
+          @request_params = {
+            wait_time_seconds: 20,
+            max_number_of_messages: 1,
+            visibility_timeout: nil,
+            attribute_names: ['All'],
+            message_attribute_names: ['All'],
+          }
+          options.each do |opt_name, value|
+            if CONFIG_OPTIONS.include?(opt_name)
+              instance_variable_set("@#{opt_name}", value)
+            elsif PARAM_OPTIONS.include?(opt_name)
+              @request_params[opt_name] = value
+            else
+              raise ArgumentError, "invalid option #{opt_name.inspect}"
+            end
+          end
+          @request_params.freeze
+          freeze
+        end
+
+        # @return [PollerConfig] Returns a new {PollerConfig} instance
+        #   with the given options applied.
+        def with(options)
+          self.class.new(to_h.merge(options))
+        end
+
+        private
+
+        def to_h
+          hash = {}
+          CONFIG_OPTIONS.each { |key| hash[key] = send(key) }
+          PARAM_OPTIONS.each { |key| hash[key] = @request_params[key] }
+          hash
+        end
+
+      end
+
+      # @api private
+      class PollerRequestParams < Hash
+
+        DEFAULTS = {
+        }
+
+        def initialize(options)
+          super(nil)
+          DEFAULTS.each do |key, default|
+            self[key] = options.key?(key) ? options[key] : default
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/aws-sdk-resources/spec/services/sqs/queue_poller_spec.rb
+++ b/aws-sdk-resources/spec/services/sqs/queue_poller_spec.rb
@@ -14,6 +14,15 @@ module Aws
 
       describe 'configuration' do
 
+        it 'raises an error on unknown configuration options' do
+          expect {
+            QueuePoller.new(queue_url, client:client, bad:'option')
+          }.to raise_error(ArgumentError, 'invalid option :bad')
+          expect {
+            QueuePoller.new(queue_url, client:client).poll(bad:'option') {|m|}
+          }.to raise_error(ArgumentError, 'invalid option :bad')
+        end
+
         it 'is immutable' do
           expect(poller.default_config).to be_frozen
           expect(poller.default_config.request_params).to be_frozen

--- a/aws-sdk-resources/spec/services/sqs/queue_poller_spec.rb
+++ b/aws-sdk-resources/spec/services/sqs/queue_poller_spec.rb
@@ -1,0 +1,352 @@
+require 'spec_helper'
+
+module Aws
+  module SQS
+    describe QueuePoller do
+
+      let(:queue_url) { "https://sqs.us-east-1.amazonaws.com/12345/test" }
+
+      let(:client) { Client.new(stub_responses: true) }
+
+      let(:options) {{ client: client }}
+
+      let(:poller) { QueuePoller.new(queue_url, options) }
+
+      describe 'configuration' do
+
+        it 'is immutable' do
+          expect(poller.default_config).to be_frozen
+          expect(poller.default_config.request_params).to be_frozen
+        end
+
+        it 'has reasonable defaults' do
+          expect(poller.queue_url).to eq(queue_url)
+          expect(poller.default_config.idle_timeout).to be(nil)
+          expect(poller.default_config.skip_delete).to be(false)
+          expect(poller.default_config.before_request).to be(nil)
+          expect(poller.default_config.request_params).to eq({
+            wait_time_seconds: 20,
+            max_number_of_messages: 1,
+            visibility_timeout: nil,
+            attribute_names: ['All'],
+            message_attribute_names: ['All'],
+          })
+        end
+
+        it 'accepts configuration options to the constructor' do
+          client = double('client')
+          callback = double('callback')
+          poller = QueuePoller.new(queue_url, {
+            client: client,
+            idle_timeout: 60,
+            skip_delete: true,
+            before_request: callback,
+            wait_time_seconds: 10,
+            max_number_of_messages: 10,
+            visibility_timeout: 10,
+            attribute_names: ['attr-name'],
+            message_attribute_names: ['msg-attr-name'],
+          })
+          expect(poller.client).to be(client)
+          expect(poller.default_config.idle_timeout).to eq(60)
+          expect(poller.default_config.skip_delete).to be(true)
+          expect(poller.default_config.before_request).to be(callback)
+          expect(poller.default_config.request_params).to eq({
+            wait_time_seconds: 10,
+            max_number_of_messages: 10,
+            visibility_timeout: 10,
+            attribute_names: ['attr-name'],
+            message_attribute_names: ['msg-attr-name'],
+          })
+        end
+
+      end
+
+      describe '#poll' do
+
+        it 'receives messages in a loop' do
+          expect(client).to receive(:receive_message).exactly(2).times.with({
+            queue_url: queue_url,
+            wait_time_seconds: 20,
+            max_number_of_messages: 1,
+            visibility_timeout: nil,
+            attribute_names: ['All'],
+            message_attribute_names: ['All'],
+          }).and_return(client.next_stub(:receive_message))
+          poller.before_request do |stats|
+            throw :stop_polling if stats.request_count >= 2
+          end
+          poller.poll { |msg| }
+        end
+
+        it 'yields received messages to the block' do
+          client.stub_responses(:receive_message, [
+            { messages: [{ body: 'msg-1-body' }] },
+            { messages: [] },
+          ])
+          yielded = nil
+          poller.poll(idle_timeout: 0) do |msg|
+            yielded = msg
+          end
+          expect(yielded.body).to eq('msg-1-body')
+        end
+
+        it 'yields an array when max messages is greater than 1' do
+          client.stub_responses(:receive_message, [
+            { messages: [
+              { body: 'msg-1-body' },
+              { body: 'msg-2-body' }
+            ] },
+            { messages: [] },
+          ])
+          yielded = nil
+          poller.poll(idle_timeout: 0, max_number_of_messages:2) do |messages|
+            yielded = messages
+          end
+          expect(yielded.map(&:body)).to eq(%w(msg-1-body msg-2-body))
+        end
+
+        describe 'message deletion' do
+
+          it 'deletes the message at the end of the block' do
+            expect(client).to receive(:delete_message_batch).with({
+              queue_url: queue_url,
+              entries: [
+                { id: 'id1', receipt_handle: 'rh1' },
+              ]
+            })
+            client.stub_responses(:receive_message, [
+              { messages: [{ message_id: 'id1', receipt_handle: 'rh1' }] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout: 0) { |msg| }
+          end
+
+          it 'supports batch deletion' do
+            expect(client).to receive(:delete_message_batch).with({
+              queue_url: queue_url,
+              entries: [
+                { id: 'id1', receipt_handle: 'rh1' },
+                { id: 'id2', receipt_handle: 'rh2' },
+              ]
+            })
+            client.stub_responses(:receive_message, [
+              { messages: [
+                { message_id: 'id1', receipt_handle: 'rh1', body: '' },
+                { message_id: 'id2', receipt_handle: 'rh2', body: '' },
+              ] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout: 0) { |msg| }
+          end
+
+          it 'can skip default delete behavior' do
+            expect(client).not_to receive(:delete_message_batch)
+            client.stub_responses(:receive_message, [
+              { messages: [{ message_id: 'id1', receipt_handle: 'rh1' }] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout: 0, skip_delete: true) { |msg| }
+          end
+
+          it 'skips delete when :skip_delete is thrown' do
+            expect(client).not_to receive(:delete_message_batch)
+            client.stub_responses(:receive_message, [
+              { messages: [{ message_id: 'id1', receipt_handle: 'rh1' }] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout: 0) { |msg| throw :skip_delete }
+          end
+
+          it 'provides the ability to manually delete messages' do
+            expect(client).to receive(:delete_message).with({
+              queue_url: queue_url,
+              receipt_handle: 'rh1',
+            })
+            client.stub_responses(:receive_message, [
+              { messages: [{ message_id: 'id1', receipt_handle: 'rh1' }] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout: 0, skip_delete: true) do |msg|
+              poller.delete_message(msg)
+            end
+          end
+
+          it 'provides the ability to manually delete message batches' do
+            expect(client).to receive(:delete_message_batch).with({
+              queue_url: queue_url,
+              entries: [
+                { id: 'id1', receipt_handle: 'rh1' },
+                { id: 'id2', receipt_handle: 'rh2' },
+              ]
+            })
+            client.stub_responses(:receive_message, [
+              { messages: [
+                { message_id: 'id1', receipt_handle: 'rh1', body: '' },
+                { message_id: 'id2', receipt_handle: 'rh2', body: '' },
+              ] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout:0, max_number_of_messages:10, skip_delete:true) do |messages|
+              poller.delete_messages(messages)
+            end
+          end
+        end
+
+        describe 'visibility timeouts' do
+
+          it 'provides a method to update the visibility timeout of a message' do
+            expect(client).to receive(:change_message_visibility_timeout).with({
+              queue_url: queue_url,
+              receipt_handle: 'rh1',
+              visibility_timeout: 60,
+            })
+            client.stub_responses(:receive_message, [
+              { messages: [{ receipt_handle: 'rh1' }] },
+              { messages: [] },
+            ])
+            poller.poll(idle_timeout:0) do |msg|
+              poller.change_message_visibility_timeout(msg, 60)
+            end
+          end
+
+        end
+
+        describe 'stop polling' do
+
+          it 'polls until :stop_polling is thrown from #before_request' do
+            expect(client).to receive(:receive_message).exactly(10).times.
+              and_return(client.next_stub(:receive_message))
+            poller.before_request do |stats|
+              throw :stop_polling if stats.request_count == 10
+            end
+            poller.poll { |msg| }
+          end
+
+          it 'polls until :idle_timeout seconds have past without messages' do
+            now = Time.now
+            one_minute_later = now + 61
+            expect(client).to receive(:receive_message).exactly(10).times.
+              and_return(client.next_stub(:receive_message))
+            poller.before_request do |stats|
+              if stats.request_count == 9
+                allow(Time).to receive(:now).and_return(one_minute_later)
+              end
+            end
+            poller.poll(idle_timeout: 60) { |msg| }
+          end
+
+        end
+
+        describe 'tracking stats' do
+
+          it 'counts the number of requests made' do
+            client.stub_responses(:receive_message, [
+              { messages: [{ body: 'msg-1-body' }] },
+              { messages: [] },
+              { messages: [{ body: 'msg-2-body' }] },
+              { messages: [] },
+              { messages: [{ body: 'msg-3-body' }] },
+            ])
+            poller.before_request do |stats|
+              throw :stop_polling if stats.received_message_count == 3
+            end
+            stats = poller.poll { |msg| }
+            expect(stats.request_count).to eq(5)
+          end
+
+          it 'counts the number of messages yielded in single mode' do
+            client.stub_responses(:receive_message, [
+              { messages: [{ body: 'msg-1-body' }] },
+              { messages: [{ body: 'msg-2-body' }] },
+              { messages: [{ body: 'msg-3-body' }] },
+              { messages: [{ body: 'msg-4-body' }] },
+              { messages: [{ body: 'msg-5-body' }] },
+              { messages: [] },
+            ])
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats.received_message_count).to eq(5)
+          end
+
+          it 'counts the number of messages yielded in batch mode' do
+            client.stub_responses(:receive_message, [
+              { messages: [
+                { body: 'msg-1-body' },
+                { body: 'msg-2-body' },
+                { body: 'msg-3-body' },
+              ] },
+              { messages: [
+                { body: 'msg-4-body' },
+                { body: 'msg-5-body' },
+                { body: 'msg-6-body' },
+              ] },
+              { messages: [] },
+            ])
+            stats = poller.poll(idle_timeout: 0, max_number_of_messages:3) { |msgs| }
+            expect(stats.received_message_count).to eq(6)
+          end
+
+          it 'tracks when a message was most recently received' do
+            client.stub_responses(:receive_message, [
+              { messages: [{ body: 'msg-1-body' }] },
+              { messages: [] },
+            ])
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats.last_message_received_at).to be_kind_of(Time)
+          end
+
+          it 'has a nil value for last_message_received_at with no messages' do
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats.last_message_received_at).to be(nil)
+          end
+
+          it 'tracks when polling started' do
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats.polling_started_at).to be_kind_of(Time)
+          end
+
+          it 'tracks when polling stops' do
+            started = Time.now
+            poller.before_request do |stats|
+              expect(stats.polling_stopped_at).to be(nil)
+            end
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats.polling_stopped_at > started).to be(true)
+          end
+
+          it 'yields a stats object to #poll' do
+            client.stub_responses(:receive_message, [
+              { messages: [{ body: 'msg-1-body' }] },
+              { messages: [{ body: 'msg-2-body' }] },
+              { messages: [{ body: 'msg-3-body' }] },
+              { messages: [] },
+            ])
+            yielded = nil
+            poller.poll(idle_timeout: 0) do |msg, stats|
+              yielded = stats
+            end
+            expect(yielded).to be_kind_of(QueuePoller::PollerStats)
+            expect(yielded.request_count).to eq(4)
+            expect(yielded.received_message_count).to eq(3)
+            expect(yielded.last_message_received_at).to be_kind_of(Time)
+          end
+
+          it 'returns a stats object' do
+            client.stub_responses(:receive_message, [
+              { messages: [{ body: 'msg-1-body' }] },
+              { messages: [{ body: 'msg-2-body' }] },
+              { messages: [{ body: 'msg-3-body' }] },
+              { messages: [] },
+            ])
+            stats = poller.poll(idle_timeout: 0) { |msg| }
+            expect(stats).to be_kind_of(QueuePoller::PollerStats)
+            expect(stats.request_count).to eq(4)
+            expect(stats.received_message_count).to eq(3)
+            expect(stats.last_message_received_at).to be_kind_of(Time)
+          end
+
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A utility class that makes it easy to poll an Amazon SQS Queue for messages.

```ruby
poller = Aws::SQS::QueuePoller.new(queue_url)

poller.poll do |msg|
  puts msg.body
end
```

Messages are automatically deleted from the queue at the end of the block. This tool supports receiving, and deleting messages in batches, long-polling, client-side tracking of request counts and messages received, and more.

## Long Polling

By default, messages are received using long polling. This method will force a default `:wait_time_seconds` of 20 seconds. If you prefer to use the queue default wait time, then pass a `nil` value for `:wait_time_seconds`.

```ruby
# disables 20 second default, use queue ReceiveMessageWaitTimeSeconds attribute
poller.poll(wait_time_seconds:nil) do |msg|
  # ...
end
```

When disabling `:wait_time_seconds` by passing `nil`, you must ensure the queue `ReceiveMessageWaitTimeSeconds` attribute is set to a non-zero value, or you will be short-polling. This will trigger significantly more API calls.

## Batch Receiving Messages

You can specify a maximum number of messages to receive with each polling attempt via `:max_number_of_messages`. When this is set to a positive value, greater than 1, the block will receive an array of messages, instead of a single message.

```ruby
# receives and yields up to 10 messages at a time
poller.poll(max_number_of_messages:10) do |messages|
  messages.each do |msg|
    # ...
  end
end
```

The maximum value for `:max_number_of_messages` is enforced by Amazon SQS.

## Visibility Timeouts

When receiving messages, you have a fixed amount of time to process and delete the message before it is added back into the queue. This is the visibility timeout. By default, the queue's `VisibilityTimeout` attribute is used. You can provide an alternative visibility timeout when polling.

```
# override queue visibility timeout
poller.poll(visibility_timeout:10) do |msg|
  # do work ...
end
```

You can reset the visibility timeout of a single message by calling `#change_message_visibility`. This is useful when you need more time to finish processing the message.

```ruby
poller.poll do |msg|

  # do work ...

  # need more time for processing
  poller.change_message_visibility(msg, 60)

  # finish work ...

end
```

If you change the visibility timeout of a message to zero, it will return to the queue immediately.

## Deleting Messages

Messages are deleted from the queue when the block returns normally.

```ruby
poller.poll do |msg|
  # do work
end # messages deleted here
```

You can skip message deletion by passing `skip_delete: true`. This allows you to manually delete the messages using {#delete_message}, or {#delete_messages}.


```ruby
# single message
poller.poll(skip_delete: true) do |msg|
  poller.delete_message(msg) # if successful
end

# message batch
poller.poll(skip_delete: true, max_number_of_messages:10) do |messages|
  poller.delete_messages(messages)
end
```

Another way to manage message deletion is to throw `:skip_delete` from the poll block. You can use this to choose when a message, or message batch is deleted on an individual basis:

```ruby
poller.poll do |msg|
  begin
    # do work
  rescue
    # unexpected error occurred while processing messages,
    # log it, and skip delete so it can be re-processed later
    throw :skip_delete
  end
end
```

## Terminating the Polling Loop

By default, polling will continue indefinitely. You can stop the poller by providing an idle timeout or by throwing `:stop_polling` from the {#before_request} callback.

### `:idle_timeout` Option

This is a configurable, maximum number of seconds to wait for a new message before the polling loop exists. By default, there is no idle timeout.

```ruby
# stops polling after a minute of no received messages
poller.poll(idle_timeout: 60) do |msg|
  # ...
end
```

### Throw `:stop_polling`

If you want more fine grained control, you can configure a before request callback to trigger before each long poll. Throwing `:stop_polling` from this callback will cause the poller to exit normally without making the next request.

```ruby
# stop after processing 100 messages
poller.before_request do |stats|
  throw :stop_polling if stats.receive_message_count >= 100
end

poller.poll do |msg|
  # do work ...
end
```

## Tracking Progress

The poller will automatically track a few statistics client-side in a PollerStats object. You can access the poller stats three ways:

* The first block argument of {#before_request}
* The second block argument of {#poll}.
* The return value from {#poll}.

Here are examples of accessing the statistics.

* Configure a {#before_request} callback.

  ```ruby
    poller.before_reqeust do |stats|
      logger.info("requests: #{stats.request_count}")
      logger.info("messages: #{stats.received_message_count}")
      logger.info("last-timestamp: #{stats.last_message_received_at}")
    end
  ```

* Accept a 2nd argument in the poll block, for example:

  ```ruby
    poller.poll do |msg, stats|
      logger.info("requests: #{stats.request_count}")
      logger.info("messages: #{stats.received_message_count}")
      logger.info("last-timestamp: #{stats.last_message_received_at}")
    end
  ```

* Return value:

  ```ruby
    stats = poller.poll(idle_timeout:10) do |msg|
      # do work ...
    end
    logger.info("requests: #{stats.request_count}")
    logger.info("messages: #{stats.received_message_count}")
    logger.info("last-timestamp: #{stats.last_message_received_at}")
  ```
