### PR TITLE
Remove deprecation warning in S3::Bucket#clear!

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
@@ -12,7 +12,7 @@ module Aws
       #
       # @return [void]
       def clear!
-        object_versions.delete
+        object_versions.batch_delete!
       end
 
       # Deletes all objects and versioned objects from this bucket and


### PR DESCRIPTION
Since `#delete` has been renamed to `#batch_delete!`, we should also update `#clear!` to not issue deprecation warnings.