### PR TITLE
Simple type fixes and method change

### DIFF
--- a/aws-sdk-core/bin/aws.rb
+++ b/aws-sdk-core/bin/aws.rb
@@ -9,7 +9,7 @@ require 'logger'
 
 def env_bool key, default
   if ENV.key?(key)
-    !['0', 'false', 'no', 'off'].include?(ENV[key].downcase)
+    ['0', 'false', 'no', 'off'].exclude?(ENV[key].downcase)
   else
     default
   end

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizer.rb
@@ -47,7 +47,7 @@ module Aws
         if member_regex.is_a?(String)
           member_regex = /^#{member_regex}$/
         end
-        @client_class.api.definition['shapes'].each do |shape_name, shape|
+        @client_class.api.definition['shapes'].each_value do |shape|
           if shape['members']
             shape['members'].each do |member_name, member_ref|
               if member_name.match(member_regex)

--- a/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -34,8 +34,7 @@ module Aws
       # @param [Array] values
       # @param [Array, nil] target
       # @return [Array]
-      def list(list, values, target = nil)
-        target = [] if target.nil?
+      def list(list, values, target = [])
         values.each { |value| target << parse_shape(list.member, value) }
         target
       end
@@ -43,8 +42,7 @@ module Aws
       # @param [Seahorse::Model::Shapes::Map] map
       # @param [Hash] values
       # @return [Hash]
-      def map(map, values, target = nil)
-        target = {} if target.nil?
+      def map(map, values, target = {})
         values.each do |key, value|
           target[key] = parse_shape(map.value, value)
         end

--- a/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -34,7 +34,8 @@ module Aws
       # @param [Array] values
       # @param [Array, nil] target
       # @return [Array]
-      def list(list, values, target = [])
+      def list(list, values, target = nil)
+        target = [] if target.nil?
         values.each { |value| target << parse_shape(list.member, value) }
         target
       end
@@ -42,7 +43,8 @@ module Aws
       # @param [Seahorse::Model::Shapes::Map] map
       # @param [Hash] values
       # @return [Hash]
-      def map(map, values, target = {})
+      def map(map, values, target = nil)
+        target = {} if target.nil?
         values.each do |key, value|
           target[key] = parse_shape(map.value, value)
         end

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/glacier_checksums.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/glacier_checksums.rb
@@ -11,7 +11,7 @@ module Aws
     # * `:upload_multipart_part`
     #
     # The `:upload_archive` and `:upload_multipart_part` operations
-    # accept a `:checksum` request paramter.  If this param
+    # accept a `:checksum` request parameter.  If this param
     # is present, then the checksum is assumed to be the proper
     # tree hash of the file to be uploaded.  If this param is
     # not present, then the required tree hash checksum will

--- a/aws-sdk-core/lib/seahorse/client/http/headers.rb
+++ b/aws-sdk-core/lib/seahorse/client/http/headers.rb
@@ -11,7 +11,7 @@ module Seahorse
       #     headers[:Authorization] = 'Abc'
       #
       #     headers.keys
-      #     #=> ['content-length', 'authorization']]
+      #     #=> ['content-length', 'authorization']
       #
       #     headers.values
       #     #=> ['100', 'Abc']

--- a/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -5,7 +5,7 @@ module Seahorse
     module Logging
 
       # A log formatter receives a {Response} object and return
-      # a log message as a string..  When you construct a {Formatter}, you provide
+      # a log message as a string. When you construct a {Formatter}, you provide
       # a pattern string with substitutions.
       #
       #     pattern = ':operation :http_response_status_code :time'

--- a/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -24,7 +24,7 @@ module Seahorse
         # @api private
         DNS_ERROR_MESSAGE = 'getaddrinfo: nodename nor servname provided, or not known'
 
-        # Raised when a {Handler} can not construct a `Net::HTTP::Request`
+        # Raised when a {Handler} cannot construct a `Net::HTTP::Request`
         # from the given http verb.
         class InvalidHttpVerbError < StandardError; end
 

--- a/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -34,7 +34,7 @@ module Seahorse
           if @types.key?(type)
             @types[type]
           else
-            raise ArgumentError, "unregisterd type `#{type}'"
+            raise ArgumentError, "unregistered type `#{type}'"
           end
         end
 


### PR DESCRIPTION
1. aws.rb
    Instead of !array.include?() we can use exclude more readable. Benchmarked these methods. The result is same almost.
2. customizer.rb
    Since shape_name is not used we can use each_value.
3. parse.rb
    This can be initialised to empty array and hash.

    Rest all files are simple typo fixes.