### PR TITLE
Ensure that file is open prior to reading from it

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_md5s.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_md5s.rb
@@ -35,6 +35,9 @@ module Aws
 
         def md5(body)
           md5 = OpenSSL::Digest::MD5.new
+
+          ensure_open(body)
+
           while chunk = body.read(OneMB)
             md5.update(chunk)
           end
@@ -42,6 +45,11 @@ module Aws
           Base64.encode64(md5.digest).strip
         end
 
+        def ensure_open(io)
+          if io.respond_to? :closed?
+            io.open if io.closed?
+          end
+        end
       end
 
       option(:compute_checksums, true)


### PR DESCRIPTION
Fixes an issue where `Aws::Plugins::S3Md5s::Handler.md5` would crash upon receiving a closed file.

We're not sure whether this is aws-sdk-ruby's responsibility, but seeing as how `body` is treated very much like a file (we're calling `read` and `rewind` on it already) it seems sensible to check that it's actually open prior to reading from it.

Fixes https://github.com/refile/refile-s3/issues/10