### PR TITLE
Avoid errors due to mutations to options argument in the upload_file method

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object.rb
@@ -245,10 +245,11 @@ module Aws
       #   without any errors.
       #
       def upload_file(source, options = {})
+        uploading_options = options.dup
         uploader = FileUploader.new(
-          multipart_threshold: options.delete(:multipart_threshold),
+          multipart_threshold: uploading_options.delete(:multipart_threshold),
           client: client)
-        uploader.upload(source, options.merge(bucket: bucket_name, key: key))
+        uploader.upload(source, uploading_options.merge(bucket: bucket_name, key: key))
         true
       end
 

--- a/aws-sdk-resources/spec/services/s3/object/upload_file_spec.rb
+++ b/aws-sdk-resources/spec/services/s3/object/upload_file_spec.rb
@@ -51,6 +51,19 @@ module Aws
           end
         }
 
+        describe 'accepts options without mutating them' do
+
+          it 'uploads objects with custom options' do
+            options = {}.freeze
+            expect(client).to receive(:put_object).with(
+              bucket: 'bucket',
+              key: 'key',
+              body: one_meg_file)
+            object.upload_file(one_meg_file, options)
+          end
+
+        end
+
         describe 'small objects' do
 
           it 'uploads small objects using Client#put_object' do


### PR DESCRIPTION
I was getting this error while trying to upload objects to S3 using the SDK

```
Can't modify a frozen hash
```

This was happening because the `upload_file` method was deleting a key from the hash with the uploading options provided to the method (mutating the hash)

```Ruby
PUBLIC_PERMISSIONS = { acl: "acl: "public-read"}.freeze

object.upload_file('path/to/file.ext', PUBLIC_PERMISSIONS)
```

A code like the one shown above will generate the error mentioned before, this PR has the fix for it

Hope this helps