### PR TITLE
iot-data api has incorrect prefix, hence does not work

### DIFF
--- a/aws-sdk-core/apis/iot-data/2015-05-28/api-2.json
+++ b/aws-sdk-core/apis/iot-data/2015-05-28/api-2.json
@@ -2,7 +2,7 @@
   "version":"2.0",
   "metadata":{
     "apiVersion":"2015-05-28",
-    "endpointPrefix":"data.iot",
+    "endpointPrefix":"iot",
     "protocol":"rest-json",
     "serviceFullName":"AWS IoT Data Plane",
     "signatureVersion":"v4",


### PR DESCRIPTION
There is no data.iot url, and and as far as I'm aware, the data plane endpoint should use the same iot prefix. This seemingly never worked. 

The unit tests failed, and it looks like because of my change, but I'm a bit baffled as to why.