### PR TITLE
remove unnecessary documentation note

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -70,9 +70,6 @@ module Aws
       # Copies this object to another object. Use `multipart_copy: true`
       # for large objects. This is required for objects that exceed 5GB.
       #
-      # @note If you need to copy to a bucket in a different region, use
-      #   {#copy_from}.
-      #
       # @param [S3::Object, String, Hash] target Where to copy the object
       #   data to. `target` must be one of the following:
       #


### PR DESCRIPTION
in my testing, Aws::S3::Object#copy_to and Aws::S3::Object#copy_from
both work equally well for cross-region copies.  if that isn't the case,
then i think the note this commit removes needs more detail about which
scenarios #copy_to cannot handle that #copy_from can.
