### PR TITLE
Fix storage class setting on PresignedPost

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
@@ -444,7 +444,7 @@ module Aws
       #   configuration.
       #   @param [String] value Storage class to use for storing the
       #   @return [self]
-      define_field(:storage_class)
+      define_field(:storage_class, 'x-amz-storage-class')
 
       # @!method website_redirect_location(value)
       #   If the bucket is configured as a website,

--- a/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
@@ -258,7 +258,12 @@ eyAiZXhwaXJhdGlvbiI6ICIyMDEzLTA4LTA3VDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6
           expect(post.fields['x-amz-security-token']).to eq('token')
           expect(policy(post)).to include('x-amz-security-token' => 'token')
         end
-
+        
+        it 'sets the storage class if requested' do
+          creds = Credentials.new('key', 'secret', 'token')
+          post = PresignedPost.new(creds, region, bucket).key('key').storage_class('REDUCED_REDUNDANCY')
+          expect(post.fields['x-amz-storage-class']).to eq('REDUCED_REDUNDANCY')
+        end
       end
     end
   end


### PR DESCRIPTION
Previously storage_class would be passed as a vanilla form field
which would be ignored by S3. The field should be passed as an
"x-amz-storage-class" which requires a minimal change in the
class descriptor. Once the field is set, the storage class is
properly set on the POSTed object.