### PR TITLE
FIX: describe_launch_configurations's max_records default is 50

### DIFF
--- a/aws-sdk-core/apis/autoscaling/2011-01-01/docs-2.json
+++ b/aws-sdk-core/apis/autoscaling/2011-01-01/docs-2.json
@@ -751,7 +751,7 @@
         "DescribeScalingActivitiesType$MaxRecords": "<p>The maximum number of items to return with this call.</p>",
         "DescribeScheduledActionsType$MaxRecords": "<p>The maximum number of items to return with this call.</p>",
         "DescribeTagsType$MaxRecords": "<p>The maximum number of items to return with this call.</p>",
-        "LaunchConfigurationNamesType$MaxRecords": "<p>The maximum number of items to return with this call. The default is 100.</p>"
+        "LaunchConfigurationNamesType$MaxRecords": "<p>The maximum number of items to return with this call. The default is 50.</p>"
       }
     },
     "MetricCollectionType": {


### PR DESCRIPTION
Hi.

I tried to this code.

```rb
client = Aws::AutoScaling::Client.new(
  region: REGION_NAME,
  access_key_id: ACCESS_KEY,
  secret_access_key: SECRET_KEY
)

launch_configs = {}
client.describe_launch_configurations.launch_configurations.each do | lc |
  p lc.launch_configuration_name
end
```

This code return `50` items.

But, [This Official Document](http://docs.aws.amazon.com/sdkforruby/api/Aws/AutoScaling/Client.html#describe_launch_configurations-instance_method) says
`The maximum number of items to return with this call. The default is 100.`

which one is correct?
make sure, I send this PR.

Please check it. thank you.