### PR TITLE
Fix Aws::PageableResponse to correctly answer `respond_to?` with methods different than #count.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Issue - Aws::PageableResponse::UnsafeEnumerableMethods - `respond_to?`
+  was not being forwarded to ancestors and it was always retuning `false`
+  except for #count.
+
 2.1.15 (2015-08-20)
 ------------------
 

--- a/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -134,7 +134,7 @@ module Aws
         if method_name == :count
           data.respond_to?(:count)
         else
-          false
+          super
         end
       end
 

--- a/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -206,7 +206,7 @@ module Aws
         expect(page.respond_to?(:count))
       end
 
-      it 'correctly answers respond_to? with methods differenc than #count' do
+      it 'correctly answers respond_to? with methods different than #count' do
         data = double('data', foo: 'bar')
         resp = Seahorse::Client::Response.new(data:data)
         page = pageable(resp, pager)

--- a/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -206,6 +206,13 @@ module Aws
         expect(page.respond_to?(:count))
       end
 
+      it 'correctly answers respond_to? with methods differenc than #count' do
+        data = double('data', foo: 'bar')
+        resp = Seahorse::Client::Response.new(data:data)
+        page = pageable(resp, pager)
+        expect(page.respond_to?(:foo)).to be(true)
+      end
+
     end
   end
 end


### PR DESCRIPTION
`Aws::PageableResponse::UnsafeEnumerableMethods` is not forwarding `respond_to?` to its ancestors (using `super`) and it's always retuning `false` (except for #count). It breaks `Searhorse::Client::Response#respond_to?`:

```ruby
response # Aws::DynamoDB::Types::QueryOutput
response.respond_to?(:items) # => false
```
