### PR TITLE
Region-to-region multipart copy fix

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -20,6 +20,10 @@ module Aws
       #   performance improvements on large objects. Amazon S3 does
       #   not accept multipart copies for objects smaller than 5MB.
       #
+      # @options options [Integer] :content_length When included
+      #   the source object will not be queried for its size before
+      #   starting the copy.
+      #
       # @example Basic object copy
       #
       #   bucket = Aws::S3::Bucket.new('target-bucket')

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -5,7 +5,7 @@ module Aws
       alias size content_length
 
       # Copies another object to this object. Use `multipart_copy: true`
-      # for large objects. This is required for objects that exceed 5GB.'
+      # for large objects. This is required for objects that exceed 5GB.
       #
       # @param [S3::Object, String, Hash] source Where to copy object
       #   data from. `source` must be one of the following:

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -20,9 +20,9 @@ module Aws
       #   performance improvements on large objects. Amazon S3 does
       #   not accept multipart copies for objects smaller than 5MB.
       #
-      # @options options [Integer] :content_length When included
-      #   the source object will not be queried for its size before
-      #   starting the copy.
+      # @options options [Integer] :content_length Used only when
+      # multipart_copy is TRUE.  When included the source object will not be
+      # queried for its size before starting the copy.
       #
       # @example Basic object copy
       #

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -21,8 +21,17 @@ module Aws
       #   not accept multipart copies for objects smaller than 5MB.
       #
       # @options options [Integer] :content_length Used only when
-      # multipart_copy is TRUE.  When included the source object will not be
-      # queried for its size before starting the copy.
+      #   multipart_copy is TRUE.  When included the source object will not be
+      #   queried for its size before starting the copy.
+      #
+      # @options options [S3::Client] :copy_source_client When present, will
+      #   be used to fetch the content length of the source object if the
+      #   :content_length options is not supplied,
+      #
+      # @options options [String] :copy_source_region May be used instead of
+      #   :copy_source_client to specify the region where the source object
+      #   resides, and thus where the HEAD request to fetch the content length of
+      #   the source object should be directed.
       #
       # @example Basic object copy
       #

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
@@ -12,6 +12,7 @@ module Aws
       end
 
       def copy_from(source, options = {})
+        options[:copy_source_client] = source.client if source.is_a?(S3::Object)
         copy_object(source, @object, merge_options(source, options))
       end
 
@@ -24,9 +25,11 @@ module Aws
 
       def copy_object(source, target, options)
         target_bucket, target_key = copy_target(target)
+
         options[:bucket] = target_bucket
         options[:key] = target_key
         options[:copy_source] = copy_source(source)
+
         if options.delete(:multipart_copy)
           ObjectMultipartCopier.new(@options).copy(options)
         else

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
@@ -13,6 +13,10 @@ module Aws
 
       def copy_from(source, options = {})
         options[:copy_source_client] ||= source.client if source.respond_to?(:client)
+        if options[:copy_source_region]
+          options[:copy_source_client] = S3::Client.new(region: options.delete(:copy_source_region))
+        end
+
         copy_object(source, @object, merge_options(source, options))
       end
 

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
@@ -12,7 +12,7 @@ module Aws
       end
 
       def copy_from(source, options = {})
-        options[:copy_source_client] = source.client if source.is_a?(S3::Object)
+        options[:copy_source_client] ||= source.client if source.respond_to?(:client)
         copy_object(source, @object, merge_options(source, options))
       end
 

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
@@ -116,12 +116,12 @@ module Aws
       end
 
       def source_size(options)
-        if options[:content_length]
-          options.delete(:content_length)
-        else
-          bucket, key = options[:copy_source].match(/([^\/]+?)\/(.+)/)[1,2]
-          @client.head_object(bucket:bucket, key:key).content_length
-        end
+        return options.delete(:content_length) if options[:content_length]
+
+        client = options[:copy_source_client] || @client
+
+        bucket, key = options[:copy_source].match(/([^\/]+?)\/(.+)/)[1,2]
+        client.head_object(bucket: bucket, key: key).content_length
       end
 
       def default_part_size(source_size)

