### PR TITLE
Add a :step_complete Waiter to Aws::EMR

### DIFF
--- a/aws-sdk-core/apis/elasticmapreduce/2009-03-31/waiters-2.json
+++ b/aws-sdk-core/apis/elasticmapreduce/2009-03-31/waiters-2.json
@@ -37,6 +37,31 @@
           "expected": "TERMINATED_WITH_ERRORS"
         }
       ]
+    },
+    "StepComplete": {
+      "delay": 30,
+      "operation": "DescribeStep",
+      "maxAttempts": 60,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "path",
+          "argument": "Step.Status.State",
+          "expected": "COMPLETED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "Step.Status.State",
+          "expected": "FAILED"
+        },
+        {
+          "state": "failure",
+          "matcher": "path",
+          "argument": "Step.Status.State",
+          "expected": "CANCELLED"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Allows a process to wait on the completion of an EMR step.