### PR TITLE
Fixing doc links

### DIFF
--- a/aws-sdk-core/lib/seahorse/client/configuration.rb
+++ b/aws-sdk-core/lib/seahorse/client/configuration.rb
@@ -59,9 +59,15 @@ module Seahorse
       end
 
       # @api private
-      DynamicDefault = Struct.new(:block) do
-        def call(*args)
-          block.call(*args)
+      class DynamicDefault
+        attr_accessor :block
+
+        def initialize(block = nil)
+          @block = block
+        end
+
+        def call(*args) 
+          @block.call(*args)
         end
       end
 

--- a/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -10,17 +10,6 @@ module Seahorse
   module Client
     module NetHttp
 
-      # @attr_reader [URI::HTTP,nil] http_proxy Returns the configured proxy.
-      # @attr_reader [Integer,Float] http_open_timeout
-      # @attr_reader [Integer,Float] http_read_timeout
-      # @attr_reader [Integer,Float] http_idle_timeout
-      # @attr_reader [Float,nil] http_continue_timeout
-      # @attr_reader [Boolean] http_wire_trace
-      # @attr_reader [Logger,nil] logger
-      # @attr_reader [Boolean] ssl_verify_peer
-      # @attr_reader [String,nil] ssl_ca_bundle
-      # @attr_reader [String,nil] ssl_ca_directory
-      # @attr_reader [String,nil] ssl_ca_store
       class ConnectionPool
 
         @pools_mutex = Mutex.new


### PR DESCRIPTION
Removing comment references that create bad documentation inks. 
Updating `DynamicDefaults` to be a class instead of struct to prevent bad documentation links.