### PR TITLE
Don't set default port 80 explicitly. Fixes #1401

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
@@ -80,7 +80,6 @@ module Aws
           uri.host = context.params[:bucket]
           uri.path.sub!("/#{context.params[:bucket]}", '')
           uri.scheme = 'http'
-          uri.port = 80
           @handler.call(context)
         end
       end

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -109,6 +109,16 @@ module Aws
           expect(url).to match(/^http:/)
         end
 
+        it 'can generate virtual hosted url' do
+          signer = Presigner.new(client: client)
+          url = signer.presigned_url(:get_object,
+            bucket:'virtual.hosted.com',
+            key:'foo',
+            virtual_host: true
+          )
+          expect(url).to match(/^http:\/\/virtual.hosted.com\/foo/)
+        end
+
       end
     end
   end

--- a/aws-sdk-resources/spec/services/s3/object/presigned_url_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/presigned_url_spec.rb
@@ -31,7 +31,7 @@ module Aws
           })
 
           url = obj.presigned_url(:get, virtual_host: true)
-          expect(url).to match(/^http:\/\/my\.bucket\.com(:80)?\//)
+          expect(url).to match(/^http:\/\/my\.bucket\.com\//)
         end
 
         it 'rejects empty keys' do


### PR DESCRIPTION
No need to set port 80 explicitly on virtual_host presigned_url. Not setting it prevents problems for some HTTP clients. Fixes #1401 