### PR TITLE
Include additional errors in the list of retryable network errors.

### DIFF
--- a/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -18,7 +18,8 @@ module Seahorse
         NETWORK_ERRORS = [
           SocketError, EOFError, IOError, Timeout::Error,
           Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
-          Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError
+          Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError,
+          Errno::EHOSTUNREACH, Errno::ECONNREFUSED
         ]
 
         # @api private


### PR DESCRIPTION
Both host unreachable and connection refused are possible transient network errors.