### PR TITLE
Fix for Aws::Xml::Parser concurrency issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 Unreleased Changes
 ------------------
 
+* Issue - Aws::Xml::Parser - Resolved an concurrency issue with the XML parser
+  related to chosing the default parsing engine.
+
+  See related [GitHub issue #1135](https://github.com/aws/aws-sdk-ruby/issues/1135).
+
 2.3.2 (2016-05-05)
 ------------------
 
 * Feature - Aws::S3 - Adds the `#list_objects_v2` API, for listing objects in
   buckets with a large number of delete markers.
-  
+
 * Feature - Aws::ECS - Task definition log driver supports log drivers available
   from Docker.
 

--- a/aws-sdk-core/lib/aws-sdk-core/endpoint_provider.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/endpoint_provider.rb
@@ -77,16 +77,19 @@ module Aws
     class << self
 
       def resolve(region, service)
-        DEFAULT_PROVIDER.resolve(region, service)
+        default_provider.resolve(region, service)
       end
 
       def signing_region(region, service)
-        DEFAULT_PROVIDER.signing_region(region, service)
+        default_provider.signing_region(region, service)
+      end
+
+      private
+
+      def default_provider
+        @default_provider ||= EndpointProvider.new(Partitions.defaults)
       end
 
     end
-
-    DEFAULT_PROVIDER = EndpointProvider.new(Partitions.defaults)
-
   end
 end

--- a/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -70,7 +70,14 @@ module Aws
         #   * {RexmlEngine}
         #
         def engine
+          set_default_engine unless @engine
           @engine
+        end
+
+        def set_default_engine
+          [:ox, :oga, :libxml, :nokogiri, :rexml].each do |name|
+            @engine ||= try_load_engine(name)
+          end
         end
 
         private
@@ -89,9 +96,7 @@ module Aws
 
       end
 
-      self.engine = [:ox, :oga, :libxml, :nokogiri, :rexml].find do |name|
-        try_load_engine(name)
-      end
+      set_default_engine
 
     end
   end


### PR DESCRIPTION
The XML parser supports multiple backends. There is a race condition when loading the parser code where the default parser has not been chosen, but the first instance of the parser has been constructed. In this scenario, it raises with a undefined method error on `nil`. This is because the self.class.engine is returning `nil`.

Here is a minimal test case that reproduces this issue. It reproduces reliably under Ruby 1.9.3:

```ruby
require 'aws-sdk-core'
require 'thread'

sqs = Aws::SQS::Client.new
threads = 10.times.map do
  Thread.new do
    sqs.send_message(queue_url:"https://...", message_body:"string")
  end
end
threads.map(&:join)
```

The work-around forces the constructor to set the default engine if this hasn't happened yet. There is an additional concurrency issue encountered with setting a default endpoint provider. This surfaced during testing. Similar issue and fix.

Fixes #1135