### PR TITLE
Resource inherits from BasicObject

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -1,6 +1,6 @@
 module Aws
   module Resources
-    class Resource
+    class Resource < BasicObject
 
       extend OperationMethods
 
@@ -9,10 +9,16 @@ module Aws
       #     used to construct a {Client} unless `:client` is given.
       #   @option options [Client] :client
       def initialize(*args)
-        options = args.last.is_a?(Hash) ? args.pop.dup : {}
+        options = args.last.is_a?(::Hash) ? args.pop.dup : {}
         @identifiers = extract_identifiers(args, options)
         @data = options.delete(:data)
         @client = extract_client(options)
+      end
+
+      # Because we're a BasicObject
+      include ::Kernel
+      def self.const_missing(name)
+        ::Object.const_get(name)
       end
 
       # Marked private to prevent double documentation


### PR DESCRIPTION
Which should allow it to remain pollution free e.g. in Rake-like
situations where Object pollution is hard to avoid.

addresses #771.

NB. Not a for-real PR - seems like too major a change to dash off in 15 minutes... A for-your-consideration kind of a PR. :-)