### PR TITLE
Fix comment on cloudfront/url_signer.rb

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
@@ -9,10 +9,12 @@ module Aws
 
     # Allows you to create signed URLs for Amazon CloudFront resources
     #
-    #     signer = Aws::CloudFront::UrlSigner.new
-    #     url = signer.signed_url(url,
+    #     signer = Aws::CloudFront::UrlSigner.new(
     #       key_pair_id: "cf-keypair-id",
     #       private_key_path: "./cf_private_key.pem"
+    #     )
+    #     url = signer.signed_url(url,
+    #       policy: policy.to_json
     #     )
     #
     class UrlSigner


### PR DESCRIPTION
When UrlSigner initialized, arguments should be provided as the test code do.

https://github.com/hamadata/aws-sdk-ruby/blob/master/aws-sdk-core/spec/aws/cloud_front/url_signer_spec.rb#L13