### PR TITLE
Fix class organization headings in docs

### DIFF
--- a/doc-src/templates/default/fulldoc/html/js/nolink.js
+++ b/doc-src/templates/default/fulldoc/html/js/nolink.js
@@ -1,0 +1,3 @@
+$(document).ready(function () {
+  $('li.nolink').off('click');
+});

--- a/doc-src/templates/default/fulldoc/html/setup.rb
+++ b/doc-src/templates/default/fulldoc/html/setup.rb
@@ -1,7 +1,11 @@
+def javascripts_full_list
+  super + ['js/nolink.js']
+end
+
 def class_list(root = Registry.root, tree = TreeContext.new)
   out = ''
   # non-service classes
-  out << "<li class='#{tree.classes.join(' ')}'>"
+  out << "<li class='#{tree.classes.join(' ')} nolink'>"
   out << "<div class='item' style='padding-left:#{tree.indent}'>"
   out << "<a class='toggle'></a> Non-Service Classes"
   out << "</div><ul>"
@@ -12,7 +16,7 @@ def class_list(root = Registry.root, tree = TreeContext.new)
   out << '</ul></li>'
 
   # service classes
-  out << "<li class='#{tree.classes.join(' ')}'>"
+  out << "<li class='#{tree.classes.join(' ')} nolink'>"
   out << "<div class='item' style='padding-left:#{tree.indent}'>"
   out << "<a class='toggle'></a> Services"
   out << "</div><ul>"


### PR DESCRIPTION
The SDK is doing some organization to the API docs page (http://docs.aws.amazon.com/sdkforruby/api/) class list. Clicking on the "Non-Service Classes" or "Services" headings results in being redirected to an "undefined" page because YARD is adding links to the lis programatically. This PR adds a small JS file to remove the linking from the heading lis.