### PR TITLE
Replace multi_json with standard library json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby
 
 sudo: false

--- a/aws-sdk-core/aws-sdk-core.gemspec
+++ b/aws-sdk-core/aws-sdk-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir = 'bin'
   spec.executables << 'aws.rb'
 
-  spec.add_dependency('multi_json', '~> 1.0')
+  spec.add_dependency('json', '~> 1.8')
   spec.add_dependency('builder', '~> 3.0')
   spec.add_dependency('jmespath', '~> 1.0')
 

--- a/aws-sdk-core/features/env.rb
+++ b/aws-sdk-core/features/env.rb
@@ -1,15 +1,15 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 
-require 'simplecov'
 require 'aws-sdk-core'
-require 'multi_json'
+require 'json'
+require 'simplecov'
 
 SimpleCov.command_name('test:integration:aws-sdk-core')
 
 cfg = './integration-test-config.json'
 
 if File.exist?(cfg)
-  Aws.config = MultiJson.load(File.read(cfg), symbolize_keys: true)
+  Aws.config = JSON.parse(File.read(cfg), symbolize_names: true)
 elsif ENV['AWS_INTEGRATION']
   # run integration tests, just don't read a configuration file from disk
 else

--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -1,5 +1,5 @@
 require 'jmespath'
-require 'multi_json'
+require 'json'
 require 'seahorse'
 
 Seahorse::Util.irregular_inflections({

--- a/aws-sdk-core/lib/aws-sdk-core/api/docstrings.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docstrings.rb
@@ -7,7 +7,7 @@ module Aws
       def self.apply(client_class, path)
         api = client_class.api.definition
         docs = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
-        docs = MultiJson.load(docs)
+        docs = JSON.parse(docs)
 
         api['documentation'] = docs['service']
 

--- a/aws-sdk-core/lib/aws-sdk-core/endpoint_provider.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/endpoint_provider.rb
@@ -6,7 +6,7 @@ module Aws
     PATH = File.join(File.dirname(__FILE__), '..', '..', 'endpoints.json')
 
     # @api private
-    RULES = MultiJson.load(File.read(PATH))['endpoints']
+    RULES = JSON.parse(File.read(PATH))['endpoints']
 
     class << self
 

--- a/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -64,7 +64,7 @@ module Aws
     end
 
     def refresh
-      credentials = MultiJson.load(get_credentials)
+      credentials = JSON.parse(get_credentials)
       @access_key_id = credentials['AccessKeyId']
       @secret_access_key = credentials['SecretAccessKey']
       @session_token = credentials['Token']

--- a/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
@@ -8,7 +8,7 @@ module Aws
       # @param [Hash] params
       # @return [String<JSON>]
       def to_json(shape, params)
-        MultiJson.dump(format(shape, params))
+        JSON.dump(format(shape, params))
       end
 
       private

--- a/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
@@ -14,11 +14,11 @@ module Aws
       private
 
       def extract_error(body, context)
-        json = MultiJson.load(body)
+        json = JSON.parse(body)
         code = error_code(json, context)
         message = error_message(code, json)
         [code, message]
-      rescue MultiJson::ParseError
+      rescue JSON::ParserError
         [http_status_error_code(context), '']
       end
 

--- a/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -10,7 +10,7 @@ module Aws
       # @param [Hash, Array, nil] target
       # @return [Hash]
       def parse(shape, json, target = nil)
-        parse_shape(shape, MultiJson.load(json, max_nesting: false), target)
+        parse_shape(shape, JSON.parse(json, max_nesting: false), target)
       end
 
       private

--- a/aws-sdk-core/lib/aws-sdk-core/json/simple_body_handler.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/simple_body_handler.rb
@@ -22,11 +22,11 @@ module Aws
       private
 
       def build_json(context)
-        context.http_request.body = MultiJson.dump(context.params)
+        context.http_request.body = JSON.dump(context.params)
       end
 
       def parse_json(context)
-        MultiJson.load(context.http_response.body_contents)
+        JSON.parse(context.http_response.body_contents)
       end
 
     end

--- a/aws-sdk-core/lib/seahorse/client/plugins/json_simple.rb
+++ b/aws-sdk-core/lib/seahorse/client/plugins/json_simple.rb
@@ -16,10 +16,10 @@ module Seahorse
         class Handler < Client::Handler
 
           def call(context)
-            context.http_request.body = MultiJson.dump(context.params)
+            context.http_request.body = JSON.dump(context.params)
             @handler.call(context).on_success do |response|
               response.error = nil
-              response.data = MultiJson.load(context.http_response.body_contents)
+              response.data = JSON.parse(context.http_response.body_contents)
             end
           end
 

--- a/aws-sdk-core/lib/seahorse/util.rb
+++ b/aws-sdk-core/lib/seahorse/util.rb
@@ -25,7 +25,7 @@ module Seahorse
       end
 
       def load_json(path)
-        MultiJson.load(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
+        JSON.parse(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
       end
 
     end

--- a/aws-sdk-core/spec/protocols_spec.rb
+++ b/aws-sdk-core/spec/protocols_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-require 'multi_json'
+require 'json'
 require 'rexml/document'
+require 'spec_helper'
 
 def fixtures
   fixtures = {}
@@ -18,7 +18,7 @@ end
 
 def each_test_case(context, fixture_path)
   return unless fixture_path
-  MultiJson.load(File.read(fixture_path)).each do |suite|
+  JSON.parse(File.read(fixture_path)).each do |suite|
     describe(suite['description'].inspect) do
       suite['cases'].each.with_index do |test_case,n|
         describe("case: #{n}") do
@@ -118,12 +118,12 @@ def match_req_body(group, suite, test_case, http_req)
         body = body.split('&').sort.join('&')
         expected_body = expected_body.split('&').sort.join('&')
       when 'json'
-        body = MultiJson.load(body) unless body == ''
-        expected_body = MultiJson.load(expected_body)
+        body = JSON.parse(body) unless body == ''
+        expected_body = JSON.parse(expected_body)
       when 'rest-json'
         if body[0] == '{'
-          body = MultiJson.load(body)
-          expected_body = MultiJson.load(expected_body)
+          body = JSON.parse(body)
+          expected_body = JSON.parse(expected_body)
         end
       when 'rest-xml'
         body = normalize_xml(body)

--- a/aws-sdk-resources/features/env.rb
+++ b/aws-sdk-resources/features/env.rb
@@ -8,7 +8,7 @@ SimpleCov.command_name('test:integration:aws-sdk-resources')
 cfg = './integration-test-config.json'
 
 if File.exist?(cfg)
-  Aws.config = MultiJson.load(File.read(cfg), symbolize_keys: true)
+  Aws.config = JSON.parse(File.read(cfg), symbolize_names: true)
 elsif ENV['AWS_INTEGRATION']
   # run integration tests, just don't read a configuration file from disk
 else

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/client.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/client.rb
@@ -80,14 +80,14 @@ module Aws
     #         @keys = keys
     #         @encryption_materials = Aws::S3::Encryption::Materials.new(
     #           key: @keys[default_key_name],
-    #           description: MultiJson.dump(key: default_key_name),
+    #           description: JSON.dump(key: default_key_name),
     #         )
     #       end
     #
     #       attr_reader :encryption_materials
     #
     #       def key_for(matdesc)
-    #         key_name = MultiJson.load(matdesc)['key']
+    #         key_name = JSON.parse(matdesc)['key']
     #         if key = @keys[key_name]
     #           key
     #         else

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
@@ -66,11 +66,11 @@ module Aws
 
         def envelope_from_instr_file(context)
           suffix = context[:encryption][:instruction_file_suffix]
-          MultiJson.load(context.client.get_object(
+          JSON.parse(context.client.get_object(
             bucket: context.params[:bucket],
             key: context.params[:key] + suffix
           ).body.read)
-        rescue S3::Errors::ServiceError, MultiJson::ParseError
+        rescue S3::Errors::ServiceError, JSON::ParserError
           nil
         end
 

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/encrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/encrypt_handler.rb
@@ -30,7 +30,7 @@ module Aws
             context.client.put_object(
               bucket: context.params[:bucket],
               key: context.params[:key] + suffix,
-              body: MultiJson.dump(envelope)
+              body: JSON.dump(envelope)
             )
           end
         end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/materials.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/materials.rb
@@ -45,9 +45,9 @@ module Aws
         end
 
         def validate_desc(description)
-          MultiJson.load(description)
+          JSON.parse(description)
           description
-        rescue MultiJson::ParseError
+        rescue JSON::ParserError
           msg = "expected description to be a valid JSON document string"
           raise ArgumentError, msg
         end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
@@ -1,6 +1,6 @@
-require 'openssl'
 require 'base64'
-require 'multi_json'
+require 'json'
+require 'openssl'
 
 module Aws
   module S3
@@ -597,7 +597,7 @@ module Aws
         signature_fields(datetime).each do |name, value|
           policy['conditions'] << { name => value }
         end
-        base64(MultiJson.dump(policy))
+        base64(JSON.dump(policy))
       end
 
       def signature_fields(datetime)

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/sns/message_verifier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/sns/message_verifier.rb
@@ -1,7 +1,7 @@
+require 'base64'
+require 'json'
 require 'net/http'
 require 'openssl'
-require 'base64'
-require 'multi_json'
 
 module Aws
   module SNS
@@ -59,7 +59,7 @@ module Aws
       # @raise [VerificationError] Raised when the given message has failed
       #   verification.
       def authenticate!(message_body)
-        msg = MultiJson.load(message_body)
+        msg = JSON.parse(message_body)
         if public_key(msg).verify(sha1, signature(msg), canonical_string(msg))
           true
         else

--- a/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
@@ -150,7 +150,7 @@ module Aws
               # first request stores the encryption materials in the instruction file
               expect(
                 a_request(:put, "https://bucket.s3-us-west-1.amazonaws.com/key.instruction").with(
-                  :body => MultiJson.dump(
+                  :body => JSON.dump(
                     'x-amz-key'=>'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
                     'x-amz-iv' => 'TO5mQgtOzWkTfoX4RE5tsA==',
                     'x-amz-matdesc' => '{}',
@@ -231,7 +231,7 @@ module Aws
                 to_return(body: encrypted_body)
               stub_request(:get, "https://bucket.s3-us-west-1.amazonaws.com/key#{suffix}").
                 to_return(
-                  :body => MultiJson.dump(
+                  :body => JSON.dump(
                     'x-amz-key'=>'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
                     'x-amz-iv' => 'TO5mQgtOzWkTfoX4RE5tsA==',
                     'x-amz-matdesc' => '{}',

--- a/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
 require 'base64'
-require 'multi_json'
+require 'json'
+require 'spec_helper'
 
 module Aws
   module S3
@@ -17,7 +17,7 @@ module Aws
       let(:post) { PresignedPost.new(creds, region, bucket, options) }
 
       def decode(policy)
-        MultiJson.load(Base64.decode64(policy))
+        JSON.parse(Base64.decode64(policy))
       end
 
       def policy(post)

--- a/aws-sdk-resources/spec/services/sns/message_verifier_spec.rb
+++ b/aws-sdk-resources/spec/services/sns/message_verifier_spec.rb
@@ -1,5 +1,5 @@
+require 'json'
 require 'spec_helper'
-require 'multi_json'
 
 module Aws
   module SNS
@@ -69,36 +69,36 @@ kMFvPxlw0XwWsvjTGPFCBIR7NZXnwQfVYbdFu88TjT10wTCZ/E3yCp77aDWD1JLV
         end
 
         it 'raises when the SigningCertURL is not https' do
-          msg = MultiJson.load(message)
+          msg = JSON.parse(message)
           msg['SigningCertURL'] = msg['SigningCertURL'].sub(/https/, 'http')
-          msg = MultiJson.dump(msg)
+          msg = JSON.dump(msg)
           expect {
             verifier.authenticate!(msg)
           }.to raise_error(MessageVerifier::VerificationError, /must be https/)
         end
 
         it 'raises when the SigningCertURL is not AWS hosted' do
-          msg = MultiJson.load(message)
+          msg = JSON.parse(message)
           msg['SigningCertURL'] = 'https://internetbadguys.com/cert.pem'
-          msg = MultiJson.dump(msg)
+          msg = JSON.dump(msg)
           expect {
             verifier.authenticate!(msg)
           }.to raise_error(MessageVerifier::VerificationError, /hosted by AWS/)
         end
 
         it 'raises when the SigningCertURL is not a pem file' do
-          msg = MultiJson.load(message)
+          msg = JSON.parse(message)
           msg['SigningCertURL'] = msg['SigningCertURL'].sub(/pem$/, 'key')
-          msg = MultiJson.dump(msg)
+          msg = JSON.dump(msg)
           expect {
             verifier.authenticate!(msg)
           }.to raise_error(MessageVerifier::VerificationError, /a \.pem file/)
         end
 
         it 'raises when the message signature fails validation' do
-          msg = MultiJson.load(message)
+          msg = JSON.parse(message)
           msg['Signature'] = 'bad'
-          msg = MultiJson.dump(msg)
+          msg = JSON.dump(msg)
           expect {
             verifier.authenticate!(msg)
           }.to raise_error(MessageVerifier::VerificationError, /cannot be verified/)
@@ -142,9 +142,9 @@ kMFvPxlw0XwWsvjTGPFCBIR7NZXnwQfVYbdFu88TjT10wTCZ/E3yCp77aDWD1JLV
         end
 
         it 'returns false if the message can not be authenticated' do
-          msg = MultiJson.load(message)
+          msg = JSON.parse(message)
           msg['Signature'] = 'bad'
-          msg = MultiJson.dump(msg)
+          msg = JSON.dump(msg)
           expect(verifier.authentic?(msg)).to be(false)
         end
 

--- a/doc-src/plugins/resources.rb
+++ b/doc-src/plugins/resources.rb
@@ -180,7 +180,7 @@ Loads the current #{name} by calling {Client##{method}}.
     endpoint = resource_class.client_class.api.metadata('endpointPrefix')
     version = resource_class.client_class.api.version
     definition = File.read("aws-sdk-core/apis/#{endpoint}/#{version}/resources-1.json")
-    definition = MultiJson.load(definition)
+    definition = JSON.parse(definition)
     definition = definition['resources'][resource_name]
     if shape_name = definition['shape']
 


### PR DESCRIPTION
As on of the authors of `multi_json`, I no longer use it in my own projects and no longer recommend its use to others, now that the `json` gem is part of the Ruby standard library. I have replaced the `multi_json` dependency with a `json` gem dependency, despite the fact that this is not strictly necessary, just to ensure that users of older versions of Ruby, which ship with an older version of `json` are using the latest gem version instead. This dependency could be removed.

I have opened a [similar pull request against `jmespath`](https://github.com/trevorrowe/jmespath.rb/pull/7) to remove the transitive dependency on `multi_json`.

I have also added Ruby 2.2 to the Travis CI matrix for testing.