### PR TITLE
Added pagination to ECR methods describe_repositories and list_images

### DIFF
--- a/aws-sdk-core/apis/ecr/2015-09-21/paginators-1.json
+++ b/aws-sdk-core/apis/ecr/2015-09-21/paginators-1.json
@@ -1,0 +1,16 @@
+{
+  "pagination": {
+    "DescribeRepositories": {
+      "result_key": "Repositories",
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListImages": {
+      "result_key": "imageIds",
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
+}

--- a/aws-sdk-core/lib/aws-sdk-core/ecr.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/ecr.rb
@@ -2,4 +2,5 @@ Aws.add_service(:ECR, {
   api: "#{Aws::API_DIR}/ecr/2015-09-21/api-2.json",
   docs: "#{Aws::API_DIR}/ecr/2015-09-21/docs-2.json",
   examples: "#{Aws::API_DIR}/ecr/2015-09-21/examples-1.json",
+  paginators: "#{Aws::API_DIR}/ecr/2015-09-21/paginators-1.json",
 })


### PR DESCRIPTION
This PR will add pagination to the output of the `describe_repositories` and `list_images` methods  of `ECR`. 

closes #1260 