### PR TITLE
Reword Waiter Documentation Template

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/api/docs/builder.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docs/builder.rb
@@ -159,11 +159,10 @@ module Aws
           end
           docstring = <<-DOCSTRING
   Returns the list of supported waiters. The following table lists the supported
-  waiters, the client method they call, the default delay between polling
-  attempts, and the default maximum number of polling attempts:
+  waiters and the client method they call:
   <table>
   <thead>
-  <tr><th>Waiter Name</th><th>Client Method</th><th>Delay</th><th>Max Attempts</th></tr>
+  <tr><th>Waiter Name</th><th>Client Method</th><th>Default Delay:</th><th>Default Max Attempts:</th></tr>
   </thead>
   <tbody>
   #{waiters}

--- a/aws-sdk-core/lib/aws-sdk-core/api/docs/builder.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docs/builder.rb
@@ -159,7 +159,8 @@ module Aws
           end
           docstring = <<-DOCSTRING
   Returns the list of supported waiters. The following table lists the supported
-  waiters and the client method they call:
+  waiters, the client method they call, the default delay between polling
+  attempts, and the default maximum number of polling attempts:
   <table>
   <thead>
   <tr><th>Waiter Name</th><th>Client Method</th><th>Delay</th><th>Max Attempts</th></tr>


### PR DESCRIPTION
Waiter docs show the default delay and max attempts, but it is ambiguous
that these are default values. Change wording to make this explicit.

Resolves issue #860