### PR TITLE
Fix Ruby fatal error: "uninitialized constant Aws::Client::Errors".

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
@@ -21,7 +21,7 @@ module Aws
         else
           code, message = extract_error(body, context)
         end
-        svc = context.client.class.name.split('::')[1]
+		svc = context.client.class.identifier.to_s.capitalize
         errors_module = Aws.const_get(svc).const_get(:Errors)
         errors_module.error_class(code).new(context, message)
       end


### PR DESCRIPTION
Hello,

Recently, trying to utilise Firehose V2 client, I ended up receiving Ruby fatal errors, basically it was always the same error:
```
"uninitialized constant Aws::Client::Errors"
```

In the end I found out that this error happens every time I receive an error response from Firehose endpoint. After debugging I noticed that mentioned error is being generated because of invalid "svc" variable initialization in xml/error_handler.rb error() method which tried to get it like this:

```
svc = context.client.class.name.split('::')[1]
```

though, client class is always Module::Client here, on the other hand, we keep service name identificator in the context.client.class.identifier, so the idea of the fix is to just capitalize identificator so "svc" variable is always created using underlying module, in my case Aws::Firehose::Errors::... instead of Aws::Client::Errors::..., like this:

```
svc = context.client.class.identifier.to_s.capitalize
```

After I applied this fix I started receiving proper errors in my code like this, which I assume is an expected behaviour:
```
Firehose my-test-stream not found under account NNNNNNNNNNNNN.
```

I would appreciate if you review my fix and sort out this problem in the next release of aws-sdk-ruby. Feel free to contact me if you have any questions.

With best,
Valera