### PR TITLE
Add DBClusterSnapshot to Aws::RDS::Resource

### DIFF
--- a/aws-sdk-core/apis/rds/2014-10-31/resources-1.json
+++ b/aws-sdk-core/apis/rds/2014-10-31/resources-1.json
@@ -354,6 +354,24 @@
                     "path": "DBClusters[]"
                 }
             },
+            "DBClusterSnapshots": {
+                "request": { "operation": "DescribeDBClusterSnapshots" },
+                "resource": {
+                    "type": "DBClusterSnapshot",
+                    "identifiers": [
+                        {
+                            "target": "ClusterId",
+                            "source": "response",
+                            "path": "DBClusterSnapshots[].DBClusterIdentifier"
+                        },
+                        {
+                            "target": "SnapshotId",
+                            "source": "response",
+                            "path": "DBClusterSnapshots[].DBClusterSnapshotIdentifier"
+                      }
+                  ]
+              }
+          },
             "DBClusterParameterGroups": {
                 "request": { "operation": "DescribeDBClusterParameterGroups" },
                 "resource": {


### PR DESCRIPTION
Related to issue #1419

Still need to look at options for direct creation of a snapshot object.