### PR TITLE
Correctly Handle Escaping for Multipart S3 Copy

### DIFF
--- a/aws-sdk-resources/features/s3/multipart_copy.feature
+++ b/aws-sdk-resources/features/s3/multipart_copy.feature
@@ -10,3 +10,10 @@ Feature: Managed multipart copies
     Given a "source_bucket" is set in cfg["s3"]["large_object"]["bucket"]
     And a "source_key" is set in cfg["s3"]["large_object"]["key"]
     Then I should be able to multipart copy the object to a different bucket
+
+  @slow
+  Scenario: Copy object with space character
+    Given I create a bucket
+    And I have a 10MB file
+    And I upload the file to the "test object" object
+    Then I should be able to copy the object

--- a/aws-sdk-resources/features/s3/step_definitions.rb
+++ b/aws-sdk-resources/features/s3/step_definitions.rb
@@ -8,16 +8,7 @@ end
 
 After("@s3") do
   @created_buckets.each do |bucket|
-    # TODO : provide a Bucket#delete! method
-    loop do
-      objects = bucket.client.list_object_versions(bucket: bucket.name)
-      objects = objects.data.versions.map do |v|
-        { key: v.key, version_id: v.version_id }
-      end
-      break if objects.empty?
-      bucket.client.delete_objects(bucket: bucket.name, delete: { objects: objects })
-    end
-    bucket.delete
+    bucket.delete!
   end
 end
 
@@ -129,4 +120,11 @@ Then(/^I should be able to multipart copy the object to a different bucket$/) do
   target_object = target_bucket.object("#{@source_key}-copy")
   target_object.copy_from("#{@source_bucket}/#{@source_key}", multipart_copy: true)
   expect(ApiCallTracker.called_operations).to include(:create_multipart_upload)
+end
+
+Then(/^I should be able to multipart copy the object$/) do
+  target_bucket = @s3.bucket(@bucket_name)
+  target_object = target_bucket.object("test object-copy")
+  target_object.copy_from("#{@bucket_name}/test object", multipart_copy: true)
+  expect(ApiCallTracker.called_operations).to include(:create_multiparty_upload)
 end

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_copier.rb
@@ -5,7 +5,7 @@ module Aws
     # @api private
     class ObjectCopier
 
-      # @param [S3::Objecst] object
+      # @param [S3::Object] object
       def initialize(object, options = {})
         @object = object
         @options = options.merge(client: @object.client)
@@ -36,7 +36,7 @@ module Aws
 
       def copy_source(source)
         case source
-        when String then escape(source)
+        when String then source
         when Hash
           src = "#{source[:bucket]}/#{escape(source[:key])}"
           src += "?versionId=#{source[:version_id]}" if source.key?(:version_id)

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
@@ -120,8 +120,16 @@ module Aws
 
         client = options[:copy_source_client] || @client
 
-        bucket, key = options[:copy_source].match(/([^\/]+?)\/(.+)/)[1,2]
-        client.head_object(bucket: bucket, key: key).content_length
+        if vid_match = options[:copy_source].match(/([^\/]+?)\/(.+)\?versionId=(.+)/)
+          bucket, key, version_id = vid_match[1,3]
+        else
+          bucket, key = options[:copy_source].match(/([^\/]+?)\/(.+)/)[1,2]
+        end
+        
+        key = CGI.unescape(key)
+        opts = { bucket: bucket, key: key }
+        opts[:version_id] = version_id if version_id
+        client.head_object(opts).content_length
       end
 
       def default_part_size(source_size)

--- a/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/multipart_copy_spec.rb
@@ -92,7 +92,7 @@ module Aws
               key: 'unescaped/key path',
               copy_source: 'source-bucket/source/key%20path',
             })
-            object.copy_from('source-bucket/source/key path')
+            object.copy_from('source-bucket/source/key%20path')
           end
 
           it 'accepts a hash source' do
@@ -108,11 +108,11 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'src-bucket/src-key?versionId=src-version-id'
+              copy_source: 'src-bucket/src%20key?versionId=src-version-id'
             })
             object.copy_from(
               bucket: 'src-bucket',
-              key: 'src-key',
+              key: 'src key',
               version_id: 'src-version-id'
             )
           end
@@ -121,12 +121,12 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/source-key',
+              copy_source: 'source-bucket/source%20key',
               content_type: 'text/plain',
             })
             object.copy_from(
               bucket: 'source-bucket',
-              key: 'source-key',
+              key: 'source key',
               content_type: 'text/plain'
             )
           end
@@ -169,10 +169,10 @@ module Aws
             expect(client).to receive(:copy_object).with({
               bucket: 'bucket',
               key: 'unescaped/key path',
-              copy_source: 'source-bucket/source-key',
+              copy_source: 'source-bucket/source%20key',
               acl: 'public-read',
             })
-            object.copy_from('source-bucket/source-key', acl: 'public-read')
+            object.copy_from('source-bucket/source%20key', acl: 'public-read')
           end
 
           it 'raises an error on an invalid source' do
@@ -182,16 +182,17 @@ module Aws
           end
         end
 
-        context 'with multipart_copy: true' do
+        context 'with version_id and multipart_copy: true' do
           before(:each) do
             size = 300 * 1024 * 1024 # 300MB
             allow(client).to receive(:head_object).with(
               bucket: 'source-bucket',
-              key: 'source/key'
+              key: 'source key',
+              version_id: 'source-version-id'
             ).and_return(client.stub_data(:head_object, content_length: size))
           end
 
