### PR TITLE
Lock Down webmock Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,8 @@ gem 'oga'
 group :test do
   gem 'rspec'
   gem 'cucumber'
-  gem 'webmock'
+  # webmock dropped support for Ruby 1.9.3 after version 2.2.0
+  gem 'webmock', '2.2.0'
   # webmock depends on addressable, but the latest version of addressable
   # has a dependency on ~> 2.0 of public_suffix which is not compatible
   # with Ruby 1.9.3

--- a/aws-sdk-core/spec/aws/polly/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/polly/presigner_spec.rb
@@ -23,7 +23,7 @@ module Aws
           expect {
             Presigner.new(region: region)
           }.to raise_error(
-            KeyError, 'key not found: :credentials'
+            KeyError, /credentials/
           )
         end
 
@@ -31,7 +31,7 @@ module Aws
           expect {
             Presigner.new(credentials: credentials)
           }.to raise_error(
-            KeyError, 'key not found: :region'
+            KeyError, /region/
           )
         end
 


### PR DESCRIPTION
Needed to fix breakage in 1.9.3 Ruby tests.