### PR TITLE
Fix Presigner not respecting :endpoint URL scheme

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
@@ -54,7 +54,11 @@ module Aws
       private
 
       def http_scheme(params, virtual_host)
-        if params.delete(:secure) == false || virtual_host
+        secure = params.delete(:secure)
+
+        if @client.config.endpoint.host != "s3.amazonaws.com"
+          @client.config.endpoint.scheme
+        elsif secure == false || virtual_host
           'http'
         else
           'https'

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -99,6 +99,16 @@ module Aws
           expect(url).to match(/^http:/)
         end
 
+        it 'uses the correct :endpoint scheme' do
+          client.config.endpoint = URI("http://example.com")
+          signer = Presigner.new(client: client)
+          url = signer.presigned_url(:get_object,
+            bucket:'aws-sdk',
+            key:'foo',
+          )
+          expect(url).to match(/^http:/)
+        end
+
       end
     end
   end


### PR DESCRIPTION
When presigned URL is generated for a client which has `:endpoint`, the URL scheme was always "https", even when the `:endpoint` had "http" scheme.