### PR TITLE
Adding support for AES/GCM/NoPadding

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
@@ -38,11 +38,35 @@ module Aws
           context.http_response.on_headers(200) do
             cipher = decryption_cipher(context)
             body = context.http_response.body
-            context.http_response.body = IODecrypter.new(cipher, body)
+            if context.http_response.headers['x-amz-meta-x-amz-tag-len']
+              # we'll need to get the entire body before decrypting
+              context.http_response.body = IODecrypter.new(cipher, body, contains_tag = true)
+            else
+              context.http_response.body = IODecrypter.new(cipher, body, contains_tag = false)
+            end
+
           end
 
           context.http_response.on_success(200) do
             decrypter = context.http_response.body
+
+            # if present, we'll need to authenticate the ciphertext
+            if context.http_response.headers['x-amz-meta-x-amz-tag-len']
+              auth_tag_len = context.http_response.headers['x-amz-meta-x-amz-tag-len'].to_i
+              decrypter.io.seek((decrypter.io.size - (auth_tag_len/8)))
+              auth_tag = decrypter.io.read
+              decrypter.cipher.auth_tag = auth_tag
+              decrypter.cipher.auth_data = ''
+              decrypter.io.truncate((decrypter.io.size - (auth_tag_len/8)))
+              decrypter.io.rewind if decrypter.io.respond_to?(:rewind)
+              # read back in the encrypted data
+              content = decrypter.io.read
+              decrypter.io.truncate(0)
+              decrypter.io.rewind if decrypter.io.respond_to?(:rewind)
+              # reprocess, decrypting data and authenticating ciphertext
+              decrypter.contains_tag = false
+              decrypter.write(content)
+            end
             decrypter.finalize
             decrypter.io.rewind if decrypter.io.respond_to?(:rewind)
             context.http_response.body = decrypter.io

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
@@ -22,6 +22,11 @@ module Aws
 
         POSSIBLE_ENVELOPE_KEYS = (V1_ENVELOPE_KEYS + V2_ENVELOPE_KEYS).uniq
 
+        POSSIBLE_ENCRYPTION_FORMATS = %w(
+          AES/GCM/NoPadding
+          AES/CBC/PKCS5Padding
+        )
+
         def call(context)
           attach_http_event_listeners(context)
           @handler.call(context)
@@ -103,7 +108,7 @@ module Aws
         end
 
         def v2_envelope(envelope)
-          unless envelope['x-amz-cek-alg'] == 'AES/CBC/PKCS5Padding'
+          unless POSSIBLE_ENCRYPTION_FORMATS.include? envelope['x-amz-cek-alg']
             alg = envelope['x-amz-cek-alg'].inspect
             msg = "unsupported content encrypting key (cek) format: #{alg}"
             raise Errors::DecryptionError, msg

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
@@ -64,7 +64,7 @@ module Aws
               decrypter.io.truncate(0)
               decrypter.io.rewind if decrypter.io.respond_to?(:rewind)
               # reprocess, decrypting data and authenticating ciphertext
-              decrypter.contains_tag = false
+              decrypter.has_tag = false
               decrypter.write(content)
             end
             decrypter.finalize

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
@@ -6,18 +6,18 @@ module Aws
 
         # @param [OpenSSL::Cipher] cipher
         # @param [#write] io An IO-like object that responds to {#write}.
-        def initialize(cipher, io, contains_tag = false)
+        def initialize(cipher, io, has_tag = false)
           @orig_cipher = cipher.clone
           @cipher = cipher.clone
           @io = io
-          @has_tag = contains_tag
+          @has_tag = has_tag
           reset_cipher
         end
 
         # @return [#write]
         attr_reader :io
         attr_reader :cipher
-        attr_writer :contains_tag
+        attr_writer :has_tag
 
         def write(chunk)
           unless @has_tag

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
@@ -6,18 +6,27 @@ module Aws
 
         # @param [OpenSSL::Cipher] cipher
         # @param [#write] io An IO-like object that responds to {#write}.
