### PR TITLE
Add support for "idempotencyToken" auto-fill

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -175,6 +175,7 @@ module Aws
     autoload :GlacierChecksums, 'aws-sdk-core/plugins/glacier_checksums'
     autoload :GlobalConfiguration, 'aws-sdk-core/plugins/global_configuration'
     autoload :HelpfulSocketErrors, 'aws-sdk-core/plugins/helpful_socket_errors'
+    autoload :IdempotencyToken, 'aws-sdk-core/plugins/idempotency_token'
     autoload :Logging, 'aws-sdk-core/plugins/logging'
     autoload :MachineLearningPredictEndpoint, 'aws-sdk-core/plugins/machine_learning_predict_endpoint'
     autoload :ParamConverter, 'aws-sdk-core/plugins/param_converter'

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -85,7 +85,6 @@ module Aws
       plugins('ec2', add: %w(
         Aws::Plugins::EC2CopyEncryptedSnapshot
         Aws::Plugins::EC2RegionValidation
-        Aws::Plugins::IdempotencyToken
       ))
 
       api('glacier') do |api|

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -85,6 +85,7 @@ module Aws
       plugins('ec2', add: %w(
         Aws::Plugins::EC2CopyEncryptedSnapshot
         Aws::Plugins::EC2RegionValidation
+        Aws::Plugins::IdempotencyToken
       ))
 
       api('glacier') do |api|

--- a/aws-sdk-core/lib/aws-sdk-core/api/docs/operation_documenter.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/docs/operation_documenter.rb
@@ -46,6 +46,10 @@ module Aws
             type = input_type(ref)
             docstring = "@option #{@optname} [#{req}#{type}] :#{name}\n"
             docstring += ref.documentation.to_s.lines.map { |line| "  #{line}" }.join
+            if ref['idempotencyToken']
+              docstring << "\n\n  This parameter will be auto-filled on your behalf"\
+                " with a random UUIDv4 when no value is provided.\n"
+            end
             tag(docstring)
           end
         end

--- a/aws-sdk-core/lib/aws-sdk-core/client.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/client.rb
@@ -16,6 +16,7 @@ module Aws
       'Aws::Plugins::RequestSigner',
       'Aws::Plugins::ResponsePaging',
       'Aws::Plugins::StubResponses',
+      'Aws::Plugins::IdempotencyToken',
     ]
 
     # @api private

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
@@ -1,0 +1,43 @@
+require 'securerandom'
+
+module Aws
+  module Plugins
+
+    # Provides support for auto filling operation parameters
+    # that enabled with `idempotencyToken` trait  with random UUID v4
+    # when no value is provided
+    class IdempotencyToken < Seahorse::Client::Plugin
+
+      option(:idempotency_auto_fill, false)
+
+      # @api private
+      class Handler < Seahorse::Client::Handler
+
+        # @param [RequestContext] context
+        # @param [Response]
+        def call(context)
+          enable_auto_fill = context.params.delete(:idempotency_auto_fill)
+          enable_auto_fill = context.config.idempotency_auto_fill if enable_auto_fill.nil?
+          if enable_auto_fill
+            auto_fill(context.params, context.operation.input)
+          end
+          @handler.call(context)
+        end
+
+        private
+
+        def auto_fill(params, ref)
+          ref.shape.members.each do |name, member_ref|
+            if member_ref['idempotencyToken']
+              params[name] = params[name] || SecureRandom.uuid
+            end
+          end
+        end
+
+      end
+
+      handler(Handler, step: :initialize)
+
+    end
+  end
+end

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
@@ -14,9 +14,7 @@ module Aws
         # @param [RequestContext] context
         # @param [Response]
         def call(context)
-          unless context.params.delete(:disable_idempotency_auto_fill)
-            auto_fill(context.params, context.operation.input)
-          end
+          auto_fill(context.params, context.operation.input)
           @handler.call(context)
         end
 

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
@@ -8,17 +8,13 @@ module Aws
     # when no value is provided
     class IdempotencyToken < Seahorse::Client::Plugin
 
-      option(:idempotency_auto_fill, false)
-
       # @api private
       class Handler < Seahorse::Client::Handler
 
         # @param [RequestContext] context
         # @param [Response]
         def call(context)
-          enable_auto_fill = context.params.delete(:idempotency_auto_fill)
-          enable_auto_fill = context.config.idempotency_auto_fill if enable_auto_fill.nil?
-          if enable_auto_fill
+          unless context.params.delete(:disable_idempotency_auto_fill)
             auto_fill(context.params, context.operation.input)
           end
           @handler.call(context)
@@ -29,7 +25,7 @@ module Aws
         def auto_fill(params, ref)
           ref.shape.members.each do |name, member_ref|
             if member_ref['idempotencyToken']
-              params[name] = params[name] || SecureRandom.uuid
+              params[name] ||= SecureRandom.uuid
             end
           end
         end

--- a/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
@@ -12,18 +12,6 @@ module Aws
         )
       }
 
