### PR TITLE
Adding Redshift waiter: ClusterRestored

### DIFF
--- a/aws-sdk-core/apis/redshift/2012-12-01/waiters-2.json
+++ b/aws-sdk-core/apis/redshift/2012-12-01/waiters-2.json
@@ -44,6 +44,25 @@
         }
       ]
     },
+    "ClusterRestored": {
+      "operation": "DescribeClusters",
+      "maxAttempts": 30,
+      "delay": 60,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "pathAll",
+          "argument": "Clusters[].RestoreStatus.Status",
+          "expected": "completed"
+        },
+        {
+          "state": "failure",
+          "matcher": "pathAny",
+          "argument": "Clusters[].ClusterStatus",
+          "expected": "deleting"
+        }
+      ]
+    },
     "SnapshotAvailable": {
       "operation": "DescribeClusterSnapshots",
       "maxAttempts": 20,


### PR DESCRIPTION
While scripting some Redshift operations, I found that the existing set of waiters only includes `:cluster_available`, which returns immediately when called for all three of these clusters:

    irb(main):029:0> pp aws[:redshift].describe_clusters.clusters.map { |c| [c.cluster_identifier, c.cluster_status, c.restore_status.try(:status)] }
    [["science-20150603-11", "available", "completed"],
     ["science-20150605-12", "available", "restoring"],
     ["warehouse03", "available", nil]]

whereas I actually want it to _continue waiting_ for the second (`["science-20150605-12", "available", "restoring"]`. This PR adds a waiter for `ClusterRestored`, which will wait for the restore status to also become `'completed'`.

One question(...? thought?) I did have: obviously implicit in this is that `restore_status.status` can *only* ever become `'completed'` after `cluster_status` becomes `'available'`. This seems to be a reasonable assumption, but seems brittle. Dunno how you feel about that. Possible future approaches that I didn't *see* but may be planned, being worked on, or exist, would be either multiple criteria per edge in the state graph or waiter composition. 

Some contributing-related notes:
 * Totally fine if a different (more specific?) waiter name is in order
 * There aren't any non-config changes, so it's passing tests, but I didn't see any tests that cover waiters specifically