### PR TITLE
Empty set. How to be?

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -48,6 +48,7 @@ module Aws
         private
 
         def format_set(set)
+          return { l: [] } if set.empty?
           case set.first
           when String then { ss: set.map(&:to_s) }
           when Numeric then { ns: set.map(&:to_s) }


### PR DESCRIPTION
Hi everyone!

Is it possible to cast empty set as empty list? Or shall I handle empty sets in my client code? 
I propose to cast the empty sets as empty lists because this is a good way to follow simple rule: "What You See Is What You Get"
We see the empty set so this is the same as the empty list, isn't it?

Referring to php-sdk, php has no set class but only array and all operations with sets performed over arrays. So under php context empty sets and empty lists are meaning same things.

Thanks,
Anton