### PR TITLE
Remove Incorrect Resource Waiter Documentation

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/documenter/waiter_operation_documenter.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/documenter/waiter_operation_documenter.rb
@@ -68,7 +68,7 @@ You can modify defaults and register callbacks by passing a block argument.
      w.before_wait do { |count, prev_resp| ... }
   end
           EXAMPLE
-          super + [tag(example)]
+          [tag(example)]
         end
 
       end

--- a/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
@@ -214,9 +214,7 @@ module Aws
             param.apply(params_hash, options)
           end
 
-          user_params = options[:params] || {}
-          params = deep_merge(user_params, params_hash)
-          resp = resource.client.wait_until(@waiter_name, params, &options[:block])
+          resp = resource.client.wait_until(@waiter_name, params_hash, &options[:block])
 
           resource_opts = resource.identifiers.dup
           if @path && resp.respond_to?(:data)
@@ -224,14 +222,6 @@ module Aws
           end
           resource_opts[:client] = resource.client
           resource.class.new(resource_opts)
-        end
-
-        def deep_merge(obj1, obj2)
-          case obj1
-          when Hash then obj1.merge(obj2) { |key, v1, v2| deep_merge(v1, v2) }
-          when Array then obj2 + obj1
-          else obj2
-          end
         end
 
       end


### PR DESCRIPTION
The resource waiter documentation uses the underlying client call
parameter data, which is not necessary and is in fact incorrect. This
removes that part of the generated documentation.

Also removes unused code around plumbing extra params through to the
waiter, which was not supported anyways.