### PR TITLE
Get Correct sigv4_region When No endpointPrefix

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb
@@ -49,7 +49,9 @@ module Aws
 
       option(:sigv4_region) do |cfg|
         prefix = cfg.api.metadata['endpointPrefix']
-        if cfg.endpoint.to_s.match(/#{prefix}\.amazonaws\.com/)
+        if prefix.nil?
+          cfg.region
+        elsif cfg.endpoint.to_s.match(/#{prefix}\.amazonaws\.com/)
           'us-east-1'
         else
           cfg.region

--- a/aws-sdk-core/spec/aws/iotdataplane/client_spec.rb
+++ b/aws-sdk-core/spec/aws/iotdataplane/client_spec.rb
@@ -31,6 +31,14 @@ module Aws
         expect(client.config.sigv4_region).to eq("us-east-1")
       end
 
+      it 'correctly extracts the sigv4 signing region outside of us-east-1' do
+        client = Client.new(
+          region: "eu-west-1",
+          endpoint: "https://FOOBARFOOBAR.iot.eu-west-1.amazonaws.com"
+        )
+        expect(client.config.sigv4_region).to eq("eu-west-1")
+      end
+
       it 'can be constructed with a region and endpoint' do
         expect {
           Client.new(region:'us-west-1', endpoint:'https://foo.com')

--- a/aws-sdk-core/spec/aws/plugins/request_signer_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/request_signer_spec.rb
@@ -64,10 +64,28 @@ module Aws
           expect(cfg.sigv4_region).to eq('us-east-1')
         end
 
-        it 'defaults to configured region if it can not be extract' do
+        it 'defaults to configured region if it can not be extracted' do
           plugin.add_options(config)
           cfg = config.build!(region: 'eu-west-1', endpoint: 'localhost' )
           expect(cfg.sigv4_region).to eq('eu-west-1')
+        end
+
+        context 'services requiring endpoint specification' do
+          let(:config) {
+            api = Api::Builder.build({})
+            cfg = Seahorse::Client::Configuration.new
+            cfg.add_option(:endpoint, 'http://uniqueness.svc-name.us-west-2.amazonaws.com')
+            cfg.add_option(:api, api)
+            cfg.add_option(:region) { 'us-west-2' }
+            cfg.add_option(:region_defaults) {{}}
+            cfg
+          }
+
+          it 'uses the specified region when no endpointPrefix is present' do
+            plugin.add_options(config)
+            cfg = config.build!(region: 'eu-west-1')
+            expect(cfg.sigv4_region).to eq('eu-west-1')
+          end
         end
 
       end


### PR DESCRIPTION
Aws::IoTDataPlane::Client intentionally does not define `endpointPrefix`
in the configured API metadata as a mechanic to force the user to supply
an `:endpoint` value on client construction.

The previous attempted fix failed to note that, in absence of
`endpontPrefix`, all endpoints will match with the first selector,
hard-coded to "us-east-1". This change will check for this case, and use
your client configured region when it occurs.

* Resolves GitHub Issue #1070
* Related to GitHub Issue #1052
* Fixes Regression In GitHub Pull Request #1053