### PR TITLE
Fix InstanceProfileCredentials warning

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -119,7 +119,7 @@ module Aws
       retries = 0
       begin
         yield
-      rescue *error_classes => error
+      rescue *error_classes
         if retries < max_retries
           @backoff.call(retries)
           retries += 1

--- a/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
+++ b/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
@@ -174,7 +174,7 @@ module Aws
         expect(InstanceProfileCredentials.new(backoff:0).retries).to be(5)
       end
 
-      it 'keepts trying "retries" times, with exponential backoff' do
+      it 'keeps trying "retries" times, with exponential backoff' do
         expected_request = stub_request(:get, "http://169.254.169.254#{path}").
           to_raise(Errno::ECONNREFUSED)
         expect(Kernel).to receive(:sleep).with(1)


### PR DESCRIPTION
Previously it was rescuing an error but then doing nothing with it, which results in warnings being generated. Also fixes a typo in the tests.

```
/Users/kdeisz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/aws-sdk-core-2.4.3/lib/aws-sdk-core/instance_profile_credentials.rb:122: warning: assigned but unused variable - error
```