### PR TITLE
Added stricter resource collection arg validation.

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
@@ -108,6 +108,7 @@ module Aws
         # @option (see Base#call)
         # @return [Collection]
         def call(options)
+          validate_args!(options)
           Collection.new(self, options)
         end
 
@@ -122,6 +123,17 @@ module Aws
         end
 
         private
+
+        def validate_args!(options)
+          args = options[:args]
+          unless args.count == 0 || args.count == 1
+            msg = "wrong number of arguments (given #{args.count}, expected 0..1)"
+            raise ArgumentError, msg
+          end
+          unless args[0].nil? || Hash === args[0]
+            raise ArgumentError, "expected Hash, got #{args[0].class}"
+          end
+        end
 
         def all_batches(options, &block)
           resp = @request.call(options)

--- a/aws-sdk-resources/spec/definition_spec.rb
+++ b/aws-sdk-resources/spec/definition_spec.rb
@@ -876,6 +876,16 @@ module Aws
               ])
               expect(doo_dads.all?(&:data_loaded?))
               expect(thing.doo_dads.limit(3).map(&:identifiers)).to eq(doo_dads[0..2].map(&:identifiers))
+
+              # raise on collection construction with string args
+              expect {
+                thing.doo_dads('doo-dad-name')
+              }.to raise_error(ArgumentError, /expected Hash, got String/)
+
+              # raise on collection construction with wrong arity
+              expect {
+                thing.doo_dads(1,2,3)
+              }.to raise_error(ArgumentError, /wrong number of arguments/)
             end
 
             it 'does not attempt to enumerate non-pageable responses' do


### PR DESCRIPTION
Resource has many operation accept a hash argument only. Updated collection methods to now raise on argument errors.

```ruby
bucket = Aws::S3::Bucket.new('bucket-name')

bucket.objects('key')
#=> now raises ArgumentError, expecting Hash, got String

bucket.objects(1,2,3)
#=> now raises ArgumentError, expecting 0..1 args, got 2
```