### PR TITLE
Add BuildTools::Changelog rspec

### DIFF
--- a/build_tools/changelog.rb
+++ b/build_tools/changelog.rb
@@ -48,6 +48,7 @@ module BuildTools
     # @option options [optional, Integer] :pull A related GitHub pull request number.
     #
     def add_entry(options)
+      add_unreleased_changes_section unless read.lines[0].strip == 'Unreleased Changes'
       lines = read.lines
       lines = lines[0..2] + Entry.new(options).lines + lines[3..-1]
       write(lines.join)

--- a/build_tools/changelog.rb
+++ b/build_tools/changelog.rb
@@ -48,8 +48,8 @@ module BuildTools
     # @option options [optional, Integer] :pull A related GitHub pull request number.
     #
     def add_entry(options)
-      add_unreleased_changes_section unless read.lines[0].strip == 'Unreleased Changes'
-      lines = read.lines
+      add_unreleased_changes_section unless read.lines.to_a[0].strip == 'Unreleased Changes'
+      lines = read.lines.to_a
       lines = lines[0..2] + Entry.new(options).lines + lines[3..-1]
       write(lines.join)
     end

--- a/build_tools/spec/changelog_spec.rb
+++ b/build_tools/spec/changelog_spec.rb
@@ -1,0 +1,141 @@
+require_relative 'spec_helper'
+
+module BuildTools
+  describe Changelog do
+
+    let(:path) { Tempfile.new('file').path }
+    let(:expected_changelog) { <<-LOG
+Unreleased Changes
+------------------
+
+* Feature - API update.
+
+1.0.0.rc2 (2016-12-09)
+------------------
+
+* Feature - API update.
+
+* Issue - Fixed an issue. See related Github issue #0000
+
+1.0.0.rc1 (2016-12-05)
+------------------
+
+* Feature - Initial preview release of the `aws-sdk-s3` gem.
+
+LOG
+    }
+
+    let(:expected_version) { <<-LOG
+foo.bar.baz (2017-02-08)
+------------------
+
+* Feature - API update.
+
+1.0.0.rc2 (2016-12-09)
+------------------
+
+* Feature - API update.
+
+* Issue - Fixed an issue. See related Github issue #0000
+
+1.0.0.rc1 (2016-12-05)
+------------------
+
+* Feature - Initial preview release of the `aws-sdk-s3` gem.
+
+LOG
+    }
+
+    let(:empty_changelog) { <<-LOG
+Unreleased Changes
+------------------
+
+1.0.0.rc1 (2016-12-05)
+------------------
+
+* Feature - Initial preview release of the `aws-sdk-s3` gem.
+
+LOG
+    }
+
+    let(:complete_log) { <<-LOG
+Unreleased Changes
+------------------
+
+1.0.0.rc2 (2016-12-09)
+------------------
+
+* Feature - API update.
+
+* Issue - Fixed an issue. See related Github issue #0000
+
+1.0.0.rc1 (2016-12-05)
+------------------
+
+* Feature - Initial preview release of the `aws-sdk-s3` gem.
+
+LOG
+    }
+
+    let(:incomplete_log) { <<-LOG
+1.0.0.rc2 (2016-12-09)
+------------------
+
+* Feature - API update.
+
+* Issue - Fixed an issue. See related Github issue #0000
+
+1.0.0.rc1 (2016-12-05)
+------------------
+
+* Feature - Initial preview release of the `aws-sdk-s3` gem.
+
+LOG
+    }
+
+    it 'adds entries when unreleased changes section presents' do
+      File.open(path, 'w', encoding: 'UTF-8') { |f| f.write(complete_log) }
+      changelog = Changelog.new(path: path)
+      changelog.add_entry(
+        type: :feature,
+        text: 'API update.'
+      )
+      new_changelog = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
+      expect(new_changelog).to eq(expected_changelog)
+    end
+
+    it 'adds entries under new unreleased section when not present' do
+      File.open(path, 'w', encoding: 'UTF-8') { |f| f.write(incomplete_log) }
+      changelog = Changelog.new(path: path)
+      changelog.add_entry(
+        type: :feature,
+        text: 'API update.'
+      )
+      new_changelog = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
+      expect(new_changelog).to eq(expected_changelog)
+    end
+
+    it 'grabs unreleased changes correctly' do
+      File.open(path, 'w', encoding: 'UTF-8') { |f| f.write(expected_changelog) }
+      changelog = Changelog.new(path: path)
+      expect(changelog.unreleased_changes.entries).not_to be_empty
+
+      File.open(path, 'w', encoding: 'UTF-8') { |f| f.write(empty_changelog) }
+      changelog = Changelog.new(path: path)
+      expect(changelog.unreleased_changes.entries).to be_empty
+    end
+
+    it 'updates version number correctly' do
+      File.open(path, 'w', encoding: 'UTF-8') { |f| f.write(expected_changelog) }
+
+      changelog = Changelog.new(path: path)
+      changelog.version_unreleased_changes(
+        version: 'foo.bar.baz',
+        date: '2017-02-08'
+      )
+      new_version = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
+      expect(new_version).to eq(expected_version)
+    end
+
+  end
+end

--- a/build_tools/spec/spec_helper.rb
+++ b/build_tools/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+require_relative '../changelog'
+
+require 'tempfile'
+require 'rspec'
+
+RSpec::Matchers.define(:match_example) do |expected|
+  match do |actual|
+    actual.to_s.strip == expected.to_s.strip
+  end
+  failure_message do |actual|
+    <<-MSG
+expected:
+
+#{expected.to_s.strip}
+
+got:
+
+#{actual.to_s.strip}
+    MSG
+  end
+end


### PR DESCRIPTION
For the purpose of verifying changelog formats before release, this PR add unit test for `BuildTools::Changelog` class as first step

Edited: Also, adding a fix for `add_entry`, always make sure new entries will be added under `Unreleased changes` section

@awood45 @trevorrowe 