### PR TITLE
Allow passing extra option to Aws::Resources::Resource#exists?

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/operations.rb
@@ -221,7 +221,7 @@ module Aws
 
           resource = options[:resource]
 
-          params_hash = {}
+          params_hash = options[:args].first || {}
           @waiter_params.each do |param|
             param.apply(params_hash, options)
           end

--- a/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/resource.rb
@@ -127,8 +127,8 @@ module Aws
       end
 
       # @api private
-      def exists?
-        wait_until_exists { |w| w.max_attempts = 1 }
+      def exists?(options = {})
+        wait_until_exists(options) { |w| w.max_attempts = 1 }
         true
       rescue Waiters::Errors::UnexpectedError => e
         raise e.error


### PR DESCRIPTION
Adds ability to pass additional waiter params to ```Aws::Resources::Resource#exists?``` and ```Aws::Resources::Operations::WaiterOperation```

Related issue #1342