-        def initialize(cipher, io)
+        def initialize(cipher, io, contains_tag = false)
           @orig_cipher = cipher.clone
           @cipher = cipher.clone
           @io = io
+          @contains_tag = contains_tag
           reset_cipher
         end
 
         # @return [#write]
         attr_reader :io
+        attr_reader :cipher
+        attr_writer :has_tag
 
         def write(chunk)
-          @io.write(@cipher.update(chunk))
+          unless @contains_tag
+            # decrypt and write
+            @io.write(@cipher.update(chunk))
+          else
+            # write encrypted data
+            @io.write(chunk)
+          end
         end
 
         def finalize

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/io_decrypter.rb
@@ -10,7 +10,7 @@ module Aws
           @orig_cipher = cipher.clone
           @cipher = cipher.clone
           @io = io
-          @contains_tag = contains_tag
+          @has_tag = contains_tag
           reset_cipher
         end
 
@@ -20,7 +20,7 @@ module Aws
         attr_writer :has_tag
 
         def write(chunk)
-          unless @contains_tag
+          unless @has_tag
             # decrypt and write
             @io.write(@cipher.update(chunk))
           else

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/kms_cipher_provider.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/kms_cipher_provider.rb
@@ -25,7 +25,7 @@ module Aws
           envelope = {
             'x-amz-key-v2' => encode64(key_data.ciphertext_blob),
             'x-amz-iv' => encode64(cipher.iv = cipher.random_iv),
-            'x-amz-cek-alg' => 'AES/CBC/PKCS5Padding', #TODO allow selection
+            'x-amz-cek-alg' => 'AES/CBC/PKCS5Padding',
             'x-amz-wrap-alg' => 'kms',
             'x-amz-matdesc' => Json.dump(encryption_context)
           }

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/kms_cipher_provider.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/kms_cipher_provider.rb
@@ -25,7 +25,7 @@ module Aws
           envelope = {
             'x-amz-key-v2' => encode64(key_data.ciphertext_blob),
             'x-amz-iv' => encode64(cipher.iv = cipher.random_iv),
-            'x-amz-cek-alg' => 'AES/CBC/PKCS5Padding',
+            'x-amz-cek-alg' => 'AES/CBC/PKCS5Padding', #TODO allow selection
             'x-amz-wrap-alg' => 'kms',
             'x-amz-matdesc' => Json.dump(encryption_context)
           }
@@ -41,7 +41,18 @@ module Aws
             encryption_context: encryption_context,
           ).plaintext
           iv = decode64(envelope['x-amz-iv'])
-          Utils.aes_decryption_cipher(:CBC, key, iv)
+          type = envelope['x-amz-cek-alg'] || false
+          block_mode = :CBC #default to CBC
+          case type
+            when 'AES/CBC/PKCS5Padding'
+              block_mode = :CBC
+            when 'AES/GCM/NoPadding'
+              block_mode = :GCM
+            else
+              msg = "unsupported content encrypting key (cek) format: #{type}"
+              raise Errors::DecryptionError, msg
+          end
+          Utils.aes_decryption_cipher(block_mode, key, iv)
         end
 
         private

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/utils.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/utils.rb
@@ -57,8 +57,8 @@ module Aws
           # @param [String, nil] iv The initialization vector
           def aes_cipher(mode, block_mode, key, iv)
             cipher = key ?
-              OpenSSL::Cipher.new("AES-#{cipher_size(key)}-#{block_mode}") :
-              OpenSSL::Cipher.new("AES-256-#{block_mode}")
+              OpenSSL::Cipher.new("aes-#{cipher_size(key)}-#{block_mode.downcase}") :
+              OpenSSL::Cipher.new("aes-256-#{block_mode.downcase}")
             cipher.send(mode) # encrypt or decrypt
             cipher.key = key if key
             cipher.iv = iv if iv

