### PR TITLE
Now raising helpful errors for SocketErrors on invalid region/endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Unreleased Changes
 
   See related [GitHub issue #1237](https://github.com/aws/aws-sdk-ruby/issues/1237).
 
+* Issue - Networking Errors - Now providing helpful error messages when recieving
+  a SocketError that appears to be caused by an invalid `:region` or `:endpoint`
+  option.
+
+  See related [GitHub pull request #1246](https://github.com/aws/aws-sdk-ruby/pull/1246).
+
 2.4.0 (2016-07-19)
 ------------------
 

--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -168,6 +168,7 @@ module Aws
     autoload :GlacierApiVersion, 'aws-sdk-core/plugins/glacier_api_version'
     autoload :GlacierChecksums, 'aws-sdk-core/plugins/glacier_checksums'
     autoload :GlobalConfiguration, 'aws-sdk-core/plugins/global_configuration'
+    autoload :HelpfulSocketErrors, 'aws-sdk-core/plugins/helpful_socket_errors'
     autoload :Logging, 'aws-sdk-core/plugins/logging'
     autoload :MachineLearningPredictEndpoint, 'aws-sdk-core/plugins/machine_learning_predict_endpoint'
     autoload :ParamConverter, 'aws-sdk-core/plugins/param_converter'

--- a/aws-sdk-core/lib/aws-sdk-core/client.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/client.rb
@@ -9,6 +9,7 @@ module Aws
       'Aws::Plugins::ParamConverter',
       'Aws::Plugins::ParamValidator',
       'Aws::Plugins::UserAgent',
+      'Aws::Plugins::HelpfulSocketErrors',
       'Aws::Plugins::RetryErrors',
       'Aws::Plugins::GlobalConfiguration',
       'Aws::Plugins::RegionalEndpoint',

--- a/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -59,7 +59,8 @@ module Aws
     class NoSuchEndpointError < RuntimeError
 
       def initialize(options = {})
-        @endpoint = options[:endpoint]
+        @context = options[:context]
+        @endpoint = @context.http_request.endpoint
         @original_error = options[:original_error]
         super(<<-MSG)
 Encountered a `SocketError` while attempting to connect to:
@@ -81,6 +82,8 @@ Known possible regions include:
 #{possible_regions}
         MSG
       end
+
+      attr_reader :context
 
       attr_reader :endpoint
 

--- a/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -77,7 +77,7 @@ This is typically the result of an invalid `:region` option.
 * Avoid configuring the `:endpoint` option directly; This is reserved for
   connecting to non-standard test endpoints.
 
-Known possible regions include:
+Known AWS regions include (not specific to this service):
 
 #{possible_regions}
         MSG

--- a/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -67,15 +67,17 @@ Encountered a `SocketError` while attempting to connect to:
 
   #{endpoint.to_s}
 
-This is typically the result of an invalid `:region` option.
+This is typically the result of an invalid `:region` option or a
+poorly formatted `:endpoint` option.
+
+* Avoid configuring the `:endpoint` option directly. Endpoints are constructed
+  from the `:region`. The `:endpoint` option is reserved for connecting to
+  non-standard test endpoints.
 
 * Not every service is available in every region.
 
 * Never suffix region names with availability zones.
   Use "us-east-1", not "us-east-1a"
-
-* Avoid configuring the `:endpoint` option directly; This is reserved for
-  connecting to non-standard test endpoints.
 
 Known AWS regions include (not specific to this service):
 

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
@@ -21,12 +21,13 @@ module Aws
         def socket_endpoint_error?(error)
           Seahorse::Client::NetworkingError === error &&
           SocketError === error.original_error &&
-          error.original_error.message.match(/failed to open tcp connection/i)
+          error.original_error.message.match(/failed to open tcp connection/i) &&
+          error.original_error.message.match(/getaddrinfo: nodename nor servname provided, or not known/i)
         end
 
         def no_such_endpoint_error(context, error)
           Errors::NoSuchEndpointError.new({
-            endpoint: context.http_request.endpoint,
+            context: context,
             original_error: error.original_error,
           })
         end

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
@@ -1,0 +1,40 @@
+module Aws
+  module Plugins
+    # @api private
+    class HelpfulSocketErrors < Seahorse::Client::Plugin
+
+      class Handler < Seahorse::Client::Handler
+
+        # Wrap `SocketError` errors with `Aws::Errors::NoSuchEndpointError`
+        def call(context)
+          response = @handler.call(context)
+          response.context.http_response.on_error do |error|
+            if socket_endpoint_error?(error)
+              response.error = no_such_endpoint_error(context, error)
+            end
+          end
+          response
+        end
+
+        private
+
+        def socket_endpoint_error?(error)
+          Seahorse::Client::NetworkingError === error &&
+          SocketError === error.original_error &&
+          error.original_error.message.match(/failed to open tcp connection/i)
+        end
+
+        def no_such_endpoint_error(context, error)
+          Errors::NoSuchEndpointError.new({
+            endpoint: context.http_request.endpoint,
+            original_error: error.original_error,
+          })
+        end
+
+      end
+
+      handle(Handler, step: :sign)
+
+    end
+  end
+end

--- a/aws-sdk-core/spec/aws/client_spec.rb
+++ b/aws-sdk-core/spec/aws/client_spec.rb
@@ -47,15 +47,17 @@ Encountered a `SocketError` while attempting to connect to:
 
   https://s3.us-west-2a.amazonaws.com/
 
-This is typically the result of an invalid `:region` option.
+This is typically the result of an invalid `:region` option or a
+poorly formatted `:endpoint` option.
+
+* Avoid configuring the `:endpoint` option directly. Endpoints are constructed
+  from the `:region`. The `:endpoint` option is reserved for connecting to
+  non-standard test endpoints.
 
 * Not every service is available in every region.
 
 * Never suffix region names with availability zones.
   Use "us-east-1", not "us-east-1a"
-
-* Avoid configuring the `:endpoint` option directly; This is reserved for
-  connecting to non-standard test endpoints.
 
 Known AWS regions include (not specific to this service):
 

--- a/aws-sdk-core/spec/aws/client_spec.rb
+++ b/aws-sdk-core/spec/aws/client_spec.rb
@@ -38,6 +38,7 @@ module Aws
         end
 
         expect(e).to be_kind_of(Errors::NoSuchEndpointError)
+        expect(e.context.retries).to be(0) # should not retry these
         expect(e.message).to include('us-east-1')
         expect(e.message).to include('us-west-1')
         expect(e.message).to include('cn-north-1')

--- a/aws-sdk-core/spec/aws/client_spec.rb
+++ b/aws-sdk-core/spec/aws/client_spec.rb
@@ -57,7 +57,7 @@ This is typically the result of an invalid `:region` option.
 * Avoid configuring the `:endpoint` option directly; This is reserved for
   connecting to non-standard test endpoints.
 
-Known possible regions include:
+Known AWS regions include (not specific to this service):
 
         MSG
       end


### PR DESCRIPTION
When receiving a networking error (`SocketError`) that that results from a failure to open a TCP connection, the error will now be decorated as `Aws::Errors::NoSuchEndpointError`. The error provides helpful information on how to likely resolve the issue, including listing known regions.

The following Ruby code:

```ruby
s3 = Aws::S3::Client.new(region:'us-east-1a')
s3.list_buckets
```

Raises the following error:

```
Aws::Errors::NoSuchEndpointError: Encountered a `SocketError` while attempting to connect to:

  https://s3.us-east-1a.amazonaws.com/

This is typically the result of an invalid `:region` option.

* Not every service is available in every region.

* Never suffix region names with availability zones.
  Use "us-east-1", not "us-east-1a"

* Avoid configuring the `:endpoint` option directly; This is reserved for
  connecting to non-standard test endpoints.

Known possible regions include:

us-east-1
us-west-1
us-west-2
ap-northeast-1
ap-northeast-2
ap-south-1
ap-southeast-1
ap-southeast-2
sa-east-1
eu-west-1
eu-central-1
cn-north-1
us-gov-west-1
```

Fixes #1246