### PR TITLE
Fix stubbing errors with 'query' protocol

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
@@ -11,6 +11,17 @@ module Aws
         end
 
         def stub_error(error_code)
+          http_resp = Seahorse::Client::Http::Response.new
+          http_resp.status_code = 400
+          http_resp.body = <<-XML.strip
+<ErrorResponse>
+  <Error>
+    <Code>#{error_code}</Code>
+    <Message>stubbed-response-error-message</Message>
+  </Error>
+</ErrorResponse>
+          XML
+          http_resp
         end
 
         private


### PR DESCRIPTION
I noticed this wasn't working:

```ruby
c = Aws::CloudFormation::Client.new(stub_responses: {validate_template: 'ValidationError'})
c.validate_template(template_body: '')
# => nil
```

The expected result is to raise an `Aws::CloudFormation::Errors::ValidationError`. :bug: :rotating_light: 

Turns out CloudFormation uses the [`query` protocol](https://github.com/aws/aws-sdk-ruby/blob/619378f0d2a2610e4c60cf794a116a3d87616da9/aws-sdk-core/apis/cloudformation/2010-05-15/api-2.json#L9), and the [`Aws::Stubbing::Protocols::Query#build_error` method was blank](https://github.com/aws/aws-sdk-ruby/blob/619378f0d2a2610e4c60cf794a116a3d87616da9/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb#L13-L14).

## YOLO?
I literally copied the method from [`RestXml#stub_error`](https://github.com/aws/aws-sdk-ruby/blob/619378f0d2a2610e4c60cf794a116a3d87616da9/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb#L17-L27). :scream_cat: There's probably a better way.

There are no tests. :no_good: 