### PR TITLE
Add support for source_profile and role_arn

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -74,10 +74,10 @@ module Aws
     def load_from_path
       profile = load_profile
       credentials = Credentials.new(
-          profile['aws_access_key_id'],
-          profile['aws_secret_access_key'],
-          profile['aws_session_token']
-        )
+        profile['aws_access_key_id'],
+        profile['aws_secret_access_key'],
+        profile['aws_session_token']
+      )
       @credentials = if profile['role_arn']
                         AssumeRoleCredentials.new(
                           role_arn: profile['role_arn'],
@@ -93,6 +93,7 @@ module Aws
       if profile['source_profile']
         profile = load_named_profile(profile['source_profile']).merge(profile)
       end
+      profile
     end
 
     def load_named_profile(name)

--- a/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -36,7 +36,13 @@ module Aws
     attr_reader :profile_name
 
     # @return [Credentials]
-    attr_reader :credentials
+    def credentials
+      if @credentials.respond_to?(:credentials)
+        @credentials.credentials
+      else
+        @credentials
+      end
+    end
 
     # @api private
     def inspect

--- a/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -44,6 +44,14 @@ module Aws
       expect(creds.session_token).to eq('TOKEN_1')
     end
 
+    it 'supports fetching a source_profile' do
+      stub_const('ENV', { 'AWS_PROFILE' => 'childprofile' })
+      creds = SharedCredentials.new(path:mock_credential_file).credentials
+      expect(creds.access_key_id).to eq('ACCESS_KEY_1')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_1')
+      expect(creds.session_token).to eq('TOKEN_3')
+    end
+
     it 'raises when a profile does not exist' do
       msg = /^Profile `bazprofile' not found in .+mock_shared_credentials/
       expect {

--- a/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
+++ b/aws-sdk-core/spec/fixtures/credentials/mock_shared_credentials
@@ -12,3 +12,7 @@ aws_session_token = TOKEN_1
 aws_access_key_id = ACCESS_KEY_2
 aws_secret_access_key = SECRET_KEY_2
 aws_session_token = TOKEN_2
+
+[childprofile]
+source_profile = fooprofile
+aws_session_token = TOKEN_3


### PR DESCRIPTION
Hello Friends, 

This PR adds initial support to aws-sdk-core for nested profiles using `source_profile` as well as assume role using `role_arn` when using a `.aws/credentials` file. 

To be honest, I'm not 100% familiar with the various ways that Credentials objects are used within this code base, so I've tried to make this as non-intrusive as possible.