### PR TITLE
Include output parameter in S3 GetBucketLocation definition

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -110,7 +110,6 @@ module Aws
 
       api('s3') do |api|
         api['metadata'].delete('signatureVersion')
-        api['operations']['GetBucketLocation'].delete('output')
       end
 
       plugins('s3', add: %w(


### PR DESCRIPTION
## WHAT
Include `output` parameter in S3 GetBucketLocation (`Aws::S3::Client#get_bucket_location`) definition.
This fix enables us to stub response of `Aws::S3::Client#get_bucket_location`.

## WHY
At aws-sdk-core v2.1.14, I cannot stub response of `Aws::S3::Client#get_bucket_location`.

```ruby
# test code
      let(:hoge_location) do
        { location_constraint: "ap-northeast-1" }
      end

      before do
        client.stub_responses(:get_bucket_location, hoge_location)
      end
```

```bash
# test result
   Failure/Error: client.stub_responses(:get_bucket_location, hoge_location)
     ArgumentError:
       unexpected value at params[:location_constraint]
     # ./vendor/bundle/ruby/2.2.0/gems/aws-sdk-core-2.1.14/lib/aws-sdk-core/param_validator.rb:26:in `validate!'
...
```

By inspection on Pry, I found that GetBucketLocation output returns `EmptyStructure`. I think It may not be expected result...

```bash
$ pry -raws-sdk-core
[1] pry(main)> client = Aws::S3::Client.new
=> #<Aws::S3::Client>
[2] pry(main)> client.operation(:get_bucket_location).output
=> #<Seahorse::Model::Shapes::ShapeRef:0x007f88031bb060
 @deprecated=false,
 @metadata={},
 @required=false,
 @shape=
  #<Seahorse::Model::Shapes::StructureShape:0x007f88031bb308
   @members={},
   @members_by_location_name={},
   @metadata={"struct_class"=>Aws::EmptyStructure},
   @name="EmptyStructure",
   @required=#<Set: {}>>>
```