### PR TITLE
Apply :endpoint option to Bucket#presigned_post

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
@@ -93,7 +93,8 @@ module Aws
           client.config.credentials,
           client.config.region,
           name,
-          options)
+          {url: url}.merge(options)
+        )
       end
 
       # @api private

--- a/aws-sdk-resources/spec/services/s3/bucket_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/bucket_spec.rb
@@ -5,12 +5,20 @@ module Aws
     class Bucket
       describe '#presigned_post' do
 
-        let(:object) { Bucket.new('bucket', stub_responses: true) }
+        def bucket(options = {})
+          options[:stub_responses] ||= true
+          Bucket.new('bucket', options)
+        end
 
         it 'creates a presigned post without a key' do
-          post = object.presigned_post(key: 'foo', acl: 'public-read')
+          post = bucket.presigned_post(key: 'foo', acl: 'public-read')
           expect(post.fields['key']).to eq('foo')
           expect(post.fields['acl']).to eq('public-read')
+        end
+
+        it 'applies the :endpoint option' do
+          post = bucket(endpoint: 'http://foo.com').presigned_post(key: 'foo')
+          expect(post.url).to eq('http://bucket.foo.com')
         end
 
       end


### PR DESCRIPTION
`Object#presigned_post` properly passes the bucket's url (which is affected by the `:endpoint` option), so to keep consistency we make `Bucket#presigned_post` pass it as well.