### PR TITLE
Marshall ruby Symbols as Strings for attribute values

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -33,6 +33,7 @@ module Aws
               list[:l] << format(value)
             end
           when String then { s: obj }
+          when Symbol then { s: obj.to_s }
           when Numeric then { n: obj.to_s }
           when StringIO, IO then { b: obj.read }
           when Set then format_set(obj)
@@ -49,7 +50,7 @@ module Aws
 
         def format_set(set)
           case set.first
-          when String then { ss: set.map(&:to_s) }
+          when String, Symbol then { ss: set.map(&:to_s) }
           when Numeric then { ns: set.map(&:to_s) }
           when StringIO, IO then { bs: set.map(&:read) }
           else

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -31,6 +31,11 @@ module Aws
           expect(formatted).to eq(ss: %w(abc mno))
         end
 
+        it 'converts symbol sets to :ss (string set)' do
+          formatted = value.marshal(Set.new([:abc, :mno]))
+          expect(formatted).to eq(ss: %w(abc mno))
+        end
+
         it 'converts numeric sets to :ns (number set)' do
           formatted = value.marshal(Set.new([123, 456]))
           expect(formatted).to eq(ns: %w(123 456))
@@ -50,6 +55,10 @@ module Aws
 
         it 'converts strings to :s' do
           expect(value.marshal('abc')).to eq(s: 'abc')
+        end
+
+        it 'converts symbol to :s' do
+          expect(value.marshal(:abc)).to eq(s: 'abc')
         end
 
         it 'converts booleans :bool' do


### PR DESCRIPTION
Allow ruby Symbols as attribute values, converting them to string representation within the AWS::DynamoDB::AttributeValue::Marshaller

DynamoDB does not have a native Symbol type and so these values are un-marshalled as Strings. Is this acceptable ?

This issue manifests itself if you attempt to save a ruby hash containing symbols as values  .. e.g 

```
dynamo_client.put_item(table_name: dynamodb_table_name, item: {hash: 'my-hash', value: :symbol_value})
```

will throw the error

unsupported type, expected Hash, Array, Set, String, Numeric, IO, true, false, or nil, got Symbol