### PR TITLE
Cleanup warnings

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
@@ -101,11 +101,6 @@ module Aws
           list
         end
 
-        def querystring_param(key, value)
-          param_name = member.location_name
-          param_value = params[member_name]
-        end
-
         def escape(string)
           Seahorse::Util.uri_escape(string)
         end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/bucket.rb
@@ -41,7 +41,7 @@ module Aws
         begin
           clear!
           delete
-        rescue Errors::BucketNotEmpty => error
+        rescue Errors::BucketNotEmpty
           attempts += 1
           if attempts >= options[:max_attempts]
             raise


### PR DESCRIPTION
This PR removes an unused variable and an unused method (that assigned two unused variables). I'm using the gem in a project that has warnings turned on and Ruby 2.0 was complaining:

/var/lib/gems/2.0.0/gems/aws-sdk-resources-2.2.9/lib/aws-sdk-resources/services/s3/bucket.rb:44: warning: assigned but unused variable - error

/var/lib/gems/2.0.0/gems/aws-sdk-core-2.2.9/lib/aws-sdk-core/rest/request/endpoint.rb:105: warning: assigned but unused variable - param_name
/var/lib/gems/2.0.0/gems/aws-sdk-core-2.2.9/lib/aws-sdk-core/rest/request/endpoint.rb:106: warning: assigned but unused variable - param_value

I have a few more warnings to work through, but going to do in a followup PR in order to keep these small and clean.