### PR TITLE
Allow region to be specified in shared credentials file

### DIFF
--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -467,12 +467,16 @@ module AWS
 
       add_option :session_token
 
+      add_option :path
+
+      add_option :profile_name
+
       add_option :region do |cfg,region|
         region || cfg.credential_provider.credentials[:region] || ENV['AWS_REGION'] || ENV['AMAZON_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
       end
 
       add_option_with_needs :credential_provider,
-        [:access_key_id, :secret_access_key, :session_token] do |cfg,static_creds|
+        [:access_key_id, :secret_access_key, :session_token, :path, :profile_name] do |cfg,static_creds|
 
         CredentialProviders::DefaultProvider.new(static_creds)
 

--- a/lib/aws/core/configuration.rb
+++ b/lib/aws/core/configuration.rb
@@ -468,7 +468,7 @@ module AWS
       add_option :session_token
 
       add_option :region do |cfg,region|
-        region || ENV['AWS_REGION'] || ENV['AMAZON_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+        region || cfg.credential_provider.credentials[:region] || ENV['AWS_REGION'] || ENV['AMAZON_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
       end
 
       add_option_with_needs :credential_provider,

--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -113,19 +113,28 @@ module AWS
         include Provider
 
         # (see StaticProvider#new)
+        # (see SharedCredentialFileProvider#new)
         def initialize static_credentials = {}
           @providers = []
-          @providers << StaticProvider.new(static_credentials)
+          # Avoid failures due to StaticProvider being picky abouts its options.
+          @providers << StaticProvider.new(
+            :access_key_id => options[:access_key_id],
+            :secret_access_key => options[:secret_access_key],
+            :session_token => options[:session_token],
+          )
           @providers << ENVProvider.new('AWS')
           @providers << ENVProvider.new('AWS', :access_key_id => 'ACCESS_KEY', :secret_access_key => 'SECRET_KEY', :session_token => 'SESSION_TOKEN')
           @providers << ENVProvider.new('AMAZON')
           begin
             if Dir.home
-              @providers << SharedCredentialFileProvider.new(static_credentials)
+              @providers << SharedCredentialFileProvider.new(
+                :path => options[:path],
+                :profile_name => options[:profile_name],
+              )
             end
           rescue ArgumentError, NoMethodError
           end
-          @providers << EC2Provider.new(static_credentials)
+          @providers << EC2Provider.new
         end
 
         # @return [Array<Provider>]

--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -121,11 +121,11 @@ module AWS
           @providers << ENVProvider.new('AMAZON')
           begin
             if Dir.home
-              @providers << SharedCredentialFileProvider.new
+              @providers << SharedCredentialFileProvider.new(static_credentials)
             end
           rescue ArgumentError, NoMethodError
           end
-          @providers << EC2Provider.new
+          @providers << EC2Provider.new(static_credentials)
         end
 
         # @return [Array<Provider>]
@@ -284,6 +284,7 @@ module AWS
           "aws_access_key_id" => :access_key_id,
           "aws_secret_access_key" => :secret_access_key,
           "aws_session_token" => :session_token,
+          "region" => :region,
         }
 
         # @option [String] :path


### PR DESCRIPTION
Pass options to all the credential providers so the user can choose which
profile they want from their shared credentials file.

Allos that shared credential file to also specify the region associated with
each profile.

Update AWS client configuration to read region from the credential provider in
addition to all its normal places.