### PR TITLE
Raise error when treehash.digest called without any updates.

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/tree_hash.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/tree_hash.rb
@@ -48,6 +48,8 @@ module Aws
     end
 
     def digest
+      raise RuntimeError, "TreeHash Digest cannot be computed without any hashes" if @hashes.empty?
+      
       hashes = @hashes
       digest = OpenSSL::Digest.new('sha256')
       until hashes.count == 1

--- a/aws-sdk-core/spec/aws/tree_hash_spec.rb
+++ b/aws-sdk-core/spec/aws/tree_hash_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+module Aws
+  describe TreeHash do
+
+    it 'should throw exception when digest is called without any updates' do
+      th = TreeHash.new
+      expect {
+        th.digest
+      }.to raise_error(RuntimeError, "TreeHash Digest cannot be computed without any hashes")
+
+      th.update ''
+       expect {
+        th.digest
+      }.to_not raise_error(RuntimeError, "TreeHash Digest cannot be computed without any hashes")
+
+    end
+
+  end
+end


### PR DESCRIPTION
This addresses the #1076 issue. 