### PR TITLE
s3 markers do not get included in the list

### DIFF
--- a/aws-sdk-core/apis/s3/2006-03-01/docs-2.json
+++ b/aws-sdk-core/apis/s3/2006-03-01/docs-2.json
@@ -1256,7 +1256,7 @@
         "ListMultipartUploadsOutput$KeyMarker": "The key at or after which the listing began.",
         "ListMultipartUploadsRequest$KeyMarker": "Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin.",
         "ListObjectVersionsOutput$KeyMarker": "Marks the last Key returned in a truncated response.",
-        "ListObjectVersionsRequest$KeyMarker": "Specifies the key to start with when listing objects in a bucket."
+        "ListObjectVersionsRequest$KeyMarker": "Specifies the key to start after when listing objects in a bucket."
       }
     },
     "KeyPrefixEquals": {
@@ -1415,7 +1415,7 @@
       "base": null,
       "refs": {
         "ListObjectsOutput$Marker": null,
-        "ListObjectsRequest$Marker": "Specifies the key to start with when listing objects in a bucket."
+        "ListObjectsRequest$Marker": "Specifies the key to start after when listing objects in a bucket."
       }
     },
     "MaxAgeSeconds": {


### PR DESCRIPTION
I was confused by the documentation which made it seem inclusive, but
looking at the s3 api docs at http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
I see that there is a parameter named start-after.