### PR TITLE
Fixes empty credential hash never getting refreshed

### DIFF
--- a/lib/aws/core/credential_providers.rb
+++ b/lib/aws/core/credential_providers.rb
@@ -47,9 +47,11 @@ module AWS
         #
         def set?
           @cache_mutex ||= Mutex.new
-          unless @cached_credentials
+          if @cached_credentials.nil? || @cached_credentials.empty?
             @cache_mutex.synchronize do
-              @cached_credentials ||= get_credentials
+              if @cached_credentials.nil? || @cached_credentials.empty?
+                @cached_credentials = get_credentials
+              end
             end
           end
           !!(@cached_credentials[:access_key_id] &&


### PR DESCRIPTION
This fix forces set? to also recheck for new credentials in case the credentials hash is empty and not only when it is nil.

In case of an EC2 instance using an instance profile the error AWS::Errors::MissingCredentialsError occurred from time to time (this also seems to occur in v2: https://github.com/aws/aws-sdk-ruby/issues/1301). It turned out to be a connection problem between the instance and the meta data service running on 169.254.169.254. However, even when the service is reachable again, the cached credentials (an empty hash) are never refreshed and clients keep ending up with the MissingCredentialsError.

Either each and every tool using calls which depend on AWS credentials could catch this error and force a AWS.config.credential_provider.refresh or the problem is fixed at it's root, as proposed by this pull request.