### PR TITLE
Fix Resource#wait_until(max_attempts: nil)

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -101,7 +101,7 @@ module Aws
       def wait_until(options = {}, &block)
         resource_copy = self.dup
         attempts = 0
-        options[:max_attempts] ||= 10
+        options[:max_attempts] = 10 unless options.key?(:max_attempts)
         options[:delay] ||= 10
         options[:poller] = Proc.new do
           attempts += 1

--- a/aws-sdk-resources/spec/resource_spec.rb
+++ b/aws-sdk-resources/spec/resource_spec.rb
@@ -229,6 +229,12 @@ module Aws
           expect(resource.data).to be(data)
         end
 
+        it 'allows unlimited attempts' do
+          attempts = 0
+          resource.wait_until(max_attempts:nil, delay:0) { (attempts += 1) == 12 }
+          expect(attempts).to be(12)
+        end
+
         it 'reloads until condition met' do
           allow(proc).to receive(:call).and_return(false,false, true)
           expect(load_operation).to receive(:call).exactly(2).times


### PR DESCRIPTION
Happy Friday! :wave: 

I noticed that passing `max_attempts: nil` to a resource didn't work like [these docs](https://github.com/aws/aws-sdk-ruby/blob/17508581a6887fb170e608242165b1ee18ccd9a9/aws-sdk-resources/lib/aws-sdk-resources/resource.rb#L65-L66) said. It only tried 10 times before raising `Aws::Waiters::Errors::TooManyAttemptsError`. :bug: :rotating_light: 

So I changed the code match the docs. :tada: :relieved: 

### Is there even a test???

You betcha. Of course it's weird to test that we actually attempt something indefinitely. So I just test that `wait_until(max_attempts: nil)` attempts more than 10 times.

### Could there be another way???

Instead of changing the code, we could change the docs to recommend passing `max_attempts: -1` or something instead. That can be a workaround until this is released. IMHO, using `nil` instead of `-1` to indicate "unlimited" seems more conventional for Rubyists.