### PR TITLE
Correct placement of Cloudfront UrlSigner in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,17 +235,6 @@ Unreleased Changes
 2.3.4 (2016-05-12)
 ------------------
 
-* Feature - Aws::CloudFront - Added support for signing CloudFront URLs.
-
-  ```ruby
-  signer = Aws::CloudFront::UrlSigner.new
-  signer.signed_url(url,
-    key_pair_id: "cf-keypair-id",
-    private_key_path: "./cf_private_key.pem"
-  )
-  #=> "http://..."
-  ```
-
 * Feature - Aws::ApplicationDiscoveryService - Added support for the new
   AWS Application Discovery Service.
 


### PR DESCRIPTION
Appears inside twice currently(2.3.13, 2.3.4). Tagged release @ https://github.com/aws/aws-sdk-ruby/releases/tag/v2.3.13 , commit @ https://github.com/aws/aws-sdk-ruby/commit/7325f1b4033969d7a3f0eec29a63546674da1791