### PR TITLE
Add Support for ECS Credential Provider

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -108,6 +108,7 @@ module Aws
   autoload :Credentials, 'aws-sdk-core/credentials'
   autoload :Deprecations, 'aws-sdk-core/deprecations'
   autoload :EagerLoader, 'aws-sdk-core/eager_loader'
+  autoload :ECSCredentials, 'aws-sdk-core/ecs_credentials'
   autoload :EmptyStructure, 'aws-sdk-core/empty_structure'
   autoload :EndpointProvider, 'aws-sdk-core/endpoint_provider'
   autoload :Errors, 'aws-sdk-core/errors'

--- a/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -68,7 +68,11 @@ module Aws
     end
 
     def instance_profile_credentials(options)
-      InstanceProfileCredentials.new(options)
+      if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+        ECSCredentials.new(options)
+      else
+        InstanceProfileCredentials.new(options)
+      end
     end
 
   end

--- a/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -1,0 +1,141 @@
+require 'json'
+require 'time'
+require 'net/http'
+
+module Aws
+  class ECSCredentials
+
+    include CredentialProvider
+    include RefreshingCredentials
+
+    # @api private
+    class Non200Response < RuntimeError; end
+
+    # These are the errors we trap when attempting to talk to the
+    # instance metadata service.  Any of these imply the service
+    # is not present, no responding or some other non-recoverable
+    # error.
+    # @api private
+    NETWORK_ERRORS = [
+      Errno::EHOSTUNREACH,
+      Errno::ECONNREFUSED,
+      Errno::EHOSTDOWN,
+      Errno::ENETUNREACH,
+      SocketError,
+      Timeout::Error,
+      Non200Response,
+    ]
+
+    # @param [Hash] options
+    # @option options [Integer] :retries (5) Number of times to retry
+    #   when retrieving credentials.
+    # @option options [String] :ip_address ('169.254.170.2')
+    # @option options [Integer] :port (80)
+    # @option options [String] :credential_path By default, the value of the
+    #   AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable.
+    # @option options [Float] :http_open_timeout (5)
+    # @option options [Float] :http_read_timeout (5)
+    # @option options [Numeric, Proc] :delay By default, failures are retried
+    #   with exponential back-off, i.e. `sleep(1.2 ** num_failures)`. You can
+    #   pass a number of seconds to sleep between failed attempts, or
+    #   a Proc that accepts the number of failures.
+    # @option options [IO] :http_debug_output (nil) HTTP wire
+    #   traces are sent to this object.  You can specify something
+    #   like $stdout.
+    def initialize options = {}
+      @retries = options[:retries] || 5
+      @ip_address = options[:ip_address] || '169.254.170.2'
+      @port = options[:port] || 80
+      @credential_path = options[:credential_path]
+      @credential_path ||= ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']
+      unless @credential_path
+        raise ArgumentError.new(
+          "Cannot instantiate an ECS Credential Provider without a credential path."
+        )
+      end
+      @http_open_timeout = options[:http_open_timeout] || 5
+      @http_read_timeout = options[:http_read_timeout] || 5
+      @http_debug_output = options[:http_debug_output]
+      @backoff = backoff(options[:backoff])
+      super
+    end
+
+    # @return [Integer] The number of times to retry failed atttempts to
+    #   fetch credentials from the instance metadata service. Defaults to 0.
+    attr_reader :retries
+
+    private
+
+    def backoff(backoff)
+      case backoff
+      when Proc then backoff
+      when Numeric then lambda { |_| sleep(backoff) }
+      else lambda { |num_failures| Kernel.sleep(1.2 ** num_failures) }
+      end
+    end
+
+    def refresh
+      # Retry loading credentials up to 3 times is the instance metadata
+      # service is responding but is returning invalid JSON documents
+      # in response to the GET profile credentials call.
+      retry_errors([JSON::ParserError, StandardError], max_retries: 3) do
+        c = JSON.parse(get_credentials.to_s)
+        @credentials = Credentials.new(
+          c['AccessKeyId'],
+          c['SecretAccessKey'],
+          c['Token']
+        )
+        @expiration = c['Expiration'] ? Time.parse(c['Expiration']) : nil
+      end
+    end
+
+    def get_credentials
+      # Retry loading credentials a configurable number of times if
+      # the instance metadata service is not responding.
+      begin
+        retry_errors(NETWORK_ERRORS, max_retries: @retries) do
+          open_connection do |conn|
+            http_get(conn, @credential_path)
+          end
+        end
+      rescue
+        '{}'
+      end
+    end
+
+    def open_connection
+      http = Net::HTTP.new(@ip_address, @port, nil)
+      http.open_timeout = @http_open_timeout
+      http.read_timeout = @http_read_timeout
+      http.set_debug_output(@http_debug_output) if @http_debug_output
+      http.start
+      yield(http).tap { http.finish }
+    end
+
+    def http_get(connection, path)
+      response = connection.request(Net::HTTP::Get.new(path))
+      if response.code.to_i == 200
+        response.body
+      else
+        raise Non200Response
+      end
+    end
+
+    def retry_errors(error_classes, options = {}, &block)
+      max_retries = options[:max_retries]
+      retries = 0
+      begin
+        yield
+      rescue *error_classes => error
+        if retries < max_retries
+          @backoff.call(retries)
+          retries += 1
+          retry
+        else
+          raise
+        end
+      end
+    end
+
+  end
+end

