### PR TITLE
Accept #to_str attributes as Strings in dynamodb

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -21,6 +21,7 @@ module Aws
       end
 
       class Marshaler
+        STRINGY_TEST = lambda { |val| val.respond_to?(:to_str) }
 
         def format(obj)
           case obj
@@ -34,6 +35,7 @@ module Aws
             end
           when String then { s: obj }
           when Symbol then { s: obj.to_s }
+          when STRINGY_TEST then { s: obj.to_str }
           when Numeric then { n: obj.to_s }
           when StringIO, IO then { b: obj }
           when Set then format_set(obj)
@@ -51,6 +53,7 @@ module Aws
         def format_set(set)
           case set.first
           when String, Symbol then { ss: set.map(&:to_s) }
+          when STRINGY_TEST then { ss: set.map(&:to_str) }
           when Numeric then { ns: set.map(&:to_s) }
           when StringIO, IO then { bs: set.to_a }
           else

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -42,6 +42,20 @@ module Aws
           expect(formatted).to eq(ss: %w(abc mno))
         end
 
+        it 'converts objects sets responding to #to_str to :ss (string set)' do
+          stringy_class = Class.new do
+            attr_reader :val
+            alias :to_str :val
+
+            def initialize(val)
+              @val = val
+            end
+          end
+          set = Set.new([stringy_class.new("abc"), stringy_class.new("mno")])
+          formatted = value.marshal(set)
+          expect(formatted).to eq(ss: %w(abc mno))
+        end
+
         it 'converts numeric sets to :ns (number set)' do
           formatted = value.marshal(Set.new([123, 456]))
           expect(formatted).to eq(ns: %w(123 456))
@@ -66,6 +80,11 @@ module Aws
 
         it 'converts symbol to :s' do
           expect(value.marshal(:abc)).to eq(s: 'abc')
+        end
+
+        it 'converts objects responding to #to_str to :s' do
+          obj = Class.new { def to_str; 'abc' end }.new
+          expect(value.marshal(obj)).to eq(s: 'abc')
         end
 
         it 'converts booleans :bool' do


### PR DESCRIPTION
Unlike #to_s, #to_str is only implemented by classes that act like
strings. This change allows user-defined classes which provide that
conversion to be used directly by dynamodb clients and be treated as
String attributes.

For example, users may define a class which is a composite of two or
more values which are stored as a single String in dynamodb, and pass
instances of that class into dynamodb clients without need for explicit
conversion.