### PR TITLE
Update get_object examples

### DIFF
--- a/doc-src/examples/s3/client/get_object/01_download_an_object_to_disk.rb
+++ b/doc-src/examples/s3/client/get_object/01_download_an_object_to_disk.rb
@@ -1,6 +1,6 @@
 # stream object directly to disk
 resp = s3.get_object(
-  response_target: '/path/to/file',
+  target: '/path/to/file',
   bucket: 'bucket-name',
   key: 'object-key')
 

--- a/doc-src/examples/s3/client/get_object/02_download_object_into_memory.rb
+++ b/doc-src/examples/s3/client/get_object/02_download_object_into_memory.rb
@@ -1,4 +1,4 @@
-# omit :response_target to download to a StringIO in memory
+# omit :target to download to a StringIO in memory
 resp = s3.get_object(bucket: 'bucket-name', key: 'object-key')
 
 # call #read or #string on the response body


### PR DESCRIPTION
#### What does it do?
Updates example code for `get_object` API.
#### Any background context you want to provide?
When looking for how to save off a download to a specific file path, I searched the repo via Github for `get_object`. The examples provided a `response_target`, but when that didn't fly, I went googling and found Trevor's helpful post [here](https://ruby.awsblog.com/post/Tx354Y6VTZ421PJ/Downloading-Objects-from-Amazon-S3-using-the-AWS-SDK-for-Ruby), that points you to `target` instead. Then, magical success. Updating so future folks can skip a step.