### PR TITLE
Allow setting config/credential files via environment variables

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -20,7 +20,11 @@ module Aws
     # `~/.aws/credentials`) and the shared config file (the default path for
     # which is `~/.aws/config`) are loaded. However, if you set the
     # `ENV['AWS_SDK_CONFIG_OPT_OUT']` environment variable, only the shared
-    # credential file will be loaded.
+    # credential file will be loaded. You can specify the shared credential
+    # file path with the `ENV['AWS_SHARED_CREDENTIALS_FILE']` environment
+    # variable or with the `:credentials_path` option. Similarly, you can
+    # specify the shared config file path with the `ENV['AWS_CONFIG_FILE']`
+    # environment variable or with the `:config_path` option.
     #
     # The default profile name is 'default'. You can specify the profile name
     # with the `ENV['AWS_PROFILE']` environment variable or with the
@@ -28,9 +32,11 @@ module Aws
     #
     # @param [Hash] options
     # @option options [String] :credentials_path Path to the shared credentials
-    #   file. Defaults to "#{Dir.home}/.aws/credentials".
+    #   file. If not specified, will check `ENV['AWS_SHARED_CREDENTIALS_FILE']`
+    #   before using the default value of "#{Dir.home}/.aws/credentials".
     # @option options [String] :config_path Path to the shared config file.
-    #   Defaults to "#{Dir.home}/.aws/config".
+    #   If not specified, will check `ENV['AWS_CONFIG_FILE']` before using the
+    #   default value of "#{Dir.home}/.aws/config".
     # @option options [String] :profile_name The credential/config profile name
     #   to use. If not specified, will check `ENV['AWS_PROFILE']` before using
     #   the fixed default value of 'default'.
@@ -254,11 +260,11 @@ module Aws
     end
 
     def determine_credentials_path
-      default_shared_config_path('credentials')
+      ENV['AWS_SHARED_CREDENTIALS_FILE'] || default_shared_config_path('credentials')
     end
 
     def determine_config_path
-      default_shared_config_path('config')
+      ENV['AWS_CONFIG_FILE'] || default_shared_config_path('config')
     end
 
     def default_shared_config_path(file)

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -37,6 +37,20 @@ module Aws
         )
       end
 
+      it 'will use the ENV variable AWS_SHARED_CREDENTIALS_FILE if set' do
+        expected_credentials_path = '/tmp/aws-test-credentials.ini'
+        stub_const('ENV', 'AWS_SHARED_CREDENTIALS_FILE' => expected_credentials_path)
+        config = SharedConfig.new
+        expect(config.credentials_path).to eq(expected_credentials_path)
+      end
+
+      it 'will use the ENV variable AWS_CONFIG_FILE if set' do
+        expected_config_path = '/tmp/aws-test-config.ini'
+        stub_const('ENV', 'AWS_CONFIG_FILE' => expected_config_path)
+        config = SharedConfig.new(config_enabled: true)
+        expect(config.config_path).to eq(expected_config_path)
+      end
+
       it 'will not load the shared config file if no ENV variable set' do
         config = SharedConfig.new
         expect(config.config_path).to be_nil


### PR DESCRIPTION
Adds support for setting the paths to the config and credentials files via environment variables, named the same as the ones used by botocore/awscli.
- config file: `AWS_CONFIG_FILE`
- credentials file: `AWS_SHARED_CREDENTIALS_FILE`
