### PR TITLE
Feature/allow local fake sqs

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/sqs_queue_urls.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/sqs_queue_urls.rb
@@ -22,8 +22,6 @@ module Aws
             context.config = context.config.dup
             context.config.region = region
             context.config.sigv4_region = region
-          else
-            raise ArgumentError, "invalid queue url `#{url}'"
           end
         end
 

--- a/aws-sdk-core/spec/aws/plugins/sqs_queue_urls_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/sqs_queue_urls_spec.rb
@@ -30,11 +30,18 @@ module Aws
         expect(resp.context.config.sigv4_region).to eq('us-west-2')
       end
 
-      it 'raises an argument error for invalid queue urls' do
+      it 'raises an argument error for badly formatted queue urls' do
         params[:queue_url] = 'oops'
         expect {
           send_request
-        }.to raise_error(ArgumentError, "invalid queue url `oops'")
+        }.to raise_error(ArgumentError, /invalid endpoint/)
+      end
+
+      it 'does not raise an error for fake sqs queue urls' do
+        params[:queue_url] = 'http://localhost:4567/test_queue'
+        expect {
+          send_request
+        }.to_not raise_error
       end
 
     end


### PR DESCRIPTION
There was a conversation in gitter about this on January 21st. The gist is that this error occurs when using a fake SQS URL:

```
ArgumentError: invalid queue url `http://fake_sqs_1:9494/TestQueue'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/plugins/sqs_queue_urls.rb:26:in `update_region'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/plugins/sqs_queue_urls.rb:10:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/query/handler.rb:27:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/seahorse/client/plugins/endpoint.rb:41:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/plugins/param_validator.rb:21:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/seahorse/client/plugins/response_target.rb:21:in `call'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/seahorse/client/request.rb:70:in `send_request'
    from /var/lib/gems/2.2.0/gems/aws-sdk-core-2.2.12/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:390:in `send_request'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:383:in `get_messages'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:332:in `block (2 levels) in poll'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:331:in `loop'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:331:in `block in poll'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:330:in `catch'
    from /var/lib/gems/2.2.0/gems/aws-sdk-resources-2.2.12/lib/aws-sdk-resources/services/sqs/queue_poller.rb:330:in `poll'
```

It was stated that the removal of these two lines would be accepted.

Thoughts?