--- a/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
@@ -384,7 +384,7 @@ module Aws
           end
         end
 
-        describe 'kms' do
+        describe 'kms_CBC' do
 
           let(:kms_client) { KMS::Client.new(stub_responses:true) }
 
@@ -432,11 +432,49 @@ module Aws
             expect(Base64.encode64(resp.context.http_request.body_contents)).to eq("4FAj3kTOIisQ+9b8/kia8g==\n")
           end
 
-          it 'supports decryption via KMS' do
+          it 'supports decryption via KMS w/ CBC' do
             kms_client.stub_responses(:decrypt, plaintext: plaintext_object_key)
             client.client.stub_responses(:get_object, {
               body: Base64.decode64("4FAj3kTOIisQ+9b8/kia8g==\n"),
               metadata: envelope
+            })
+            resp = client.get_object(bucket:'aws-sdk', key:'foo')
+            expect(resp.body.read).to eq('plain-text')
+          end
+
+        end
+
+        describe 'kms_GCM' do
+
+          let(:kms_client) { KMS::Client.new(stub_responses:true) }
+
+          let(:client) do
+            Encryption::Client.new({
+                                       kms_key_id: 'kms-key-id',
+                                       kms_client: kms_client,
+                                       stub_responses: true,
+                                   })
+          end
+
+          let(:headers) {{
+              "x-amz-meta-x-amz-wrap-alg" => "kms",
+              "x-amz-meta-x-amz-cek-alg" => "AES/GCM/NoPadding",
+              "x-amz-meta-x-amz-iv" => "XujE1oWCO83rw1PU",
+              "x-amz-meta-x-amz-key-v2" => Base64.strict_encode64("encrypted-object-key"),
+              "x-amz-meta-x-amz-matdesc" => "{\"kms_cmk_id\":\"kms-key-id\"}",
+              "x-amz-meta-x-amz-tag-len" => "128"
+          }}
+
+          let(:plaintext_object_key) {
+            "\xACb.\xEB\x16\x19(\x9AJ\xE0uCA\x034z\xF6&\x7F\x8E\x0E\xC0\xD5\x1A\x88\xAF2\xB1\xEEg#\x15"
+          }
+
+          it 'supports decryption via KMS w/ GCM' do
+            kms_client.stub_responses(:decrypt, plaintext: plaintext_object_key)
+            client.client.stub_responses(:get_object, {
+                body: Base64.decode64("ZpPUtKX0PPupGaE0o7FbJw2Ov53MXfqenLA="),
+                headers: headers,
+                status_code: 200
             })
             resp = client.get_object(bucket:'aws-sdk', key:'foo')
             expect(resp.body.read).to eq('plain-text')


### PR DESCRIPTION
Adds support for AES/GCM/NoPadding and uses the auth_tag from the end of the ciphertext to authenticate the complete ciphertext when `cipher.final` is called in the code.  Should also add additional flexibility to add further formats in the future if necessary.

Presence of an auth tag is detected via `x-amz-meta-x-amz-tag-len` being present in the response headers.  Unencrypted data is then written to the IO Object (vs unencrypting on .write without auth tag) to obtain the auth tag from the last `x-amz-meta-x-amz-tag-len` bits of the ciphertext. The IO Object is then truncated to remove the auth tag and then re-processed and decrypted after setting the `cipher.auth_tag` and `cipher.auth_data=''` on the cipher (order of operations is critical).  When `cipher.final` is called, OpenSSL authenticates the ciphertext and returns.

Currently lacks tests, but was locally tested with and without a target_response to test the different IO classes that are used.  Would like to get tests written, but wanted to get this in front of people first.

**Simple Example Usage**
```ruby
# pass in the kms_key_id, bucket, object_key, and target
s3encrypt = Aws::S3::Encryption::Client.new(kms_key_id: kms_key_id)
s3encrypt.get_object(bucket:bucket, key:object_key, response_target: target)
```