### PR TITLE
Add the "DeploymentSuccessful" waiter for commands and recipe executions

### DIFF
--- a/aws-sdk-core/apis/opsworks/2013-02-18/waiters-2.json
+++ b/aws-sdk-core/apis/opsworks/2013-02-18/waiters-2.json
@@ -18,6 +18,26 @@
         }
       ]
     },
+    "DeploymentSuccessful": {
+      "delay": 15,
+      "operation": "DescribeDeployments",
+      "maxAttempts": 40,
+      "description": "Wait until a deployment has completed successfully",
+      "acceptors": [
+        {
+          "expected": "successful",
+          "matcher": "pathAll",
+          "state": "success",
+          "argument": "Deployments[].Status"
+        },
+        {
+          "expected": "failed",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "Deployments[].Status"
+        }
+      ]
+    },
     "InstanceOnline": {
       "delay": 15,
       "operation": "DescribeInstances",


### PR DESCRIPTION
This adds a waiter to wait for successful deployment / command execution.