### PR TITLE
Added `:use_accelerate_endpoint` option to Aws::S3::Client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::S3 - You can now pass a configuration option to accelerate
+  `Aws::S3::Client` object operations. You can construct a client with
+  `use_accelerate_endpoint: true` to enable this feature.
+
+  ```ruby
+  s3 = Aws::S3::Client.new(use_accelerate_endpoint: true)
+  s3.put_object(bucket: 'bucket-name', key:'key')
+  #=> uses https://bucket-name.s3-accelerate.amazonaws.com
+  ```
+
+  You can pass `:use_accelerate_endpoint` to client operations to
+  override the client default.
+
+  ```ruby
+  # non-accelerated client
+  s3 = Aws::S3::Client.new
+
+  # non-accelerated
+  s3.put_object(bucket: 'bucket-name', key:'key')
+
+  # accelerated
+  s3.put_object(bucket: 'bucket-name', key:'key', use_accelerate_endpoint: true)
+  ```
+
+  [See the Amazon S3 documentation for more information](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html).
+
 2.2.35 (2016-04-19)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Unreleased Changes
 ------------------
 
 * Feature - Aws::S3 - You can now pass a configuration option to accelerate
-  `Aws::S3::Client` object operations. You can construct a client with
+  `Aws::S3::Client` operations. You can construct a client with
   `use_accelerate_endpoint: true` to enable this feature.
 
   ```ruby
@@ -26,6 +26,12 @@ Unreleased Changes
   ```
 
   [See the Amazon S3 documentation for more information](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html).
+
+  Not supported for the following operations:
+
+  * `#create_bucket`
+  * `#list_buckets`
+  * `#delete_bucket`
 
 2.2.35 (2016-04-19)
 ------------------

--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -169,6 +169,7 @@ module Aws
     autoload :RequestSigner, 'aws-sdk-core/plugins/request_signer'
     autoload :RetryErrors, 'aws-sdk-core/plugins/retry_errors'
     autoload :Route53IdFix, 'aws-sdk-core/plugins/route_53_id_fix'
+    autoload :S3Accelerate, 'aws-sdk-core/plugins/s3_accelerate'
     autoload :S3BucketDns, 'aws-sdk-core/plugins/s3_bucket_dns'
     autoload :S3Expect100Continue, 'aws-sdk-core/plugins/s3_expect_100_continue'
     autoload :S3GetBucketLocationFix, 'aws-sdk-core/plugins/s3_get_bucket_location_fix'

--- a/aws-sdk-core/lib/aws-sdk-core/api/docs/param_formatter.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docs/param_formatter.rb
@@ -44,7 +44,7 @@ module Aws
             end
           when ListShape then list(ref, i, visited)
           when MapShape then map(ref, i, visited)
-          when BooleanShape then "true"
+          when BooleanShape then "false"
           when IntegerShape then '1'
           when FloatShape then '1.0'
           when StringShape then string(ref)

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_accelerate.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_accelerate.rb
@@ -1,0 +1,73 @@
+module Aws
+  module Plugins
+
+    # Provides support for using `Aws::S3::Client` with Amazon S3 Transfer
+    # Acceleration.
+    #
+    # Go here for more information about transfer acceleration:
+    # [http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html)
+    #
+    # @seahorse.client.option [Boolean] :use_accelerate_endpoint (false)
+    #   When set to `true`, accelerated bucket endpoints will be used
+    #   for all object operations. You must first enable
+    #   accelerate for each bucket. [Go here for more information](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html).
+    #
+    class S3Accelerate < Seahorse::Client::Plugin
+
+      option(:use_accelerate_endpoint, false)
+
+      def add_handlers(handlers, config)
+        operations = config.api.operation_names - [
+          :create_bucket, :list_buckets, :delete_bucket,
+        ]
+        handlers.add(OptionHandler, step: :initialize, operations: operations)
+        handlers.add(AccelerateHandler, step: :build, priority: 0, operations: operations)
+      end
+
+      # @api private
+      class OptionHandler < Seahorse::Client::Handler
+        def call(context)
+          accelerate = context.params.delete(:use_accelerate_endpoint)
+          accelerate = context.config.use_accelerate_endpoint if accelerate.nil?
+          context[:use_accelerate_endpoint] = accelerate
+          @handler.call(context)
+        end
+      end
+
+      # @api private
+      class AccelerateHandler < Seahorse::Client::Handler
+
+        def call(context)
+          use_accelerate_endpoint(context) if context[:use_accelerate_endpoint]
+          @handler.call(context)
+        end
+
+        private
+
+        def use_accelerate_endpoint(context)
+          bucket_name = context.params[:bucket]
+          validate_bucket_name!(bucket_name)
+          endpoint = URI.parse(context.http_request.endpoint.to_s)
+          endpoint.scheme = 'https'
+          endpoint.port = 443
+          endpoint.host = "#{bucket_name}.s3-accelerate.amazonaws.com"
+          context.http_request.endpoint = endpoint.to_s
+        end
+
+        def validate_bucket_name!(bucket_name)
+          unless S3BucketDns.dns_compatible?(bucket_name, ssl = true)
+            msg = "unable to use `accelerate: true` on buckets with "
+            msg << "non-DNS compatible names"
+            raise ArgumentError, msg
+          end
+          if bucket_name.include?('.')
+            msg = "unable to use `accelerate: true` on buckets with dots"
+            msg << "in their name: #{bucket_name.inspect}"
+            raise ArgumentError, msg
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/aws-sdk-core/lib/aws-sdk-core/signers/s3.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/signers/s3.rb
@@ -12,6 +12,7 @@ module Aws
         acl delete cors lifecycle location logging notification partNumber
         policy requestPayment restore tagging torrent uploadId uploads
         versionId versioning versions website replication requestPayment
