### PR TITLE
Lock down nokogiri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ end
 gem 'json', '1.8.3' if RUBY_VERSION == '1.9.3'
 gem 'ox' unless ENV['PURE_RUBY']
 gem 'libxml-ruby' unless ENV['PURE_RUBY']
-gem 'nokogiri' unless ENV['PURE_RUBY']
+# nokogiri dropped support for Ruby <= 2.0.0 in version 1.7.0
+gem 'nokogiri', '1.6.8.1' unless ENV['PURE_RUBY']
 gem 'oga'
 
 group :test do


### PR DESCRIPTION
Nokogiri 1.7 ended support for Ruby <= 2.0.0.