### PR TITLE
Presigned POST requests got error response, when using SSE-C.

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/presigned_post.rb
@@ -531,7 +531,7 @@ module Aws
       # @return [self]
       def server_side_encryption_customer_key(value)
         field_name = 'x-amz-server-side-encryption-customer-key'
-        with(field_name, value)
+        with(field_name, base64(value))
         with(field_name + '-MD5', base64(OpenSSL::Digest::MD5.digest(value)))
       end
 

--- a/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/presigned_post_spec.rb
@@ -177,11 +177,12 @@ module Aws
 
         it 'computes a MD5 of the customer provided encryption key' do
           key = 'abcmnoxyz12345'
+          encoded_key = Base64.strict_encode64(key)
           md5 = Base64.strict_encode64(OpenSSL::Digest::MD5.digest(key))
           post.server_side_encryption_customer_key(key)
-          expect(post.fields['x-amz-server-side-encryption-customer-key']).to eq(key)
+          expect(post.fields['x-amz-server-side-encryption-customer-key']).to eq(encoded_key)
           expect(post.fields['x-amz-server-side-encryption-customer-key-MD5']).to eq(md5)
-          expect(policy(post)).to include('x-amz-server-side-encryption-customer-key' => key)
+          expect(policy(post)).to include('x-amz-server-side-encryption-customer-key' => encoded_key)
           expect(policy(post)).to include('x-amz-server-side-encryption-customer-key-MD5' => md5)
         end
 


### PR DESCRIPTION
The encryption key must be  base64-encoding.

See at http://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html