### PR TITLE
Don't Read IO Objects in Attribute Value Marshal

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -34,7 +34,7 @@ module Aws
             end
           when String then { s: obj }
           when Numeric then { n: obj.to_s }
-          when StringIO, IO then { b: obj.read }
+          when StringIO, IO then { b: obj }
           when Set then format_set(obj)
           when true, false then { bool: obj }
           when nil then { null: true }

--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -51,7 +51,7 @@ module Aws
           case set.first
           when String then { ss: set.map(&:to_s) }
           when Numeric then { ns: set.map(&:to_s) }
-          when StringIO, IO then { bs: set.map(&:read) }
+          when StringIO, IO then { bs: set.to_a }
           else
             msg = "set types only support String, Numeric, or IO objects"
             raise ArgumentError, msg

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -26,6 +26,12 @@ module Aws
           ])
         end
 
+        it 'converts IO objects to :b (blob)' do
+          io = StringIO.new('bar')
+          formatted = value.marshal(foo: io)
+          expect(formatted[:m]["foo"][:b].read).to eq('bar')
+        end
+
         it 'converts string sets to :ss (string set)' do
           formatted = value.marshal(Set.new(%w(abc mno)))
           expect(formatted).to eq(ss: %w(abc mno))

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -26,7 +26,7 @@ module Aws
           ])
         end
 
-        it 'converts IO objects to :b (blob)' do
+        it 'converts IO objects to :b (binary)' do
           io = StringIO.new('bar')
           formatted = value.marshal(foo: io)
           expect(formatted[:m]["foo"][:b].read).to eq('bar')
@@ -43,8 +43,9 @@ module Aws
         end
 
         it 'converts binary sets to :bs (binary set)' do
-          formatted = value.marshal(Set.new([StringIO.new('data')]))
-          expect(formatted).to eq(bs: ['data'])
+          io_obj = StringIO.new('data')
+          formatted = value.marshal(Set.new([io_obj]))
+          expect(formatted).to eq(bs: [io_obj])
         end
 
         it 'converts numerics to :n (number)' do


### PR DESCRIPTION
Resolves Issue #831

Running the following code exercised the problem, and now works with
this change:

```
dynamodb.put_item(
  table_name: "foo",
  item: {
    id: 1,
    contents: StringIO.new("bar")
  }
)
```

The issue appeared to be that #read was called twice on the StringIO or
IO object, and the second call would fail as String#read does not
exist.

One thing I'd like to review further before merging is the fact that maps and collections do this same #read call but do not have this problem when tested.