### PR TITLE
Add missing "path" for CloudFormation "Stacks" collection

### DIFF
--- a/aws-sdk-core/apis/cloudformation/2010-05-15/resources-1.json
+++ b/aws-sdk-core/apis/cloudformation/2010-05-15/resources-1.json
@@ -36,7 +36,8 @@
           "type": "Stack",
           "identifiers": [
             { "target": "Name", "source": "response", "path": "Stacks[].StackName" }
-          ]
+          ],
+          "path": "Stacks[]"
         }
       }
     }


### PR DESCRIPTION
The adds a "path" to for the "Stacks" resource collection, allowing data to be loaded into Stack objects by the "DescribeStacks" call.

Addresses aws/aws-sdk-ruby#1265.

As far as I could see, "Stacks" is the only "hasMany" collection that is missing a "path".