-          it 'performs multipart uploads when :multipart_copy is true' do
+          it 'performs multipart uploads for a versioned object' do
             expect(client).to receive(:create_multipart_upload).
               with(bucket: 'bucket', key: 'unescaped/key path').
               and_return(client.stub_data(:create_multipart_upload, upload_id:'id'))
@@ -200,7 +201,7 @@ module Aws
                 bucket: 'bucket',
                 key: 'unescaped/key path',
                 part_number: n,
-                copy_source: 'source-bucket/source/key',
+                copy_source: 'source-bucket/source%20key?versionId=source-version-id',
                 copy_source_range: "bytes=#{(n-1)*52428800}-#{n*52428800-1}",
                 upload_id: 'id'
               ).and_return(client.stub_data(:upload_part_copy, copy_part_result:{etag: "etag#{n}"}))
@@ -213,7 +214,45 @@ module Aws
                 parts: (1..6).map { |n| { etag: "etag#{n}", part_number: n } }
               }
             })
-            object.copy_from('source-bucket/source/key', multipart_copy: true)
+            object.copy_from(
+              'source-bucket/source%20key?versionId=source-version-id',
+              multipart_copy: true
+            )
+          end
+        end
+
+        context 'with multipart_copy: true' do
+          before(:each) do
+            size = 300 * 1024 * 1024 # 300MB
+            allow(client).to receive(:head_object).with(
+              bucket: 'source-bucket',
+              key: 'source key'
+            ).and_return(client.stub_data(:head_object, content_length: size))
+          end
+
+          it 'performs multipart uploads when :multipart_copy is true' do
+            expect(client).to receive(:create_multipart_upload).
+              with(bucket: 'bucket', key: 'unescaped/key path').
+              and_return(client.stub_data(:create_multipart_upload, upload_id:'id'))
+            (1..6).each do |n|
+              expect(client).to receive(:upload_part_copy).with(
+                bucket: 'bucket',
+                key: 'unescaped/key path',
+                part_number: n,
+                copy_source: 'source-bucket/source%20key',
+                copy_source_range: "bytes=#{(n-1)*52428800}-#{n*52428800-1}",
+                upload_id: 'id'
+              ).and_return(client.stub_data(:upload_part_copy, copy_part_result:{etag: "etag#{n}"}))
+            end
+            expect(client).to receive(:complete_multipart_upload).with({
+              bucket: 'bucket',
+              key: 'unescaped/key path',
+              upload_id: 'id',
+              multipart_upload: {
+                parts: (1..6).map { |n| { etag: "etag#{n}", part_number: n } }
+              }
+            })
+            object.copy_from('source-bucket/source%20key', multipart_copy: true)
           end
 
           it 'supports alternative part sizes' do
@@ -227,7 +266,7 @@ module Aws
                 bucket: 'bucket',
                 key: 'unescaped/key path',
                 part_number: n,
-                copy_source: 'source-bucket/source/key',
+                copy_source: 'source-bucket/source%20key',
                 copy_source_range: "bytes=#{(n-1)*5242880}-#{n*5242880-1}",
                 upload_id: 'id'
               ).and_return(client.stub_data(:upload_part_copy, copy_part_result:{etag: "etag#{n}"}))
@@ -240,7 +279,7 @@ module Aws
                 parts: (1..60).map { |n| { etag: "etag#{n}", part_number: n } }
               }
             })
-            object.copy_from('source-bucket/source/key',
+            object.copy_from('source-bucket/source%20key',
                              multipart_copy: true,
                              min_part_size: 5 * 1024 * 1024
                             )
@@ -254,7 +293,7 @@ module Aws
             expect(client).to receive(:abort_multipart_upload).
               with(bucket: 'bucket', key: 'unescaped/key path', upload_id: 'id')
             expect {
-              object.copy_from('source-bucket/source/key', multipart_copy: true)
+              object.copy_from('source-bucket/source%20key', multipart_copy: true)
             }.to raise_error(Aws::S3::Errors::NoSuchKey)
           end
 
@@ -262,16 +301,16 @@ module Aws
             size = 4 * 1024 * 1024
             allow(client).to receive(:head_object).with(
               bucket: 'source-bucket',
-              key: 'source/key'
+              key: 'source key'
             ).and_return(client.stub_data(:head_object, content_length: size))
             expect {
-              object.copy_from('source-bucket/source/key', multipart_copy: true)
+              object.copy_from('source-bucket/source%20key', multipart_copy: true)
             }.to raise_error(ArgumentError, /smaller than 5MB/)
           end
 
           it 'accepts file size option to avoid HEAD request' do
             expect(client).not_to receive(:head_object)
-            object.copy_from('source-bucket/source/key',
+            object.copy_from('source-bucket/source%20key',
                              multipart_copy: true,
                              content_length: 10 * 1024 * 1024
                             )
@@ -353,7 +392,7 @@ module Aws
 
           it 'does not modify given options' do
             options = { multipart_copy: true }
-            object.copy_from('source-bucket/source/key', options)
+            object.copy_from('source-bucket/source%20key', options)
             expect(options).to eq(multipart_copy: true)
           end
 


### PR DESCRIPTION
Multipart uploads managed by the `Aws::S3::Resource` object copier did
not correctly handle keys with characters that must be URL
encoded. Calls to `Aws::S3::Client#head_object` should not be URL
encoded, but they were, causing mismatches over the wire. This change
unescapes the key for the `#head_object` call, fixing multipart managed
uploads.

Additionally, it fixes a previously unknown bug where managed multipart
copies would not be able to consume a versioned object as the
source. That support is also included in this change.

Resolves GitHub issue #1143