### PR TITLE
Don't enforce 1 week limit on presigned urls.

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
@@ -11,9 +11,6 @@ module Aws
     class Presigner
 
       # @api private
-      ONE_WEEK = 60 * 60 * 24 * 7
-
-      # @api private
       FIFTEEN_MINUTES = 60 * 15
 
       # @option options [Client] :client Optionally provide an existing
@@ -63,10 +60,6 @@ module Aws
 
       def expires_in(params)
         if expires_in = params.delete(:expires_in)
-          if expires_in > ONE_WEEK
-            msg = "expires_in value of #{expires_in} exceeds one-week maximum"
-            raise ArgumentError, msg
-          end
           expires_in
         else
           FIFTEEN_MINUTES

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -75,20 +75,6 @@ module Aws
           expect(actual_url).to eq(expected_url)
         end
 
-        it 'raises when expires_in length is over 1 week' do
-          bucket = "examplebucket"
-          key = "test.txt"
-          pre = Presigner.new(client: client)
-          params = {
-            bucket: bucket,
-            key: key,
-            expires_in: (7 * 86400) + 1
-          }
-          expect {
-            pre.presigned_url(:get_object, params)
-          }.to raise_error(ArgumentError)
-        end
-
         it 'can generate http (non-secure) urls' do
           signer = Presigner.new(client: client)
           url = signer.presigned_url(:get_object,


### PR DESCRIPTION
We have run into this restriction while updating from v1 version of the gem.
