### PR TITLE
Fix ArgumentError when S3 responds with invalid Expires Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 Unreleased Changes
 ------------------
 
+* Issue - Aws::S3 - Resolved an issue with `Aws::S3::Client#head_object` and
+  `#get_object` where an `ArgumentError` was raised if Amazon S3 responded with
+  an Expires header that contained an unparsable string.
+
+  The `#head_object` and `#get_object` response now return `nil` when the Expires
+  header contains an invalid value. You can now access the raw string value
+  of the Expires header with `#expires_string`.
+
+  ```ruby
+  # If Amazon S3 responds with `Expires: abc` as a header
+  resp = s3.head_object(bucket:'bucket', key:'key')
+  resp.expires #=> nil
+  resp.expires_string #=> "abc"
+  ```
+
+  See related [GitHub issue #1184](https://github.com/aws/aws-sdk-ruby/issues/1184).
+
 * Issue - Memory Usage - Added a pair of utility methods that perform more efficient
   SHA4256 and MD5 checksums of file objects. Before this change, data was read in
   1MB chunks. Now using the `OpenSSL::Digest.file` interface to reduce memory usage.

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -157,6 +157,24 @@ module Aws
             end
           end
         end
+
+        api['shapes']['ExpiresString'] = { 'type' => 'string' }
+        %w(HeadObjectOutput GetObjectOutput).each do |shape|
+          members = api['shapes'][shape]['members']
+          # inject this into sort order so this appears directly
+          # after #expires
+          api['shapes'][shape]['members'] = members.inject({}) do |h, (k,v)|
+            if k == 'Expires'
+              h['ExpiresString'] = {
+                'shape' => 'ExpiresString',
+                'location' => 'header',
+                'locationName' => 'Expires',
+              }
+            end
+            h[k] = v
+            h
+          end
+        end
       end
 
       doc('s3') do |docs|

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -161,9 +161,9 @@ module Aws
         api['shapes']['ExpiresString'] = { 'type' => 'string' }
         %w(HeadObjectOutput GetObjectOutput).each do |shape|
           members = api['shapes'][shape]['members']
-          # inject this into sort order so this appears directly
-          # after #expires
+          # inject ExpiresString directly after Expires
           api['shapes'][shape]['members'] = members.inject({}) do |h, (k,v)|
+            h[k] = v
             if k == 'Expires'
               h['ExpiresString'] = {
                 'shape' => 'ExpiresString',
@@ -171,7 +171,6 @@ module Aws
                 'locationName' => 'Expires',
               }
             end
-            h[k] = v
             h
           end
         end

--- a/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Aws
   module Rest
     module Response
@@ -38,7 +40,11 @@ module Aws
             if value =~ /\d+(\.\d*)/
               Time.at(value.to_f)
             else
-              Time.parse(value)
+              begin
+                Time.parse(value)
+              rescue
+                nil
+              end
             end
           else raise "unsupported shape #{ref.shape.class}"
           end

--- a/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
@@ -45,7 +45,14 @@ module Aws
           elsif rules[:payload]
             body_for(api, operation, rules[:payload_member], data[rules[:payload]])
           else
-            body_for(api, operation, rules, data)
+            filtered = Seahorse::Model::Shapes::ShapeRef.new(
+              shape: Seahorse::Model::Shapes::StructureShape.new.tap do |s|
+                rules.shape.members.each do |member_name, member_ref|
+                  s.add_member(member_name, member_ref) if member_ref.location.nil?
+                end
+              end
+            )
+            body_for(api, operation, filtered, data)
           end
         end
 

--- a/aws-sdk-core/spec/aws/s3/client_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client_spec.rb
@@ -190,6 +190,24 @@ module Aws
 
       end
 
+      describe 'invalid Expires header' do
+        %w(get_object head_object).each do |method|
+
+          it "correctly handled invalid Expires header for #{method}" do
+            s3 = Client.new
+            s3.handle(step: :send) do |context|
+              context.http_response.signal_headers(200, {'Expires' => 'abc'})
+              context.http_response.signal_done
+              Seahorse::Client::Response.new(context: context)
+            end
+            resp = s3.send(method, bucket:'b', key:'k')
+            expect(resp.expires).to be(nil)
+            expect(resp.expires_string).to eq('abc')
+          end
+
+        end
+      end
+
       describe '#create_bucket' do
 
         it 'omits location constraint for the classic region' do

--- a/aws-sdk-core/spec/aws/s3/client_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client_spec.rb
@@ -205,6 +205,25 @@ module Aws
             expect(resp.expires_string).to eq('abc')
           end
 
+          it 'accepts a stubbed Expires header as a Time value' do
+            now = Time.at(Time.now.to_i)
+            s3 = Client.new(stub_responses: {
+              method.to_sym => { expires: now }
+            })
+            resp = s3.send(method, bucket:'b', key:'k')
+            expect(resp.expires).to eq(now)
+            expect(resp.expires_string).to eq(now.httpdate)
+          end
+
+          it 'accepts a stubbed Expires header as String value' do
+            s3 = Client.new(stub_responses: {
+              method.to_sym => { expires_string: 'abc' }
+            })
+            resp = s3.send(method, bucket:'b', key:'k')
+            expect(resp.expires).to be(nil)
+            expect(resp.expires_string).to eq('abc')
+          end
+
         end
       end
 


### PR DESCRIPTION
Resolved an issue with `Aws::S3::Client#head_object` and `#get_object` where an `ArgumentError` was raised if Amazon S3 responded with an Expires header that contained an unparsable string.

The `#head_object` and `#get_object` response now return `nil` when the Expires header contains an invalid value. You can now access the raw string value of the Expires header with `#expires_string`.
```ruby
# If Amazon S3 responds with `Expires: abc` as a header
resp = s3.head_object(bucket:'bucket', key:'key')
resp.expires #=> nil
resp.expires_string #=> "abc"
```

See related [GitHub issue #1184](https://github.com/aws/aws-sdk-ruby/issues/1184).