### PR TITLE
Update error_handler.rb to handle nil error_code

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
@@ -51,7 +51,7 @@ module Aws
       end
 
       def remove_prefix(context, error_code)
-        if prefix = context.config.api.metadata('errorPrefix')
+        if error_code && prefix = context.config.api.metadata('errorPrefix')
           error_code.sub(/^#{prefix}/, '')
         else
           error_code


### PR DESCRIPTION
We're occasionally seeing errors on this line:

```
NoMethodError: undefined method `sub' for nil:NilClass
File "/opt/rubies/ruby-2.1.5/lib/ruby/gems/2.1.0/gems/aws-sdk-core-2.0.33/lib/aws-sdk-core/xml/error_handler.rb" line 55 in remove_prefix
File "/opt/rubies/ruby-2.1.5/lib/ruby/gems/2.1.0/gems/aws-sdk-core-2.0.33/lib/aws-sdk-core/xml/error_handler.rb" line 50 in extract_error
File "/opt/rubies/ruby-2.1.5/lib/ruby/gems/2.1.0/gems/aws-sdk-core-2.0.33/lib/aws-sdk-core/xml/error_handler.rb" line 21 in error
File "/opt/rubies/ruby-2.1.5/lib/ruby/gems/2.1.0/gems/aws-sdk-core-2.0.33/lib/aws-sdk-core/xml/error_handler.rb" line 9 in block in call
File "/opt/rubies/ruby-2.1.5/lib/ruby/gems/2.1.0/gems/aws-sdk-core-2.0.33/lib/seahorse/client/response.rb" line 43 in call
```