### PR TITLE
Fix Cloudfront url_signer for more than one query parameter in a Rails environment

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
@@ -138,7 +138,7 @@ module Aws
               }
           ]
         }
-        json_hash.to_json
+        JSON.dump json_hash
       end
 
       def encode(policy)

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
@@ -138,7 +138,7 @@ module Aws
               }
           ]
         }
-        JSON.dump json_hash
+        JSON.dump(json_hash)
       end
 
       def encode(policy)


### PR DESCRIPTION
Vanilla rails escapes html entities in json by default using `to_json`

Use `JSON.dump` to preserve html entities (e.g. `&` for more than one query param)

Fixes issue #1386 