### PR TITLE
Add `Resource#wait_until { |resource| condition }` custom waiters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::Resources::Resource - Added support for custom waiters
+  with `Aws::Resources::Resource#wait_until`.
+
 * Issue - Query Protocol - No longer returning nil for empty maps in
   query responses. `Aws::SQS::Client#get_queue_attributes` will always
   have a hash a `resp.attributes` instead of a possible `nil` value.

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -26,6 +26,8 @@ module Aws
       # Waiter polls an API operation until a resource enters a desired
       # state.
       #
+      # @note The waiting operation is performed on a copy. The original resource remains unchanged
+      #
       # ## Basic Usage
       #
       # Waiter will polls until it is succesful, it fails by

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -23,10 +23,79 @@ module Aws
       # @return [Hash<Symbol,String>]
       attr_reader :identifiers
 
-      # @option options [Integer] :max_attempts (10)
-      # @option options [Integer] :delay (10)
-      # @option options [Proc] :before_attempt (nil)
-      # @option options [Proc] :before_wait (nil)
+      # Waiter polls an API operation until a resource enters a desired
+      # state.
+      #
+      # ## Basic Usage
+      #
+      # Waiter will polls until it is succesful, it fails by
+      # entering a terminal state, or until a maximum number of attempts
+      # are made.
+      #
+      #     # polls in a loop until condition is true
+      #     resource.wait_until(options) {|resource| condition}
+      #
+      # ## Example
+      #
+      #     instance.wait_until(max_attempts:10, delay:5) {|instance| instance.state.name == 'running' }
+      #
+      # ## Configuration
+      #
+      # You can configure the maximum number of polling attempts, and the
+      # delay (in seconds) between each polling attempt. The waiting condition is set
+      # by passing a block to {#wait_until}:
+      #
+      #     # poll for ~25 seconds
+      #     resource.wait_until(max_attempts:5,delay:5) {|resource|...}
+      #
+      # ## Callbacks
+      #
+      # You can be notified before each polling attempt and before each
+      # delay. If you throw `:success` or `:failure` from these callbacks,
+      # it will terminate the waiter.
+      #
+      #     started_at = Time.now
+      #     # poll for 1 hour, instead of a number of attempts
+      #     proc = Proc.new do |attempts, response|
+      #       throw :failure if Time.now - started_at > 3600
+      #     end
+      #
+      #       # disable max attempts
+      #     instance.wait_until(before_wait:proc, max_attempts:nil) {...}
+      #
+      # ## Handling Errors
+      #
+      # When a waiter is successful, it returns the Resource. When a waiter
+      # fails, it raises an error.
+      #
+      #     begin
+      #       resource.wait_until(...)
+      #     rescue Aws::Waiters::Errors::WaiterFailed
+      #       # resource did not enter the desired state in time
+      #     end
+      #
+      #
+      # @yieldparam [Resource] resource to be used in the waiting condition
+      #
+      # @raise [Errors::FailureStateError] Raised when the waiter terminates
+      #   because the waiter has entered a state that it will not transition
+      #   out of, preventing success.
+      #
+      # @raise [Errors::TooManyAttemptsError] Raised when the configured
+      #   maximum number of attempts have been made, and the waiter is not
+      #   yet successful.
+      #
+      # @raise [Errors::UnexpectedError] Raised when an error is encounted
+      #   while polling for a resource that is not expected.
+      #
+      # @raise [NotImplementedError] Raised when the resource does not
+      #   support #reload operation
+      #
+      # @option options [Integer] :max_attempts (10) Maximum number of attempts
+      # @option options [Integer] :delay (10) Delay between each attempt in seconds
+      # @option options [Proc] :before_attempt (nil) Callback invoked before each attempt
+      # @option options [Proc] :before_wait (nil) Callback invoked before each wait
+      # @return [Resource] if the waiter was successful
       def wait_until(options = {}, &block)
         resource_copy = self.dup
         attempts = 0

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -28,7 +28,7 @@ module Aws
       # @option options [Proc] :before_attempt (nil)
       # @option options [Proc] :before_wait (nil)
       def wait_until(options = {}, &block)
-        resource_copy = self.class.new(@identifiers.merge(client:@client, data:@data))
+        resource_copy = self.dup
         attempts = 0
         options[:max_attempts] ||= 10
         options[:delay] ||= 10

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -28,15 +28,16 @@ module Aws
       # @option options [Proc] :before_attempt (nil)
       # @option options [Proc] :before_wait (nil)
       def wait_until(options = {}, &block)
+        resource_copy = self.class.new(@identifiers.merge(client:@client, data:@data))
         attempts = 0
         options[:max_attempts] ||= 10
         options[:delay] ||= 10
         options[:poller] = Proc.new do
           attempts += 1
-          if block.call(self)
-            [:success, self]
+          if block.call(resource_copy)
+            [:success, resource_copy]
           else
-            reload unless attempts == options[:max_attempts]
+            resource_copy.reload unless attempts == options[:max_attempts]
             :retry
           end
         end

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -79,15 +79,15 @@ module Aws
       #
       # @yieldparam [Resource] resource to be used in the waiting condition
       #
-      # @raise [Errors::FailureStateError] Raised when the waiter terminates
+      # @raise [Aws::Waiters::Errors::FailureStateError] Raised when the waiter terminates
       #   because the waiter has entered a state that it will not transition
       #   out of, preventing success.
       #
-      # @raise [Errors::TooManyAttemptsError] Raised when the configured
+      # @raise [Aws::Waiters::Errors::TooManyAttemptsError] Raised when the configured
       #   maximum number of attempts have been made, and the waiter is not
       #   yet successful.
       #
-      # @raise [Errors::UnexpectedError] Raised when an error is encounted
+      # @raise [Aws::Waiters::Errors::UnexpectedError] Raised when an error is encounted
       #   while polling for a resource that is not expected.
       #
       # @raise [NotImplementedError] Raised when the resource does not

--- a/aws-sdk-resources/spec/resource_spec.rb
+++ b/aws-sdk-resources/spec/resource_spec.rb
@@ -127,6 +127,7 @@ module Aws
 
         before(:each) do
           allow(load_operation).to receive(:call).
+            with(client: client, resource:resource).
             and_return(*datas)
           resource_class.load_operation = load_operation
         end


### PR DESCRIPTION
The wait_until method doesn't alter the Resource's internal state. It operates on a copy. Added docs and specs. This addresses issue #738 