### PR TITLE
provide sane defaults for the CredentialProviderChain

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -2,7 +2,7 @@ module Aws
   # @api private
   class CredentialProviderChain
 
-    def initialize(config)
+    def initialize(config = nil)
       @config = config
     end
 
@@ -32,6 +32,7 @@ module Aws
 
     def static_credentials(options)
       config = options[:config]
+      return nil if config.nil?
       Credentials.new(
         config.access_key_id,
         config.secret_access_key,
@@ -54,7 +55,8 @@ module Aws
       nil
     end
 
-    def shared_credentials(options = {})
+    def shared_credentials(options)
+      return nil if options[:config].nil?
       SharedCredentials.new(profile_name: options[:config].profile)
     rescue Errors::NoSuchProfileError
       nil

--- a/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -114,6 +114,14 @@ module Aws
       expect(credentials.session_token).to eq('token')
     end
 
+    describe 'with config set to nil' do
+      let(:config) { nil }
+
+      it 'defaults to nil' do
+        expect(credentials).to be(nil)
+      end
+
+    end
     describe 'with shared credentials' do
 
       let(:path) { File.join('HOME', '.aws', 'credentials') }


### PR DESCRIPTION
I'm working on writing some code for aws and I would like to utilize the credential provider chain so my code can Just Work™ based on the logic in the chain.

The `CredentialProviderChain` class currently [requires a `config` object](https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb#L5) to be passed to it during initialization, and the function of that config object is not clear. [Even the spec](https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb#L8-L15) just stubs out the config with empty values. The only place this class is currently used in the sdk is [in the request_signer plugin](https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb) and it seems to be passing the `Seahorse::Client::Configuration` object through.

It seems like the reason it's accepting an argument is so you can have pre-configured static credentials that it will simply return back to you. This is fine, but the case of not having static credentials and wanting the chain to go on and provide its own credentials is a confusing one. It's not very clear what I need to pass the constructor to make it go on, and my initial intuitive option (nil, or just no argument at all) fails.