### PR TITLE
Typo fix in upload_file spec test

### DIFF
--- a/FEATURE_REQUESTS.md
+++ b/FEATURE_REQUESTS.md
@@ -193,12 +193,6 @@ This feature would be an interface for the information provided here http://docs
 
 See [related GitHub issue #926](https://github.com/aws/aws-sdk-ruby/issues/926).
 
-### Signed CloudFront URLs
-
-Amazon CloudFront supports pre-signed URLs, similar to those used by Amazon S3. It would be helpful to have a pre-signed url builder for SDK users.
-
-See [related GitHub issue #700](https://github.com/aws/aws-sdk-ruby/issues/700).
-
 ### Progress callbacks for Amazon S3 Object uploads
 
 To enable users to track file upload process, it would be helpful to support a progress callback for `Aws::S3::Object#upload_file`.

--- a/aws-sdk-resources/spec/services/s3/object/upload_file_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/upload_file_spec.rb
@@ -28,7 +28,7 @@ module Aws
           )
         }
 
-        let(:one_meg_file) { Tempfile.new('ten-meg-file') }
+        let(:one_meg_file) { Tempfile.new('one-meg-file') }
 
         let(:ten_meg_file) { Tempfile.new('ten-meg-file') }
 


### PR DESCRIPTION
A small typo fix in spec test & some clean-up works in `FEATURE_REQUESTS.md`.

cc:\ @trevorrowe @awood45 