--- a/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
+++ b/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
@@ -1,0 +1,187 @@
+require 'spec_helper'
+
+module Aws
+  describe ECSCredentials do
+
+    let(:path) { '/latest/credentials?id=foobarbaz' }
+
+    describe 'without instance metadata service present' do
+
+      [
+        Errno::EHOSTUNREACH,
+        Errno::ECONNREFUSED,
+        SocketError,
+        Timeout::Error,
+      ].each do |error_class|
+        it "returns no credentials for #{error_class}" do
+          stub_request(:get, "http://169.254.170.2#{path}").to_raise(error_class)
+          expect(ECSCredentials.new(credential_path: path, backoff:0).set?).to be(false)
+        end
+      end
+
+    end
+
+    describe 'with ECS credential service present' do
+
+      before(:each) do
+        stub_const('ENV', {
+          "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" => path
+        })
+      end
+
+      let(:expiration) { Time.now.utc + 3600 }
+      let(:expiration2) { expiration + 3600 }
+
+      let(:resp) { <<-JSON.strip }
+{
+  "RoleArn" : "arn:aws:iam::123456789012:role/BarFooRole",
+  "AccessKeyId" : "akid",
+  "SecretAccessKey" : "secret",
+  "Token" : "session-token",
+  "Expiration" : "#{expiration.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+}
+      JSON
+
+      let(:resp2) { <<-JSON.strip }
+{
+  "RoleArn" : "arn:aws:iam::123456789012:role/BarFooRole",
+  "AccessKeyId" : "akid-2",
+  "SecretAccessKey" : "secret-2",
+  "Token" : "session-token-2",
+  "Expiration" : "#{(expiration2).strftime('%Y-%m-%dT%H:%M:%SZ')}"
+}
+      JSON
+
+      before(:each) do
+        stub_request(:get, "http://169.254.170.2#{path}").
+          to_return(:status => 200, :body => resp).
+          to_return(:status => 200, :body => resp2)
+      end
+
+      it 'populates credentials from the instance profile' do
+        c = ECSCredentials.new(backoff:0)
+        expect(c.credentials.access_key_id).to eq('akid')
+        expect(c.credentials.secret_access_key).to eq('secret')
+        expect(c.credentials.session_token).to eq('session-token')
+        expect(c.expiration.to_s).to eq(expiration.to_s)
+      end
+
+      it 're-queries the metadata service when #refresh! is called' do
+        c = ECSCredentials.new
+        c.refresh!
+        expect(c.credentials.access_key_id).to eq('akid-2')
+        expect(c.credentials.secret_access_key).to eq('secret-2')
+        expect(c.credentials.session_token).to eq('session-token-2')
+        expect(c.expiration.to_s).to eq(expiration2.to_s)
+      end
+
+      it 'retries if the first load fails' do
+        stub_request(:get, "http://169.254.170.2#{path}").
+          to_return(:status => 200, :body => resp2)
+        c = ECSCredentials.new(backoff:0)
+        expect(c.credentials.access_key_id).to eq('akid-2')
+        expect(c.credentials.secret_access_key).to eq('secret-2')
+        expect(c.credentials.session_token).to eq('session-token-2')
+        expect(c.expiration.to_s).to eq(expiration2.to_s)
+      end
+
+      it 'retries if get profile response is invalid JSON' do
+        stub_request(:get, "http://169.254.170.2#{path}").
+          to_return(:status => 200, :body => ' ').
+          to_return(:status => 200, :body => '').
+          to_return(:status => 200, :body => '{').
+          to_return(:status => 200, :body => resp2)
+        c = ECSCredentials.new(backoff:0)
+        expect(c.credentials.access_key_id).to eq('akid-2')
+        expect(c.credentials.secret_access_key).to eq('secret-2')
+        expect(c.credentials.session_token).to eq('session-token-2')
+        expect(c.expiration.to_s).to eq(expiration2.to_s)
+      end
+
+      it 'retries invalid JSON exactly 3 times' do
+        stub_request(:get, "http://169.254.170.2#{path}").
+          to_return(:status => 200, :body => '').
+          to_return(:status => 200, :body => ' ').
+          to_return(:status => 200, :body => '{').
+          to_return(:status => 200, :body => ' ')
+        expect {
+          ECSCredentials.new(backoff:0)
+        }.to raise_error(JSON::ParserError)
+      end
+
+      it 'retries errors parsing expiration time 3 times' do
+        stub_request(:get, "http://169.254.170.2#{path}").
+          to_return(:status => 200, :body => '{ "Expiration": "Expiration" }').
+          to_return(:status => 200, :body => '{ "Expiration": "Expiration" }').
+          to_return(:status => 200, :body => '{ "Expiration": "Expiration" }').
+          to_return(:status => 200, :body => '{ "Expiration": "Expiration" }')
+        expect {
+          ECSCredentials.new(backoff:0)
+        }.to raise_error(ArgumentError)
+      end
+
+      describe 'auto refreshing' do
+
+        # expire in 4 minutes
+        let(:expiration) { Time.now.utc + 299 }
+
+        it 'auto-refreshes within 5 minutes from expiration' do
+          c = ECSCredentials.new
+          expect(c.credentials.access_key_id).to eq('akid-2')
+          expect(c.credentials.secret_access_key).to eq('secret-2')
+          expect(c.credentials.session_token).to eq('session-token-2')
+          expect(c.expiration.to_s).to eq(expiration2.to_s)
+        end
+
+      end
+
+      describe 'failure cases' do
+
+        let(:resp) { '{}' }
+
+        it 'given an empty response, entry credentials are returned' do
+          # This handles the case when the service response but returns
+          # a JSON document without credentials (error cases)
+          stub_request(:get, "http://169.254.170.2#{path}").
+            to_return(:status => 200, :body => resp)
+          c = ECSCredentials.new
+          expect(c.set?).to be(false)
+          expect(c.credentials.access_key_id).to be(nil)
+          expect(c.credentials.secret_access_key).to be(nil)
+          expect(c.credentials.session_token).to be(nil)
+          expect(c.expiration).to be(nil)
+        end
+
+      end
+
+    end
+
+    describe '#retries' do
+
+      before(:each) do
+        stub_const('ENV', {
+          "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" => path
+        })
+      end
+
+      it 'defaults to 0' do
+        stub_request(:get, "http://169.254.170.2#{path}").to_raise(SocketError)
+        expect(ECSCredentials.new(backoff:0).retries).to be(5)
+      end
+
+      it 'keeps trying "retries" times, with exponential backoff' do
+        expected_request = stub_request(:get, "http://169.254.170.2#{path}").
+          to_raise(Errno::ECONNREFUSED)
+        expect(Kernel).to receive(:sleep).with(1)
+        expect(Kernel).to receive(:sleep).with(2)
+        expect(Kernel).to receive(:sleep).with(4)
+        ECSCredentials.new(
+          backoff: lambda{|n| Kernel.sleep(2 ** n ) },
+          retries:3
+        )
+        assert_requested(expected_request, times:4)
+      end
+
+    end
+  end
+end

--- a/aws-sdk-core/spec/spec_helper.rb
+++ b/aws-sdk-core/spec/spec_helper.rb
@@ -15,14 +15,16 @@ SimpleCov.command_name('test:unit:aws-sdk-core')
 RSpec.configure do |config|
   config.before(:each) do
 
+    # Note that failure to do this could trigger ECS Credentials, which are
+    # gated by an environment variable
     stub_const('ENV', {})
 
     # disable loading credentials from shared file
     allow(Dir).to receive(:home).and_raise(ArgumentError)
 
     # disable instance profile credentials
-    path = '/latest/meta-data/iam/security-credentials/'
-    stub_request(:get, "http://169.254.169.254#{path}").to_raise(SocketError)
+    ec2_md_path = '/latest/meta-data/iam/security-credentials/'
+    stub_request(:get, "http://169.254.169.254#{ec2_md_path}").to_raise(SocketError)
 
   end
 end


### PR DESCRIPTION
Adds the `Aws::ECSCredentials` class, which provides refreshable
credentials within Amazon EC2 Container Service containers, when the
credential provider feature is enabled.

Also, adds this credential provider to the default credential provider
chain. If the feature is present, the `Aws::ECSCredentials` provider
will be used instead of the EC2 Instance Metadata service provider.