### PR TITLE
Fix typo in client_stubs documentation

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -57,7 +57,7 @@ module Aws
     #
     #     Aws.config[:s3] = {
     #       stub_responses: {
-    #         list_buckets: { bukets: [{name: 'my-bucket' }] }
+    #         list_buckets: { buckets: [{name: 'my-bucket' }] }
     #       }
     #     }
     #


### PR DESCRIPTION
Small typo in client_stubs documentation.

:star2: :star: 