### PR TITLE
Fix InstanceExists Waiter

### DIFF
--- a/aws-sdk-core/apis/ec2/2015-10-01/waiters-2.json
+++ b/aws-sdk-core/apis/ec2/2015-10-01/waiters-2.json
@@ -7,8 +7,9 @@
       "operation": "DescribeInstances",
       "acceptors": [
         {
-          "matcher": "status",
-          "expected": 200,
+          "matcher": "path",
+          "expected": true,
+          "argument": "length(Reservations[]) > `0`",
           "state": "success"
         },
         {


### PR DESCRIPTION
Instead of checking just the status of DescribeInstances operation from aws, we should check if the reservations list have length > 0.