### PR TITLE
Progress callback for S3Object Multipart upload

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/file_part.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/file_part.rb
@@ -10,12 +10,14 @@ module Aws
       # @option options [required,Integer] :offset The file part will read
       #   starting at this byte offset.
       # @option options [required,Integer] :size The maximum number of bytes to
+      # @yieldparam [Integer] # of bytes read from disk
       #   read from the `:offset`.
-      def initialize(options = {})
+      def initialize(options = {}, &block)
         @source = options[:source]
         @first_byte = options[:offset]
         @last_byte = @first_byte + options[:size]
         @size = options[:size]
+        @read_block = block
         @file = nil
       end
 
@@ -63,6 +65,7 @@ module Aws
           data = @file.read(remaining_bytes)
         end
         @position += data ? data.bytesize : 0
+        @read_block.call data ? data.bytesize : 0 if @read_block
         output_buffer ? output_buffer.replace(data || '') : data
       end
 

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/file_uploader.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/file_uploader.rb
@@ -26,10 +26,11 @@ module Aws
       # @param [String,Pathname,File,Tempfile] source
       # @option options [required,String] :bucket
       # @option options [required,String] :key
+      # @yieldparam [Integer] # of bytes read from disk during Multipart upload
       # @return [void]
-      def upload(source, options = {})
+      def upload(source, options = {}, &block)
         if File.size(source) >= multipart_threshold
-          MultipartFileUploader.new(@options).upload(source, options)
+          MultipartFileUploader.new(@options).upload(source, options, &block)
         else
           put_object(source, options)
         end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -206,6 +206,15 @@ module Aws
       #     # and the parts are uploaded in parallel
       #     obj.upload_file('/path/to/very_large_file')
       #
+      # You can provide a block progress updates as bytes are read from disk
+      # Only applies to multipart uploads.
+      #
+      #     # large files are automatically split into parts
+      #     # and the parts are uploaded in parallel
+      #     obj.upload_file('/path/to/very_large_file') do |bytes_read|
+      #       puts "Read #{bytes_read}"
+      #     end
+      #
       # @param [String,Pathname,File,Tempfile] source A file or path to a file
       #   on the local file system that should be uploaded to this object.
       #   If you pass an open file object, then it is your responsibility

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -215,6 +215,8 @@ module Aws
       #   than `:multipart_threshold` are uploaded using the S3 multipart APIs.
       #   Default threshold is 15MB.
       #
+      # @yieldparam [Integer] # of bytes read from disk during upload
+      #
       # @raise [MultipartUploadError] If an object is being uploaded in
       #   parts, and the upload can not be completed, then the upload is
       #   aborted and this error is raised.  The raised error has a `#errors`
@@ -224,11 +226,11 @@ module Aws
       # @return [Boolean] Returns `true` when the object is uploaded
       #   without any errors.
       #
-      def upload_file(source, options = {})
+      def upload_file(source, options = {}, &block)
         uploader = FileUploader.new(
           multipart_threshold: options.delete(:multipart_threshold),
           client: client)
-        uploader.upload(source, options.merge(bucket: bucket_name, key: key))
+        uploader.upload(source, options.merge(bucket: bucket_name, key: key), &block)
         true
       end
 

--- a/aws-sdk-resources/spec/services/s3/file_part_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/file_part_spec.rb
@@ -57,7 +57,6 @@ module Aws
         end
 
         describe 'with block' do
-
           it 'yields the number of bytes read for a partial read' do
             bytes_read = 0
             read_block = lambda{|bytes| bytes_read += bytes}

--- a/aws-sdk-resources/spec/services/s3/file_part_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/file_part_spec.rb
@@ -56,12 +56,23 @@ module Aws
           expect(part.read(15)).to eq(nil)
         end
 
-        it 'returns "" when #read is called without bytes from part end' do
-          part = FilePart.new(source:path, offset:0, size:15)
-          expect(part.read).to eq('The quick brown')
-          expect(part.read).to eq('')
-        end
+        describe 'with block' do
 
+          it 'yields the number of bytes read for a partial read' do
+            bytes_read = 0
+            read_block = lambda{|bytes| bytes_read += bytes}
+            part = FilePart.new(source:path, offset:0, size:15, &read_block)
+            part.read(10)
+            expect(bytes_read).to eq(10)
+          end
+          it 'yields the remaining bytes read when #read called with num bytes past end' do
+            bytes_read = 0
+            read_block = lambda{|bytes| bytes_read += bytes}
+            part = FilePart.new(source:path, offset:0, size:15, &read_block)
+            part.read(100)
+            expect(bytes_read).to eq(15)
+          end
+        end
       end
 
       describe '#rewind' do


### PR DESCRIPTION
Be gentle :) Trying to solve #648 

* Doesn't apply to non-`MultipartFileUpload`'s
* Doesn't "undo" progress for retries in `rewind` (suppose you could just `@read_block.call(-@position)` to deal with that.)
* Callers responsibility to deal with thread safety

Feedback welcome!