### PR TITLE
SigV4 as Default for All Amazon S3 Calls

### DIFF
--- a/aws-sdk-core/features/s3/step_definitions.rb
+++ b/aws-sdk-core/features/s3/step_definitions.rb
@@ -14,7 +14,9 @@ After("@s3") do
       break if objects.empty?
       @client.delete_objects(bucket: bucket, delete: { objects: objects })
     end
+    puts "MADE IT TO DELETING BUCKET"
     @client.delete_bucket(bucket: bucket)
+    puts "DELETED BUCKET"
   end
 end
 

--- a/aws-sdk-core/features/s3/step_definitions.rb
+++ b/aws-sdk-core/features/s3/step_definitions.rb
@@ -14,9 +14,7 @@ After("@s3") do
       break if objects.empty?
       @client.delete_objects(bucket: bucket, delete: { objects: objects })
     end
-    puts "MADE IT TO DELETING BUCKET"
     @client.delete_bucket(bucket: bucket)
-    puts "DELETED BUCKET"
   end
 end
 

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
@@ -45,7 +45,7 @@ module Aws
         def new_hostname(context, region)
           bucket = context.params[:bucket]
           if region == 'us-east-1'
-            "#{bucket}.s3-external-1.amazonaws.com"
+            "#{bucket}.s3.amazonaws.com"
           else
             bucket + '.' + URI.parse(EndpointProvider.resolve(region, 's3')).host
           end

--- a/aws-sdk-core/spec/aws/s3/client_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client_spec.rb
@@ -102,37 +102,6 @@ module Aws
           "sa-east-1",
           "eu-west-1",
           "us-gov-west-1",
-        ].each do |region|
-
-          it "defaults signature version 4 for #{region}" do
-            client = Client.new(stub_responses: true, region: region)
-            resp = client.head_object(bucket:'name', key:'key')
-            expect(resp.context.http_request.headers['authorization']).to match(
-              'AWS4-HMAC-SHA256')
-          end
-
-          it "falls back on classic S3 signing for #put_object in #{region}" do
-            client = Client.new(stub_responses: true, region: region)
-            resp = client.put_object(bucket:'name', key:'key', body:'data')
-            expect(resp.context.http_request.headers['authorization']).to match(
-              'AWS akid:')
-          end
-
-          it "forces v4 signing when aws:kms used for server side encryption" do
-            client = Client.new(stub_responses: true, region: region)
-            resp = client.put_object(
-              bucket: 'name',
-              key: 'key',
-              server_side_encryption: 'aws:kms',
-              body: 'data'
-            )
-            expect(resp.context.http_request.headers['authorization']).to match(
-              'AWS4-HMAC-SHA256')
-          end
-
-        end
-
-        [
           "cn-north-1",
           "eu-central-1",
           "unknown-region",
@@ -165,14 +134,7 @@ module Aws
           end
         end
 
-        it "defaults classic s3 signature us-east-1" do
-          client = Client.new(stub_responses: true, region: 'us-east-1')
-          resp = client.head_object(bucket:'name', key:'key')
-          expect(resp.context.http_request.headers['authorization']).to match(
-            'AWS akid:')
-        end
-
-        it "upgrades to signature version 4 when aws:kms used for sse" do
+        it "uses signature version 4 when aws:kms used for sse" do
           client = Client.new(stub_responses: true, region: 'us-east-1')
           resp = client.put_object(
             bucket: 'name',


### PR DESCRIPTION
Remove hacks that supported 'S3 Signer' default for many common code
paths. Now, SigV4 is always the default and special fallback logic is
removed.

You can still use the legacy signer, without special fallbacks, by
specifying the signature version in your client:
`client = Aws::S3::Client.new(signature_version: 's3')`

Resolves issue #949 and may be related to issue #965 