### PR TITLE
Fix method name at queue_poller example

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/sqs/queue_poller.rb
@@ -150,7 +150,7 @@ module Aws
     #
     #     # stop after processing 100 messages
     #     poller.before_request do |stats|
-    #       throw :stop_polling if stats.receive_message_count >= 100
+    #       throw :stop_polling if stats.received_message_count >= 100
     #     end
     #
     #     poller.poll do |msg|


### PR DESCRIPTION
Small correction for SQS [QueuePoller](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/QueuePoller.html) documentation, at the example titled **Throw :stop_polling**.

It calls `stats.receive_message_count` instead of `stats.received_message_count`.