### PR TITLE
Fix Aws::Resources warning

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources.rb
@@ -64,11 +64,11 @@ module Aws
           'stop' => 'batch_stop',
           'terminate' => 'batch_terminate!',
           'unmonitor' => 'batch_unmonitor',
-        }.each do |deprecated_name, name|
+        }.each do |deprecated_name, correct_name|
           Resources::Operations::DeprecatedOperation.define({
             resource_class: EC2::Instance,
             deprecated_name: deprecated_name,
-            name: name,
+            name: correct_name,
           })
         end
         Resources::Operations::DeprecatedOperation.define({


### PR DESCRIPTION
Previously this loop was shadowing an outer variable, resulting in a ruby warning.

```
/Users/kdeisz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/aws-sdk-resources-2.4.3/lib/aws-sdk-resources.rb:67: warning: shadowing outer local variable - name
```