-      it 'can disable auto_fill per operation' do
-        resp = ec2.run_scheduled_instances(
-          instance_count: 1,
-          launch_specification: {
-            image_id: "ami-12345678",
-          },
-          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
-          disable_idempotency_auto_fill: true
-        )
-        expect(resp.context.params[:client_token]).to be_nil
-      end
-
       it 'auto fills param with `idempotencyToken` trait by default' do
         resp = ec2.run_scheduled_instances(
           instance_count: 1,

--- a/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+module Aws
+  module Plugins
+
+    describe IdempotencyToken do
+
+      let(:ec2) {
+        Aws::EC2::Client.new(
+          region: 'us-west-2',
+          stub_responses: true
+        )
+      }
+
+      let(:ec2_auto_fill) {
+        ec2 = Aws::EC2::Client.new(
+          region: 'us-west-2',
+          idempotency_auto_fill: true,
+          stub_responses: true
+        )
+      }
+
+      it 'disable auto_fill by default' do
+        resp = ec2.run_scheduled_instances(
+          instance_count: 1,
+          launch_specification: {
+            image_id: "ami-12345678",
+          },
+          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+        )
+        expect(resp.context.params[:client_token]).to be_nil
+      end
+
+      it 'disable auto_fill per operation' do
+        resp = ec2_auto_fill.run_scheduled_instances(
+          instance_count: 1,
+          launch_specification: {
+            image_id: "ami-12345678",
+          },
+          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+          idempotency_auto_fill: false
+        )
+        expect(resp.context.params[:client_token]).to be_nil
+      end
+
+      it 'auto fills param with `idempotencyToken` trait when enabled per operation' do
+        resp = ec2.run_scheduled_instances(
+          instance_count: 1,
+          launch_specification: {
+            image_id: "ami-12345678",
+          },
+          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+          idempotency_auto_fill: true
+        )
+        expect(
+          resp.context.params[:client_token]
+        ).to match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/)
+      end
+
+      it 'auto fills param with `idempotencyToken` trait when enabled per client' do
+        resp = ec2_auto_fill.run_scheduled_instances(
+          instance_count: 1,
+          launch_specification: {
+            image_id: "ami-12345678",
+          },
+          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+        )
+        expect(
+          resp.context.params[:client_token]
+        ).to match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/)
+      end
+
+      it 'allows overwriting params with UUID v4 auto filled' do
+        resp = ec2.run_scheduled_instances(
+          instance_count: 1,
+          launch_specification: {
+            image_id: "ami-12345678",
+          },
+          client_token: "foo",
+          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+          idempotency_auto_fill: true
+        )
+        expect(resp.context.params[:client_token]).to eq('foo')
+      end
+
+    end
+  end
+end

--- a/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/idempotency_token_spec.rb
@@ -12,53 +12,20 @@ module Aws
         )
       }
 
-      let(:ec2_auto_fill) {
-        ec2 = Aws::EC2::Client.new(
-          region: 'us-west-2',
-          idempotency_auto_fill: true,
-          stub_responses: true
-        )
-      }
-
-      it 'disable auto_fill by default' do
+      it 'can disable auto_fill per operation' do
         resp = ec2.run_scheduled_instances(
           instance_count: 1,
           launch_specification: {
             image_id: "ami-12345678",
           },
           scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
+          disable_idempotency_auto_fill: true
         )
         expect(resp.context.params[:client_token]).to be_nil
       end
 
-      it 'disable auto_fill per operation' do
-        resp = ec2_auto_fill.run_scheduled_instances(
-          instance_count: 1,
-          launch_specification: {
-            image_id: "ami-12345678",
-          },
-          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
-          idempotency_auto_fill: false
-        )
-        expect(resp.context.params[:client_token]).to be_nil
-      end
-
-      it 'auto fills param with `idempotencyToken` trait when enabled per operation' do
+      it 'auto fills param with `idempotencyToken` trait by default' do
         resp = ec2.run_scheduled_instances(
-          instance_count: 1,
-          launch_specification: {
-            image_id: "ami-12345678",
-          },
-          scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
-          idempotency_auto_fill: true
-        )
-        expect(
-          resp.context.params[:client_token]
-        ).to match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/)
-      end
-
-      it 'auto fills param with `idempotencyToken` trait when enabled per client' do
-        resp = ec2_auto_fill.run_scheduled_instances(
           instance_count: 1,
           launch_specification: {
             image_id: "ami-12345678",
@@ -78,7 +45,6 @@ module Aws
           },
           client_token: "foo",
           scheduled_instance_id: "sci-1234-1234-1234-1234-123456789012",
-          idempotency_auto_fill: true
         )
         expect(resp.context.params[:client_token]).to eq('foo')
       end


### PR DESCRIPTION
Adds support for auto-fill parameters with "idempotencyToken" trait enabled, populate default value  with a random UUIDv4.

@trevorrowe @awood45 