### PR TITLE
Added `#exists?` methods to a handful of resource classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Unreleased Changes
 ------------------
 
+* Feature - Resources - Added `#exists?` methods to a handful of resource classes.
+  The `#exists?` method works by polling the exists wait for the resource exactly
+  once. If the waiter is successful, then `true` is returned, if it fails, then
+  `false` is returned.
+
+  To add additional `#exists?` methods, a waiter must be added to the resource
+  class as `Exists` and that waiter must be defined in the *.waiters.json
+  document for that service.
+
 * Issue - Presigned URLs - Resolved an issue where `x-amz-` headers were not
   being signed as part of a pre-signed URL.
 

--- a/FEATURE_REQUESTS.md
+++ b/FEATURE_REQUESTS.md
@@ -40,16 +40,6 @@ Amazon CloudFront supports pre-signed URLs, similar to those used by Amazon S3. 
 
 See [related GitHub issue #700](https://github.com/aws/aws-sdk-ruby/issues/700).
 
-### Adding `#exists?` method to Resource Classes
-
-Version 1 of the AWS SDK for Ruby had hand-coded methods for each resource class that would return a boolean value as a response to `#exists?`. These methods would typically call an API operation to describe the resource, rescuing errors as appropriate.
-
-No such functionality exists in the version 2 SDK currently. It would be ideal to avoid hand-coding these methods. One possible solution is to add waiters for each resource type, e.g. `:bucket_exists`. The resource classes could be linked to their exists waiter. The resource class would poll the waiter exactly once, returning a true or false value.
-
-This approach has the benefit of expanding waiter coverage and providing a reliable `#exists?` method.
-
-See [related GitHub issue #696](https://github.com/aws/aws-sdk-ruby/issues/696).
-
 ### Amazon S3 Presigned Post
 
 The version 1 SDK has support for generating a pre-signed POST request. This returned a hash of key/value pairs that should be embedded into a HTML POST form for browsers. This should be ported to the version 2 SDK, and updated to use signature version 4.

--- a/aws-sdk-core/apis/EC2.resources.json
+++ b/aws-sdk-core/apis/EC2.resources.json
@@ -838,6 +838,13 @@
         }
       },
       "waiters": {
+        "Exists": {
+          "waiterName": "InstanceExists",
+          "params": [
+            { "target": "InstanceIds[]", "source": "identifier", "name": "Id" }
+          ],
+          "path": "Reservations[0].Instances[0]"
+        },
         "Running": {
           "waiterName": "InstanceRunning",
           "params": [

--- a/aws-sdk-core/apis/EC2.waiters.json
+++ b/aws-sdk-core/apis/EC2.waiters.json
@@ -1,6 +1,23 @@
 {
   "version": 2,
   "waiters": {
+    "InstanceExists": {
+      "delay": 5,
+      "maxAttempts": 40,
+      "operation": "DescribeInstances",
+      "acceptors": [
+        {
+          "matcher": "status",
+          "expected": 200,
+          "state": "success"
+        },
+        {
+          "matcher": "error",
+          "expected": "InvalidInstanceIDNotFound",
+          "state": "retry"
+        }
+      ]
+    },
     "BundleTaskComplete": {
       "delay": 15,
       "operation": "DescribeBundleTasks",

--- a/aws-sdk-core/apis/S3.waiters.json
+++ b/aws-sdk-core/apis/S3.waiters.json
@@ -12,6 +12,11 @@
           "state": "success"
         },
         {
+          "expected": 403,
+          "matcher": "status",
+          "state": "success"
+        },
+        {
           "expected": 404,
           "matcher": "status",
           "state": "retry"

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -34,6 +34,19 @@ module Aws
         !@data.nil?
       end
 
+      # @api private
+      def exists?
+        wait_until_exists { |w| w.max_attempts = 1 }
+        true
+      rescue Waiters::Errors::UnexpectedError => e
+        raise e.error
+      rescue Waiters::Errors::WaiterFailed
+        false
+      rescue NoMethodError
+        msg = "#exists? is not implemented for #{self.class.name}"
+        raise NotImplementedError, msg
+      end
+
       # Loads data for this resource.
       # @note Calling this method will send a request to AWS.
       # @return [self]

--- a/doc-src/plugins/resources.rb
+++ b/doc-src/plugins/resources.rb
@@ -98,6 +98,7 @@ a default client will be constructed.
     document_identifier_attributes(yard_class, resource_class)
     document_data_attribute_getters(yard_class, resource_class)
     document_operation_methods(yard_class, resource_class)
+    document_exists_method(yard_class, resource_class)
     yard_class
   end
 
@@ -222,6 +223,15 @@ Loads the current #{name} by calling {Client##{method}}.
     documenter = Aws::Resources::Documenter.const_get(type + 'Documenter')
     documenter = documenter.new(yard_class, resource_class, name, operation)
     documenter.method_object
+  end
+
+  def document_exists_method(yard_class, resource_class)
+    if resource_class.operation_names.include?(:wait_until_exists)
+      name = resource_class.name.split('::').last
+      m = YARD::CodeObjects::MethodObject.new(yard_class, :exists?)
+      m.scope = :instance
+      m.docstring = "@return [Boolean] Returns true if this #{name} exists. Returns `false` otherwise."
+    end
   end
 
 end


### PR DESCRIPTION
The `#exists?` method works by polling the exists wait for the resource exactly once. If the waiter is successful, then `true` is returned, if it fails, then `false` is returned.

To add additional `#exists?` methods, a waiter must be added to the resource class as `Exists` and that waiter must be defined in the *.waiters.json document for that service.

See #696