--- a/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
@@ -3,14 +3,71 @@ require 'spec_helper'
 module Aws
   module S3
     describe Object do
-
       let(:object) { S3::Object.new('bucket', 'unescaped/key path', stub_responses: true) }
-
       let(:client) { object.client }
 
-      describe 'default behavior' do
-        describe '#copy_from' do
+      describe '#copy_to' do
+        it 'accepts a string source' do
+          expect(client).to receive(:copy_object).with({
+            bucket: 'target-bucket',
+            key: 'target-key',
+            copy_source: 'bucket/unescaped/key%20path',
+          })
+          object.copy_to('target-bucket/target-key')
+        end
 
+        it 'accepts a hash source' do
+          expect(client).to receive(:copy_object).with({
+            bucket: 'target-bucket',
+            key: 'target-key',
+            copy_source: 'bucket/unescaped/key%20path',
+          })
+          object.copy_to(bucket:'target-bucket', key:'target-key')
+        end
+
+        it 'accept a hash with options merged' do
+          expect(client).to receive(:copy_object).with({
+            bucket: 'target-bucket',
+            key: 'target-key',
+            copy_source: 'bucket/unescaped/key%20path',
+            content_type: 'text/plain',
+          })
+          object.copy_to(
+            bucket: 'target-bucket',
+            key: 'target-key',
+            content_type: 'text/plain'
+          )
+        end
+
+        it 'accepts an S3::Object source' do
+          expect(client).to receive(:copy_object).with({
+            bucket: 'target-bucket',
+            key: 'target-key',
+            copy_source: 'bucket/unescaped/key%20path',
+          })
+          target = S3::Object.new('target-bucket', 'target-key', stub_responses:true)
+          object.copy_to(target)
+        end
+
+        it 'accepts additional options' do
+          expect(client).to receive(:copy_object).with({
+            bucket: 'target-bucket',
+            key: 'target-key',
+            copy_source: 'bucket/unescaped/key%20path',
+            acl: 'public-read',
+          })
+          object.copy_to('target-bucket/target-key', acl: 'public-read')
+        end
+
+        it 'raises an error on an invalid targets' do
+          expect {
+            object.copy_to(:target)
+          }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe '#copy_from' do
+        context 'with multipart_copy: false' do
           it 'supports the deprecated form' do
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
@@ -79,75 +136,9 @@ module Aws
               object.copy_from(:source)
             }.to raise_error(ArgumentError)
           end
-
         end
 
-        describe '#copy_to' do
-
-          it 'accepts a string source' do
-            expect(client).to receive(:copy_object).with({
-              bucket: 'target-bucket',
-              key: 'target-key',
-              copy_source: 'bucket/unescaped/key%20path',
-            })
-            object.copy_to('target-bucket/target-key')
-          end
-
-          it 'accepts a hash source' do
-            expect(client).to receive(:copy_object).with({
-              bucket: 'target-bucket',
-              key: 'target-key',
-              copy_source: 'bucket/unescaped/key%20path',
-            })
-            object.copy_to(bucket:'target-bucket', key:'target-key')
-          end
-
-          it 'accept a hash with options merged' do
-            expect(client).to receive(:copy_object).with({
-              bucket: 'target-bucket',
-              key: 'target-key',
-              copy_source: 'bucket/unescaped/key%20path',
-              content_type: 'text/plain',
-            })
-            object.copy_to(
-              bucket: 'target-bucket',
-              key: 'target-key',
-              content_type: 'text/plain'
-            )
-          end
-
-          it 'accepts an S3::Object source' do
-            expect(client).to receive(:copy_object).with({
-              bucket: 'target-bucket',
-              key: 'target-key',
-              copy_source: 'bucket/unescaped/key%20path',
-            })
-            target = S3::Object.new('target-bucket', 'target-key', stub_responses:true)
-            object.copy_to(target)
-          end
-
-          it 'accepts additional options' do
-            expect(client).to receive(:copy_object).with({
-              bucket: 'target-bucket',
-              key: 'target-key',
-              copy_source: 'bucket/unescaped/key%20path',
-              acl: 'public-read',
-            })
-            object.copy_to('target-bucket/target-key', acl: 'public-read')
-          end
-
-          it 'raises an error on an invalid targets' do
-            expect {
-              object.copy_to(:target)
-            }.to raise_error(ArgumentError)
-          end
-
-        end
-      end
-
-      describe 'multipart_copy: true' do
-        describe '#copy_from' do
-
+        context 'with multipart_copy: true' do
           before(:each) do
             size = 300 * 1024 * 1024 # 300MB
             allow(client).to receive(:head_object).with(
@@ -206,9 +197,9 @@ module Aws
               }
             })
             object.copy_from('source-bucket/source/key',
-              multipart_copy: true,
-              min_part_size: 5 * 1024 * 1024
-            )
+                             multipart_copy: true,
+                             min_part_size: 5 * 1024 * 1024
+                            )
           end
 
           it 'aborts the upload on errors' do
