### PR TITLE
Re-enforce path addressing for S3 GetBucketLocation requests

### DIFF
--- a/aws-sdk-core/features/s3/buckets.feature
+++ b/aws-sdk-core/features/s3/buckets.feature
@@ -54,3 +54,12 @@ Feature: S3 Buckets
     When I create a bucket with the location constraint "us-west-2"
     When I put a large object
     Then the object should exist
+
+  Scenario: Get location of DNS-compatible bucket in nonstandard region
+    Given I am using the S3 "us-west-2" region
+    And I create a DNS compatible bucket
+    When I am using the S3 "us-east-1" region
+    When I get the bucket location
+    Then the bucket name should be in the request path
+    And the bucket name should not be in the request host
+    And the location constraint should be "us-west-2"

--- a/aws-sdk-core/features/s3/step_definitions.rb
+++ b/aws-sdk-core/features/s3/step_definitions.rb
@@ -272,3 +272,11 @@ end
 Given(/^I have a bucket configured with a virtual hosted CNAME$/) do
   @bucket_name = cfg_value('s3', 'virtual_hosted_bucket')
 end
+
+When(/^I get the bucket location$/) do
+  @response = @client.get_bucket_location(bucket: @bucket_name)
+end
+
+Then(/^the location constraint should be "([^"]*)"$/) do |lc|
+  expect(@response.location_constraint).to eq(lc)
+end

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_bucket_dns.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_bucket_dns.rb
@@ -39,7 +39,7 @@ module Aws
           if
             bucket_name &&
             S3BucketDns.dns_compatible?(bucket_name, https?(endpoint)) &&
-            context.operation_name != 'get_bucket_location'
+            context.operation_name.to_s != 'get_bucket_location'
           then
             move_bucket_to_subdomain(bucket_name, endpoint)
           end


### PR DESCRIPTION
Signature v4 broke GetBucketLocation requests that use virtual host
addressing of buckets; GetBucketLocation requests must now use path
addressing. This was addressed in 68a6cde, but this fix was later broken
by refactoring related to f19e4d8. This commit fixes 68a6cde and adds an
integration test for the behavior.