### PR TITLE
Fix for Aws::S3::Client#head_bucket with improper region.

### DIFF
--- a/aws-sdk-core/features/s3/buckets.feature
+++ b/aws-sdk-core/features/s3/buckets.feature
@@ -9,6 +9,12 @@ Feature: S3 Buckets
     When I delete the bucket
     Then the bucket should not exist
 
+  Scenario: HEAD bucket works with improper region
+    Given I am using the S3 "us-west-2" region
+    And I create a bucket
+    When I am using the S3 "us-east-1" region
+    Then I should be able to HEAD the bucket
+
   Scenario: CRUD buckets using a regional endpoint
     Given I am using the S3 "us-west-2" region
     When I create a bucket

--- a/aws-sdk-core/features/s3/step_definitions.rb
+++ b/aws-sdk-core/features/s3/step_definitions.rb
@@ -61,6 +61,10 @@ Then(/^the bucket should exist$/) do
   expect { @client.get_bucket_location(bucket: @bucket_name) }.not_to raise_error
 end
 
+Then(/^I should be able to HEAD the bucket$/) do
+  expect { @client.head_bucket(bucket: @bucket_name) }.not_to raise_error
+end
+
 When(/^I delete the bucket$/) do
   @client.delete_bucket(bucket: @bucket_name)
   @created_buckets.delete(@bucket_name)

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb
@@ -100,10 +100,8 @@ module Aws
         end
 
         def get_region_and_retry(context)
-          actual_region = region_from_body(context)
-          if actual_region.nil? || actual_region == ""
-            raise "Couldn't get region from body: #{context.body}"
-          end
+          actual_region = context.http_response.headers['x-amz-bucket-region']
+          actual_region ||= region_from_body(context.http_response.body_contents)
           update_bucket_cache(context, actual_region)
           log_warning(context, actual_region)
           update_region_header(context, actual_region)
@@ -116,7 +114,10 @@ module Aws
 
         def wrong_sigv4_region?(resp)
           resp.context.http_response.status_code == 400 &&
+          (
+            resp.context.http_response.headers['x-amz-bucket-region'] ||
             resp.context.http_response.body_contents.match(/<Region>.+?<\/Region>/)
+          )
         end
 
         def update_region_header(context, region)
@@ -128,8 +129,13 @@ module Aws
           signer.sign(context.http_request)
         end
 
-        def region_from_body(context)
-          context.http_response.body_contents.match(/<Region>(.+?)<\/Region>/)[1]
+        def region_from_body(body)
+          region = body.match(/<Region>(.+?)<\/Region>/)[1]
+          if region.nil? || region == ""
+            raise "couldn't get region from body: #{body}"
+          else
+            region
+          end
         end
 
         def log_warning(context, actual_region)


### PR DESCRIPTION
Resolved the following issues:

```ruby
s3 = Aws::S3::Client.new(region: 'us-west-1')
s3.head_bucket(bucket: 'us-west-2-bucket')
#=> raises Aws::S3::Errors::BadRequest (without a message)
```

If the bucket exists, but you are configured for the incorrect region, the SDK fails to extract the actual bucket region from the 400 response. This results in an empty error message. Added support for loading the bucket region from the "x-amz-bucket-region" header, which is necessary for all HEAD responses.

Fixes #1161