### PR TITLE
Re-parse the virtual_host URI in presigned_url after changing the scheme. Fixes #1400, #1401

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
@@ -76,11 +76,12 @@ module Aws
       def use_bucket_as_hostname(req)
         req.handlers.remove(Plugins::S3BucketDns::Handler)
         req.handle do |context|
-          uri = context.http_request.endpoint
+          uri = context.http_request.endpoint.dup
           uri.host = context.params[:bucket]
           uri.path.sub!("/#{context.params[:bucket]}", '')
           uri.scheme = 'http'
           uri.port = 80
+          context.http_request.endpoint = URI.parse(uri.to_s)
           @handler.call(context)
         end
       end

--- a/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/s3/presigner.rb
@@ -42,6 +42,7 @@ module Aws
         if params[:key].nil? or params[:key] == ''
           raise ArgumentError, ":key must not be blank"
         end
+        params = params.dup
         virtual_host = !!params.delete(:virtual_host)
         scheme = http_scheme(params, virtual_host)
 

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -109,6 +109,16 @@ module Aws
           expect(url).to match(/^http:/)
         end
 
+        it 'can generate virtual hosted url' do
+          signer = Presigner.new(client: client)
+          url = signer.presigned_url(:get_object,
+            bucket:'virtual.hosted.com',
+            key:'foo',
+            virtual_host: true
+          )
+          expect(url).to match(/^http:\/\/virtual.hosted.com\/foo/)
+        end
+
       end
     end
   end

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -119,6 +119,18 @@ module Aws
           expect(url).to match(/^http:\/\/virtual.hosted.com\/foo/)
         end
 
+        it 'returns same url when called twice' do
+          signer = Presigner.new(client: client)
+          params = {
+            bucket:'virtual.hosted.com',
+            key:'foo',
+            virtual_host: true
+          }
+          signer.presigned_url(:get_object, params)
+          url = signer.presigned_url(:get_object, params)
+          expect(url).to match(/^http:\/\/virtual.hosted.com\/foo/)
+        end
+
       end
     end
   end

--- a/aws-sdk-core/spec/aws/s3/presigner_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/presigner_spec.rb
@@ -131,6 +131,21 @@ module Aws
           expect(url).to match(/^http:\/\/virtual.hosted.com\/foo/)
         end
 
+        it 'does not mutate the params hash' do
+          signer = Presigner.new(client: client)
+          params = {
+            bucket:'virtual.hosted.com',
+            key:'foo',
+            virtual_host: true
+          }
+          signer.presigned_url(:get_object, params)
+          expect(params).to include(
+            bucket:'virtual.hosted.com',
+            key:'foo',
+            virtual_host: true
+          )
+        end
+
       end
     end
   end

--- a/aws-sdk-resources/spec/services/s3/object/presigned_url_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/presigned_url_spec.rb
@@ -31,7 +31,7 @@ module Aws
           })
 
           url = obj.presigned_url(:get, virtual_host: true)
-          expect(url).to match(/^http:\/\/my\.bucket\.com(:80)?\//)
+          expect(url).to match(/^http:\/\/my\.bucket\.com\//)
         end
 
         it 'rejects empty keys' do


### PR DESCRIPTION
`Presigner#presigned_url` should not mutate params hash when it processes paramaters such as `virtual_host` and `secure`. This is fixed by duplicating the hash. Fixes #1400 