### PR TITLE
Avoid Double URL Encoding S3 Keys

### DIFF
--- a/aws-sdk-resources/features/s3/multipart_copy.feature
+++ b/aws-sdk-resources/features/s3/multipart_copy.feature
@@ -10,3 +10,9 @@ Feature: Managed multipart copies
     Given a "source_bucket" is set in cfg["s3"]["large_object"]["bucket"]
     And a "source_key" is set in cfg["s3"]["large_object"]["key"]
     Then I should be able to multipart copy the object to a different bucket
+
+  Scenario: Copy object with space character
+    Given I create a bucket
+    And I have a 1MB file
+    And I upload the file to the "test object" object
+    Then I should be able to copy the object

--- a/aws-sdk-resources/features/s3/step_definitions.rb
+++ b/aws-sdk-resources/features/s3/step_definitions.rb
@@ -8,16 +8,7 @@ end
 
 After("@s3") do
   @created_buckets.each do |bucket|
-    # TODO : provide a Bucket#delete! method
-    loop do
-      objects = bucket.client.list_object_versions(bucket: bucket.name)
-      objects = objects.data.versions.map do |v|
-        { key: v.key, version_id: v.version_id }
-      end
-      break if objects.empty?
-      bucket.client.delete_objects(bucket: bucket.name, delete: { objects: objects })
-    end
-    bucket.delete
+    bucket.delete!
   end
 end
 
@@ -129,4 +120,11 @@ Then(/^I should be able to multipart copy the object to a different bucket$/) do
   target_object = target_bucket.object("#{@source_key}-copy")
   target_object.copy_from("#{@source_bucket}/#{@source_key}", multipart_copy: true)
   expect(ApiCallTracker.called_operations).to include(:create_multipart_upload)
+end
+
+Then(/^I should be able to copy the object$/) do
+  target_bucket = @s3.bucket(@bucket_name)
+  target_object = target_bucket.object("test object-copy")
+  target_object.copy_from("#{@bucket_name}/test object")
+  expect(ApiCallTracker.called_operations).to include(:copy_object)
 end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
@@ -36,15 +36,15 @@ module Aws
 
       def copy_source(source)
         case source
-        when String then escape(source)
+        when String then source
         when Hash
-          src = "#{source[:bucket]}/#{escape(source[:key])}"
+          src = "#{source[:bucket]}/#{source[:key]}"
           src += "?versionId=#{source[:version_id]}" if source.key?(:version_id)
           src
         when S3::Object, S3::ObjectSummary
-          "#{source.bucket_name}/#{escape(source.key)}"
+          "#{source.bucket_name}/#{source.key}"
         when S3::ObjectVersion
-          "#{source.bucket_name}/#{escape(source.object_key)}?versionId=#{source.id}"
+          "#{source.bucket_name}/#{source.object_key}?versionId=#{source.id}"
         else
           msg = "expected source to be an Aws::S3::Object, Hash, or String"
           raise ArgumentError, msg
@@ -88,10 +88,6 @@ module Aws
 
         options[:copy_source_client] ||= @object.client
 
-      end
-
-      def escape(str)
-        Seahorse::Util.uri_path_escape(str)
       end
 
     end

--- a/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
@@ -11,7 +11,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
           })
           object.copy_to('target-bucket/target-key')
         end
@@ -20,7 +20,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
           })
           object.copy_to(bucket:'target-bucket', key:'target-key')
         end
@@ -29,7 +29,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
           })
           object.copy_to(bucket:'target-bucket', key:'target-key')
         end
@@ -38,7 +38,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
             content_type: 'text/plain',
           })
           object.copy_to(
@@ -52,7 +52,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
           })
           target = S3::Object.new('target-bucket', 'target-key', stub_responses:true)
           object.copy_to(target)
@@ -62,7 +62,7 @@ module Aws
           expect(client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
-            copy_source: 'bucket/unescaped/key%20path',
+            copy_source: 'bucket/unescaped/key path',
             acl: 'public-read',
           })
           object.copy_to('target-bucket/target-key', acl: 'public-read')
@@ -81,16 +81,16 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/escaped/source/key%20path',
+              copy_source: 'source-bucket/escaped/source/key path',
             })
-            object.copy_from(copy_source: 'source-bucket/escaped/source/key%20path')
+            object.copy_from(copy_source: 'source-bucket/escaped/source/key path')
           end
 
           it 'accepts a string source' do
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/source/key%20path',
+              copy_source: 'source-bucket/source/key path',
             })
             object.copy_from('source-bucket/source/key path')
           end
@@ -99,7 +99,7 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/unescaped/source/key%20path'
+              copy_source: 'source-bucket/unescaped/source/key path'
             })
             object.copy_from(bucket:'source-bucket', key:'unescaped/source/key path')
           end
@@ -136,7 +136,7 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/unescaped/source/key%20path',
+              copy_source: 'source-bucket/unescaped/source/key path',
             })
             object.copy_from(src)
           end
@@ -146,7 +146,7 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/unescaped/source/key%20path',
+              copy_source: 'source-bucket/unescaped/source/key path',
             })
             object.copy_from(src)
           end
@@ -160,7 +160,7 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/unescaped/source/key%20path?versionId=source-version-id',
+              copy_source: 'source-bucket/unescaped/source/key path?versionId=source-version-id',
             })
             object.copy_from(src)
           end


### PR DESCRIPTION
When performing a copy operation with the S3 Object resource, the object
key would be URL encoded before being sent on to the S3 client, which
URL encodes the key a second time. This was causing a 404 to
short-circuit the copy operation.

Tests were checking the inputs into the client call, which would not
catch the second step of the double encoding.

Resolves issue #1143 