### PR TITLE
Resolved an issue with EC2 request ids.

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
@@ -11,8 +11,11 @@ module Aws
 
           def parse_xml(context)
             if rules = context.operation.output
-              data = Xml::Parser.new(rules).parse(xml(context)) do |h|
-                context.metadata[:request_id] = h['requestId']
+              parser = Xml::Parser.new(rules)
+              data = parser.parse(xml(context)) do |path, value|
+                if path.size == 2 && path.last == 'requestId'
+                  context.metadata[:request_id] = value
+                end
               end
               data
             else

--- a/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -20,6 +20,21 @@ module Aws
         @engine = options[:engine] || self.class.engine
       end
 
+      # Parses the XML document, returning a parsed structure.
+      #
+      # If you pass a block, this will yield for XML
+      # elements that are not modeled in the rules given
+      # to the constructor.
+      #
+      #   parser.parse(xml) do |path, value|
+      #     puts "uhandled: #{path.join('/')} - #{value}"
+      #   end
+      #
+      # The purpose of the unhandled callback block is to
+      # allow callers to access values such as the EC2
+      # request ID that are part of the XML body but not
+      # part of the operation result.
+      #
       # @param [String] xml An XML document string to parse.
       # @param [Structure] target (nil)
       # @return [Structure]

--- a/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -23,9 +23,9 @@ module Aws
       # @param [String] xml An XML document string to parse.
       # @param [Structure] target (nil)
       # @return [Structure]
-      def parse(xml, target = nil)
+      def parse(xml, target = nil, &unhandled_callback)
         xml = '<xml/>' if xml.nil? or xml.empty?
-        stack = Stack.new(@rules, target)
+        stack = Stack.new(@rules, target, &unhandled_callback)
         @engine.new(stack).parse(xml.to_s)
         stack.result
       end

--- a/aws-sdk-core/spec/aws/ec2/client_spec.rb
+++ b/aws-sdk-core/spec/aws/ec2/client_spec.rb
@@ -4,6 +4,34 @@ module Aws
   module EC2
     describe Client do
 
+      describe 'request ids' do
+
+        it 'populates request ids in the response context' do
+          client = Client.new(stub_responses: true)
+          client.handle(step: :send) do |context|
+            context.http_response.signal_done(
+              status_code: 200,
+              headers: {},
+              body: <<-XML.strip)
+              <?xml version="1.0" encoding="UTF-8"?>
+              <DescribeRegionsResponse xmlns="http://ec2.amazonaws.com/doc/2015-10-01/">
+                <requestId>9f93c10f-78e0-445e-ae6c-6e03fe74179b</requestId>
+                <regionInfo>
+                  <item>
+                    <regionEndpoint>ec2.us-west-2.amazonaws.com</regionEndpoint>
+                    <regionName>us-west-2</regionName>
+                  </item>
+                </regionInfo>
+              </DescribeRegionsResponse>
+            XML
+            Seahorse::Client::Response.new(context: context)
+          end
+          resp = client.describe_regions
+          expect(resp.context[:request_id]).to eq('9f93c10f-78e0-445e-ae6c-6e03fe74179b')
+        end
+
+      end
+
       describe 'gov-cloud' do
 
         it 'expands the endpoint correctly for gov-cloud' do


### PR DESCRIPTION
This is a regression from when we switched to stream parsing the XML. Older versions of the SDK parsed the entire XML document into a DOM, and then walked that DOM to parse the values. Because the entire document was no longer available in memory, the parser could no longer yield it as a hash. This caused the EC2 protocol handler to silently fail, no longer able to populate the request ID.

This update adds a callback to the XML parser that yields when un-modeled/un-handled XML values are present in the response. The EC2 handler registers a callback and checks the context/path of the unhandled value and captures it if it is the request id.

To prevent a regression in the future, a unit test was added to ensure the EC2 client correctly extracts the request id from the HTTP response body and stores it in the response context.

Fixes #1038