### PR TITLE
Create two additional waiters AppAvailable and InstanceProfileAvailable

### DIFF
--- a/aws-sdk-core/apis/iam/2010-05-08/waiters-2.json
+++ b/aws-sdk-core/apis/iam/2010-05-08/waiters-2.json
@@ -1,6 +1,23 @@
 {
   "version": 2,
   "waiters": {
+    "InstanceProfileAvailable": {
+      "delay": 15,
+      "operation": "GetInstanceProfile",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": 200,
+          "matcher": "status",
+          "state": "success"
+        },
+        {
+          "state": "retry",
+          "matcher": "status",
+          "expected": 404
+        }
+      ]
+    },
     "UserExists": {
       "delay": 1,
       "operation": "GetUser",

--- a/aws-sdk-core/apis/opsworks/2013-02-18/waiters-2.json
+++ b/aws-sdk-core/apis/opsworks/2013-02-18/waiters-2.json
@@ -1,6 +1,18 @@
 {
   "version": 2,
   "waiters": {
+    "AppAvailable": {
+      "delay": 15,
+      "operation": "DescribeApps",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "expected": 200,
+          "matcher": "status",
+          "state": "success"
+        }
+      ]
+    },
     "InstanceOnline": {
       "delay": 15,
       "operation": "DescribeInstances",


### PR DESCRIPTION
This creates 2 additional waiters:

- OpsWorks AppAvailable, to ensure an app is available before taking subsequent actions
- IAM InstanceProfileAvailable, to let you wait for an instance profile to be available 