### PR TITLE
Recognise Kinesis throttling errors.

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -32,6 +32,7 @@ module Aws
           'ProvisionedThroughputExceededException', # dynamodb
           'RequestLimitExceeded',                   # ec2
           'BandwidthLimitExceeded',                 # cloud search
+          'LimitExceededException',                 # kinesis
         ])
 
         CHECKSUM_ERRORS = Set.new([

--- a/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -83,6 +83,11 @@ module Aws
             expect(inspector(error).throttling_error?).to be(true)
           end
 
+          it 'returns true for LimitExceededException' do
+            error = Kinesis::Errors::LimitExceededException.new(nil,nil)
+            expect(inspector(error).throttling_error?).to be(true)
+          end
+
           it 'returns true for error codes that match /throttl/' do
             error = IAM::Errors::Throttled.new(nil,nil)
             expect(inspector(error).throttling_error?).to be(true)


### PR DESCRIPTION
Kinesis can raise a `LimitExceededException` that isn't retried like other throttling errors as the name doesn't include 'throttl' and it's not included in the whitelist of other throttling errors.

This adds the exception to the whitelist so it can be retried.
