### PR TITLE
fixes spelling errors in several files. "encyrption" => "encryption"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2845,7 +2845,7 @@ Unreleased Changes
   #=> "... cipher text ..."
   ```
 
-  You can configure a `:key_provider` to the encyrption client to allow
+  You can configure a `:key_provider` to the encryption client to allow
   for using multiple decryption keys. See the `Aws::S3::Encryption::Client`
   API documentation for more information.
 

--- a/aws-sdk-resources/features/s3/client_side_encryption.feature
+++ b/aws-sdk-resources/features/s3/client_side_encryption.feature
@@ -8,7 +8,7 @@ Feature: S3 Objects
   Scenario: Encrypting client-side with GET and PUT
     Given I have an encryption client
     When I perform an encrypted PUT of the value "secret"
-    And I GET the object with a non-encyrption client
+    And I GET the object with a non-encryption client
     Then the object data should be encrypted
     When I GET the object with an encryption client
     Then the object data should be "secret"
@@ -25,7 +25,7 @@ Feature: S3 Objects
     Given a "kms_key_id" is set in cfg["cse_kms"]["kms_key_id"]
     And I have an encryption client configured to use KMS
     When I perform an encrypted PUT of the value "secret"
-    And I GET the object with a non-encyrption client
+    And I GET the object with a non-encryption client
     Then the object data should be encrypted
     When I GET the object with an encryption client
     Then the object data should be "secret"

--- a/aws-sdk-resources/features/s3/step_definitions.rb
+++ b/aws-sdk-resources/features/s3/step_definitions.rb
@@ -73,7 +73,7 @@ When(/^I perform an encrypted PUT of the value "(.*?)"$/) do |value|
   @cse.put_object(bucket: @bucket_name, key: @key, body: @plain_text)
 end
 
-When(/^I GET the object with a non\-encyrption client$/) do
+When(/^I GET the object with a non\-encryption client$/) do
   @cipher_text = @s3.client.get_object(bucket: @bucket_name, key: @key).body.read
 end
 

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/encryption/decrypt_handler.rb
@@ -62,7 +62,7 @@ module Aws
           if envelope = get_encryption_envelope(context)
             context[:encryption][:cipher_provider].decryption_cipher(envelope)
           else
-            raise Errors::DecryptionError, "unable to locate encyrption envelope"
+            raise Errors::DecryptionError, "unable to locate encryption envelope"
           end
         end
 

--- a/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/encryption/client_spec.rb
@@ -322,7 +322,7 @@ module Aws
                 to_return(status: 404)
               expect {
                 client.get_object(bucket:'bucket', key:'key')
-              }.to raise_error(Errors::DecryptionError, 'unable to locate encyrption envelope')
+              }.to raise_error(Errors::DecryptionError, 'unable to locate encryption envelope')
             end
 
             it 'resets the cipher during decryption on error' do


### PR DESCRIPTION
"Encryption" was spelled as "encyrption" in several files. This commit fixes all those errors.