### PR TITLE
addressed #1053, us-west-1 was hardcoded

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb
@@ -49,8 +49,11 @@ module Aws
 
       option(:sigv4_region) do |cfg|
         prefix = cfg.api.metadata['endpointPrefix']
+
         if cfg.endpoint.to_s.match(/#{prefix}\.amazonaws\.com/)
-          'us-east-1'
+          'us-east-1' if cfg.endpoint.to_s.include? 'us-east-1'
+          'ap-northeast-1' if cfg.endpoint.to_s.include? 'ap-northeast-1'
+          'eu-west-1' if cfg.endpoint.to_s.include? 'eu-west-1'          
         else
           cfg.region
         end


### PR DESCRIPTION
i had an issue with yesterdays fix. 

the option(:sigv4_region) was returning us-west-1 and this hardcoded fix didn't work for me. i have pushed a fix that allows different regions (depending on the region included in the endpoint)