### PR TITLE
Fix Issues With Oj Before 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ matrix:
   exclude:
     - rvm: jruby
       env: KITCHEN_SINK=1
+  include:
+    - rvm: 2.3.0
+      env: OLD_OJ=1
 
 notifications:
   webhooks:

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,14 @@ gemspec path: 'aws-sdk-core'
 
 gem 'rake', require: false
 
-gem 'oj' unless ENV['PURE_RUBY'] && !ENV['OLD_OJ']
-gem 'oj', '1.3.0' if ENV['OLD_OJ']
+if !ENV['PURE_RUBY']
+  if ENV['OLD_OJ']
+    gem 'oj', '1.3.0'
+  else
+    gem 'oj'
+  end
+end
+
 gem 'ox' unless ENV['PURE_RUBY']
 gem 'libxml-ruby' unless ENV['PURE_RUBY']
 gem 'nokogiri' unless ENV['PURE_RUBY']

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gemspec path: 'aws-sdk-core'
 
 gem 'rake', require: false
 
-gem 'oj' unless ENV['PURE_RUBY']
+gem 'oj' unless ENV['PURE_RUBY'] && !ENV['OLD_OJ']
+gem 'oj', '1.3.0' if ENV['OLD_OJ']
 gem 'ox' unless ENV['PURE_RUBY']
 gem 'libxml-ruby' unless ENV['PURE_RUBY']
 gem 'nokogiri' unless ENV['PURE_RUBY']

--- a/aws-sdk-core/lib/aws-sdk-core/json.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/json.rb
@@ -40,13 +40,21 @@ module Aws
 
       def oj_engine
         require 'oj'
-        [Oj, [{mode: :compat, symbol_keys: false}], [{ mode: :compat }], Oj::ParseError]
+        [Oj, [{mode: :compat, symbol_keys: false}], [{ mode: :compat }], oj_parse_error]
       rescue LoadError
         false
       end
 
       def json_engine
         [JSON, [], [], JSON::ParserError]
+      end
+
+      def oj_parse_error
+        if Oj.const_defined?('ParseError')
+          Oj::ParseError
+        else
+          SyntaxError
+        end
       end
 
     end


### PR DESCRIPTION
Where Oj::ParseError is now thrown for invalid JSON, older versions used
the standard libary SyntaxError. Includes a Travis test for backwards
compatibility.

Resolves GitHub issue #1139