### PR TITLE
Fix S3 bucket dns for IP endpoint

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_bucket_dns.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_bucket_dns.rb
@@ -39,6 +39,7 @@ module Aws
           if
             bucket_name &&
             S3BucketDns.dns_compatible?(bucket_name, https?(endpoint)) &&
+            endpoint.host !~ /(\d+\.){3}\d+/ &&
             context.operation_name.to_s != 'get_bucket_location'
           then
             move_bucket_to_subdomain(bucket_name, endpoint)

--- a/aws-sdk-core/spec/aws/plugins/s3_bucket_dns_endpoint_spec.rb
+++ b/aws-sdk-core/spec/aws/plugins/s3_bucket_dns_endpoint_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'uri'
+
+module Aws
+  module Plugins
+    describe S3BucketDns do
+
+      let(:plugin) { S3BucketDns.new }
+      
+      describe 'handler' do
+
+        let(:handlers) { Seahorse::Client::HandlerList.new }
+      
+        let(:config) { Seahorse::Client::Configuration.new }
+
+        let(:context) { Seahorse::Client::RequestContext.new }
+
+        before(:each) do
+          plugin.add_options(config)
+          plugin.add_handlers(handlers, config.build!)
+        end
+
+        it 's3 bucket aws endpoint' do
+          handlers.add(NoSendHandler, step: :send)
+          context.params[:bucket] = 'bucket-name'
+          context.http_request.endpoint = URI.parse("https://s3.amazonaws.com/")
+          resp = handlers.to_stack.call(context)
+          expect(resp.context.http_request.endpoint).to eq(URI.parse("https://bucket-name.s3.amazonaws.com/"))
+        end
+
+        it 's3 bucket IP endpoint' do
+          handlers.add(NoSendHandler, step: :send)
+          context.params[:bucket] = 'bucket-name'
+          context.http_request.endpoint = URI.parse("https://127.0.0.1:9021")
+          resp = handlers.to_stack.call(context)
+          expect(resp.context.http_request.endpoint).to eq(URI.parse("https://127.0.0.1:9021"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In case we have IP endpoint, the function move_dns_compat_bucket_to_subdomain change the endpoint path and doesn't allow to connect to the S3 API.

This is problematic when we have S3 endpoint of Dell/EMC Centera S3 API.