+        accelerate
 
         response-content-type response-content-language
         response-expires response-cache-control

--- a/aws-sdk-core/spec/aws/api/docs/request_syntax_example_spec.rb
+++ b/aws-sdk-core/spec/aws/api/docs/request_syntax_example_spec.rb
@@ -312,7 +312,7 @@ resp = client.operation_name({
     },
     blob: "data",
     byte: "ByteShape",
-    boolean: true,
+    boolean: false,
     character: "CharacterShape",
     double: 1.0,
     float: 1.0,

--- a/aws-sdk-core/spec/aws/s3/client/accelerate_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client/accelerate_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'stringio'
+
+module Aws
+  module S3
+    describe Client do
+
+      let(:options) {{ stub_responses: true, region: 'us-east-1' }}
+
+      let(:client) { Client.new(options) }
+
+      let(:accelerated_client) { Client.new(options.merge(use_accelerate_endpoint: true)) }
+
+      describe ':use_accelerate_endpoint' do
+
+        it 'defaults to false' do
+          client = Client.new(options)
+          expect(client.config.use_accelerate_endpoint).to be(false)
+          resp = client.put_object(bucket:'bucket-name', key:'key')
+          expect(resp.context.http_request.endpoint.to_s).to eq(
+            'https://bucket-name.s3.amazonaws.com/key')
+        end
+
+        it 'can be set in the constructor' do
+          client = Client.new(options.merge(use_accelerate_endpoint: true))
+          expect(client.config.use_accelerate_endpoint).to be(true)
+          resp = client.put_object(bucket:'bucket-name', key:'key')
+          expect(resp.context.http_request.endpoint.to_s).to eq(
+            'https://bucket-name.s3-accelerate.amazonaws.com/key')
+        end
+
+        it 'can be set on the operation' do
+          expect(client.config.use_accelerate_endpoint).to be(false)
+          resp = client.put_object(bucket:'bucket-name', key:'key', use_accelerate_endpoint: true)
+          expect(resp.context.http_request.endpoint.to_s).to eq(
+            'https://bucket-name.s3-accelerate.amazonaws.com/key')
+        end
+
+        it 'can be disabled by the operation' do
+          resp = accelerated_client.put_object(bucket:'bucket-name', key:'key', use_accelerate_endpoint: false)
+          expect(resp.context.http_request.endpoint.to_s).to eq(
+            'https://bucket-name.s3.amazonaws.com/key')
+        end
+
+        it 'does not apply to #create_bucket' do
+          resp = accelerated_client.create_bucket(bucket:'bucket-name')
+          expect(resp.context.http_request.endpoint.to_s).to eq('https://bucket-name.s3.amazonaws.com/')
+        end
+
+        it 'does not apply to #list_buckets' do
+          resp = accelerated_client.list_buckets
+          expect(resp.context.http_request.endpoint.to_s).to eq('https://s3.amazonaws.com/')
+        end
+
+        it 'does not apply to #delete_bucket' do
+          resp = accelerated_client.delete_bucket(bucket:'bucket-name')
+          expect(resp.context.http_request.endpoint.to_s).to eq('https://bucket-name.s3.amazonaws.com/')
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can now pass a configuration option to accelerate `Aws::S3::Client` operations. You can construct a client with `use_accelerate_endpoint: true` to enable this feature.

```ruby
s3 = Aws::S3::Client.new(use_accelerate_endpoint: true)
s3.put_object(bucket: 'bucket-name', key:'key')
#=> uses https://bucket-name.s3-accelerate.amazonaws.com
```

You can pass `:use_accelerate_endpoint` to client operations to override the client default.

```ruby
s3 = Aws::S3::Client.new(use_accelerate_endpoint: true)
s3.put_object(bucket: 'bucket-name', key:'key')
#=> uses https://bucket-name.s3-accelerate.amazonaws.com
```

You can pass `:use_accelerate_endpoint` to client operations to override the client default.

```ruby
# non-accelerated client
s3 = Aws::S3::Client.new

# non-accelerated
s3.put_object(bucket: 'bucket-name', key:'key')

# accelerated
s3.put_object(bucket: 'bucket-name', key:'key', use_accelerate_endpoint: true)
```

[See the Amazon S3 documentation for more information](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html).

Not supported for the following operations:

* `#create_bucket`
* `#list_buckets`
* `#delete_bucket`