### PR TITLE
fixed Aws::RDS::DBInstance#pending_maintenance_actions validate parameters error

### DIFF
--- a/aws-sdk-core/apis/rds/2014-10-31/resources-1.json
+++ b/aws-sdk-core/apis/rds/2014-10-31/resources-1.json
@@ -1813,7 +1813,7 @@
                                 "value": "db-instance-id"
                             },
                             {
-                                "target": "Filters[0].Value",
+                                "target": "Filters[0].Values[]",
                                 "source": "identifier",
                                 "name": "Id"
                             }


### PR DESCRIPTION
Aws::RDS::DBInstance#pending_maintenance_actions occur parameters validation error.

```
[1] pry(main)> Aws::RDS::Resource.new.db_instance("test-posgres0001").pending_maintenance_actions.first
ArgumentError: parameter validator found 2 errors:                                                    
  - missing required parameter params[:filters][0][:values]
  - unexpected value at params[:filters][0][:value]
from /home/ohba/rails/cu-development.service/tmp/bundler/ruby/2.3.0/gems/aws-sdk-core-2.5.11/lib/aws-sdk-core/param_validator.rb:28:in `validate!'
```

I fixed.