@@ -245,6 +236,8 @@ module Aws
           context 'when the target and source objects are in different regions' do
             let(:content_length) { 10 * 1024 * 1024 }
 
+            let(:source_region) { 'ap-southeast-1' }
+
             let(:source_bucket) { 'source-bucket' }
             let(:target_bucket) { 'target-bucket' }
 
@@ -262,11 +255,55 @@ module Aws
               allow(source_client).to receive(:head_object).and_return(head_response)
             end
 
-            it 'queries the content length of the source object from the source region' do
-              expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
-              expect(target_client).not_to receive(:head_object)
+            context 'and the source is an S3::Object' do
+              it 'queries the content length of the source object from the source region' do
+                expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
+                expect(target_client).not_to receive(:head_object)
 
-              target_object.copy_from(source_object, multipart_copy: true)
+                target_object.copy_from(source_object, multipart_copy: true)
+              end
+            end
+
+            context 'and the source is a Hash' do
+              let(:source_hash) { { bucket: source_bucket, key: key } }
+
+              it 'the :copy_source_client option value is used to query content_length' do
+                expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
+                expect(target_client).not_to receive(:head_object)
+
+                target_object.copy_from(source_hash, multipart_copy: true, copy_source_client: source_client)
+              end
+
+              it 'the :copy_source_region option value is used to construct a client used to query content_length' do
+                allow(S3::Client).to receive(:new).and_call_original
+
+                expect(S3::Client).to receive(:new).with({region: source_region}).and_return(source_client)
+                expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
+                expect(target_client).not_to receive(:head_object)
+
+                target_object.copy_from(source_hash, multipart_copy: true, copy_source_region: source_region)
+              end
+            end
+
+            context 'and the source is a String' do
+              let(:source_string) { "#{source_bucket}/#{key}" }
+
+              it 'the :copy_source_client option value is used to query content_length' do
+                expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
+                expect(target_client).not_to receive(:head_object)
+
+                target_object.copy_from(source_string, multipart_copy: true, copy_source_client: source_client)
+              end
+
+              it 'the :copy_source_region option value is used to construct a client used to query content_length' do
+                allow(S3::Client).to receive(:new).and_call_original
+
+                expect(S3::Client).to receive(:new).with({region: source_region}).and_return(source_client)
+                expect(source_client).to receive(:head_object).with({bucket: source_bucket, key: key})
+                expect(target_client).not_to receive(:head_object)
+
+                target_object.copy_from(source_string, multipart_copy: true, copy_source_region: source_region)
+              end
             end
           end
 


### PR DESCRIPTION
Fixes #1083 

:deciduous_tree: 

Ensures that the appropriate client is queried to find the source object's size when copying from region-to-region. 

I also noticed that, though the tests appear to explicitly state that passing content_length to `S3::Object#copy_from` will bypass calling HEAD on the source object, the documentation did not mention this option. I updated the `copy_from` documentation to include the content_length option as that's the workaround we're currently using.