### PR TITLE
Fix error loading incorrect path

### DIFF
--- a/aws-sdk-core/lib/seahorse/client/plugin_list.rb
+++ b/aws-sdk-core/lib/seahorse/client/plugin_list.rb
@@ -87,7 +87,9 @@ module Seahorse
             @canonical_name = plugin.name || plugin.object_id
             @plugin = plugin
           when Symbol, String
-            @canonical_name, @gem_name = plugin.to_s.split('.').reverse
+            words = plugin.to_s.split('.')
+            @canonical_name = words.pop
+            @gem_name = words.empty? ? nil : words.join('.')
             @plugin = nil
           else
             @canonical_name = plugin.object_id

--- a/aws-sdk-core/spec/fixtures/example.com/plugin.rb
+++ b/aws-sdk-core/spec/fixtures/example.com/plugin.rb
@@ -1,0 +1,4 @@
+module YellowSeahorseFixtures
+  class Plugin
+  end
+end

--- a/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
+++ b/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
@@ -89,6 +89,13 @@ module Seahorse
           expect(plugins.to_a).to eq([SeahorseFixtures::Plugin])
         end
 
+        it 'requires prefixes including dot from plugin names when loading' do
+          expect(Kernel.const_defined?(:YellowSeahorseFixtures)).to eq(false)
+          prefix = File.dirname(File.dirname(File.dirname(__FILE__)))
+          plugins.add("#{prefix}/fixtures/example.com/plugin.YellowSeahorseFixtures::Plugin")
+          expect(plugins.to_a).to eq([YellowSeahorseFixtures::Plugin])
+        end
+
       end
 
       describe '#remove' do


### PR DESCRIPTION
If `.` is included in the directory path, a loading error occurs.

ex.: `/Users/ojiry/work/src/github.com/ojiry/aws-sdk-ruby/spec/fixtures/plugin.SeahorseFixtures::Plugin`

```shell
Failures:

  1) Seahorse::Client::PluginList#add requires prefixes from plugin names when loading
     Failure/Error: expect(plugins.to_a).to eq([SeahorseFixtures::Plugin])

     LoadError:
       cannot load such file -- com/ojiry/aws-sdk-ruby/aws-sdk-core/spec/fixtures/plugin
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:131:in `require_plugin'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:103:in `plugin'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:59:in `block in each'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:73:in `block in each_plugin'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:72:in `synchronize'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:72:in `each_plugin'
     # ./aws-sdk-core/lib/seahorse/client/plugin_list.rb:58:in `each'
     # ./aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb:89:in `to_a'
     # ./aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb:89:in `block (3 levels) in <module:Client>'
```