### PR TITLE
Fix error message on unsupported S3 signature version

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
@@ -12,7 +12,8 @@ module Aws
 
         def call(context)
           require_credentials(context)
-          case context.config.signature_version
+          version = context.config.signature_version
+          case version
           when 'v4' then apply_v4_signature(context)
           when 's3' then apply_s3_legacy_signature(context)
           else

--- a/aws-sdk-core/spec/aws/s3/client_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client_spec.rb
@@ -146,6 +146,17 @@ module Aws
             'AWS4-HMAC-SHA256')
         end
 
+        it 'raises a runtime error on unsupported signature version' do
+          client = Client.new(
+            signature_version: 'v2',
+            stub_responses: true,
+            region: 'us-east-1'
+          )
+          expect {
+            client.head_object(bucket:'name', key:'key')
+          }.to raise_error(/unsupported/)
+        end
+
       end
 
       describe 'https required for sse cpk' do


### PR DESCRIPTION
When an unsupported signature version is passed to the S3 client, it will raise a confusing error message:

```
NameError: undefined local variable or method `version' for #<Aws::Plugins::S3RequestSigner::SigningHandler:0x007f896f5273a8>
```

This change will make it raises the intended error message:

```
RuntimeError: unsupported signature version "v2", valid options: 'v4' (default), 's3'
```