### PR TITLE
UrlSigner methods move to module Signer, create CookieSigner

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront.rb
@@ -9,7 +9,9 @@ Aws.add_service(:CloudFront, {
 module Aws
   module CloudFront
 
+    autoload :Signer, 'aws-sdk-core/cloudfront/signer.rb'
     autoload :UrlSigner, 'aws-sdk-core/cloudfront/url_signer.rb'
+    autoload :CookieSigner, 'aws-sdk-core/cloudfront/cookie_signer.rb'
 
   end
 end

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
@@ -7,24 +7,24 @@ require 'openssl'
 module Aws
   module CloudFront
 
-    # Allows you to create signed URLs for Amazon CloudFront resources
+    # Allows you to create signed cookie for Amazon CloudFront resources
     #
-    #     signer = Aws::CloudFront::UrlSigner.new(
+    #     signer = Aws::CloudFront::CookieSigner.new(
     #       key_pair_id: "cf-keypair-id",
     #       private_key_path: "./cf_private_key.pem"
     #     )
-    #     url = signer.signed_url(url,
+    #     url = signer.signed_cookie(url,
     #       policy: policy.to_json
     #     )
     #
-    class UrlSigner
+    class CookieSigner
       include Signer
 
       # create a signed Amazon CloudFront URL
       # @param [String] url
       # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
       # @option params [String<JSON>] :policy
-      def signed_url(url, params = {})
+      def signed_cookie(url, params = {})
         url_sections = url.split('://')
         if url_sections.length < 2
           raise ArgumentError, "Invaild URL:#{url}"
@@ -38,14 +38,11 @@ module Aws
           policy: params[:policy]
         )
 
-        start_flag = URI.parse(uri).query ? '&' : '?'
-        uri = "#{uri}#{start_flag}#{signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')}"
-
-        if scheme == 'rtmp'
-          rtmp_url(URI(uri))
-        else
-          uri
-        end
+        cookie_parameters = {}
+        signed_content.each { |k, v|
+          cookie_parameters["CloudFront-#{k}"] = v.to_s.gsub("\n", '')
+        }
+        cookie_parameters
       end
 
     end

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
@@ -13,7 +13,7 @@ module Aws
     #       key_pair_id: "cf-keypair-id",
     #       private_key_path: "./cf_private_key.pem"
     #     )
-    #     url = signer.signed_cookie(url,
+    #     cookies = signer.signed_cookie(url,
     #       policy: policy.to_json
     #     )
     #

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/cookie_signer.rb
@@ -25,13 +25,7 @@ module Aws
       # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
       # @option params [String<JSON>] :policy
       def signed_cookie(url, params = {})
-        url_sections = url.split('://')
-        if url_sections.length < 2
-          raise ArgumentError, "Invaild URL:#{url}"
-        end
-        # removing wildcard character to get real scheme
-        scheme = url_sections[0].gsub('*', '')
-        uri = "#{scheme}://#{url_sections[1]}"
+        scheme, uri = scheme_and_uri(url)
         signed_content = signature(
           resource: resource(scheme, uri),
           expires: time(params[:expires]),

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
@@ -1,0 +1,167 @@
+require 'base64'
+require 'uri'
+require 'time'
+require 'json'
+require 'openssl'
+
+module Aws
+  module CloudFront
+
+    # Allows you to create signed URLs for Amazon CloudFront resources
+    #
+    #     signer = Aws::CloudFront::UrlSigner.new
+    #     url = signer.signed_url(url,
+    #       key_pair_id: "cf-keypair-id",
+    #       private_key_path: "./cf_private_key.pem"
+    #     )
+    #
+    module Signer
+
+      # @option options [String] :key_pair_id
+      # @option options [String] :private_key
+      # @option options [String] :private_key_path
+      def initialize(options = {})
+        @key_pair_id = key_pair_id(options)
+        @private_key = private_key(options)
+      end
+
+      # create a signed Amazon CloudFront URL
+      # @param [String] url
+      # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
+      # @option params [String<JSON>] :policy
+      def signed_url(url, params = {})
+        url_sections = url.split('://')
+        if url_sections.length < 2
+          raise ArgumentError, "Invaild URL:#{url}"
+        end
+        # removing wildcard character to get real scheme
+        scheme = url_sections[0].gsub('*', '')
+        uri = "#{scheme}://#{url_sections[1]}"
+        signed_content = signature(
+          resource: resource(scheme, uri),
+          expires: time(params[:expires]),
+          policy: params[:policy]
+        )
+
+        start_flag = URI.parse(uri).query ? '&' : '?'
+        uri = "#{uri}#{start_flag}#{signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')}"
+
+        if scheme == 'rtmp'
+          rtmp_url(URI(uri))
+        else
+          uri
+        end
+      end
+
+      private
+
+      def time(expires)
+        case expires
+        when Time then expires.to_i
+        when DateTime, Date then expires.to_time.to_i
+        when String then Time.parse(expires).to_i
+        when Integer, NIL then expires
+        else
+          msg = "expected a time value for :expires, got `#{expires.class}'"
+          raise ArgumentError, msg
+        end
+      end
+
+      # create a relative signed URL for RTMP distribution
+      def rtmp_url(uri)
+        result = uri.path.gsub(' ', '/')
+        result[0] = ''
+        if uri.query
+          "#{result}?#{uri.query}"
+        else
+          result
+        end
+      end
+
+      # prepare resource for signing
+      def resource(scheme, url)
+        case scheme
+        when 'http', 'http*', 'https' then url
+        when 'rtmp'
+          url_info = URI.parse(url)
+          path = url_info.path
+          path[0] = ''
+          resource_content = "#{File.dirname(path)}/#{File.basename(path)}".gsub(' ', '/')
+          if url_info.query
+            "#{resource_content}?#{uri.query}"
+          else
+            resource_content
+          end
+        else
+          msg = "Invaild URI scheme:#{scheme}.Scheme must be one of: http, https or rtmp."
+          raise ArgumentError, msg
+        end
+      end
+
+      # create signed values that used to construct signed URLs or Set-Cookie parameters
+      # @option param [String] :resource
+      # @option param [Integer<timestamp>] :expires
+      # @option param [String<JSON>] :policy
+      def signature(params = {})
+        signature_content = {}
+        if params[:policy]
+          policy = params[:policy].gsub('/\s/s', '')
+          signature_content['Policy'] = encode(policy)
+        elsif params[:resource] && params[:expires]
+          policy = canned_policy(params[:resource], params[:expires])
+          signature_content['Expires'] = params[:expires]
+        else
+          msg = "Either a policy or a resource with an expiration time must be provided."
+          raise ArgumentError, msg
+        end
+
+        signature_content['Signature'] = encode(sign_policy(policy))
+        signature_content['Key-Pair-Id'] = @key_pair_id
+        signature_content
+      end
+
+      # create the signature string with policy signed
+      def sign_policy(policy)
+        key = OpenSSL::PKey::RSA.new(@private_key)
+        key.sign(OpenSSL::Digest::SHA1.new, policy)
+      end
+
+      # create canned policy that used for signing
+      def canned_policy(resource, expires)
+        json_hash = {
+          'Statement' => [
+            'Resource' => resource,
+              'Condition' => {
+                'DateLessThan' => {'AWS:EpochTime' => expires}
+              }
+          ]
+        }
+        JSON.dump(json_hash)
+      end
+
+      def encode(policy)
+        Base64.encode64(policy).gsub(/[+=\/]/, '+' => '-', '=' => '_', '/' => '~')
+      end
+
+      def key_pair_id(options)
+        if options[:key_pair_id].nil? or options[:key_pair_id] == ''
+          raise ArgumentError, ":key_pair_id must not be blank"
+        else
+          options[:key_pair_id]
+        end
+      end
+
+      def private_key(options)
+        if options[:private_key]
+          options[:private_key]
+        elsif options[:private_key_path]
+          File.open(options[:private_key_path], 'rb') { |f| f.read }
+        else
+          msg = ":private_key or :private_key_path should be provided"
+          raise ArgumentError, msg
+        end
+      end
+
+    end
+  end
+end

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
@@ -7,14 +7,6 @@ require 'openssl'
 module Aws
   module CloudFront
 
-    # Allows you to create signed URLs for Amazon CloudFront resources
-    #
-    #     signer = Aws::CloudFront::UrlSigner.new
-    #     url = signer.signed_url(url,
-    #       key_pair_id: "cf-keypair-id",
-    #       private_key_path: "./cf_private_key.pem"
-    #     )
-    #
     module Signer
 
       # @option options [String] :key_pair_id

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
@@ -25,35 +25,17 @@ module Aws
         @private_key = private_key(options)
       end
 
-      # create a signed Amazon CloudFront URL
-      # @param [String] url
-      # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
-      # @option params [String<JSON>] :policy
-      def signed_url(url, params = {})
+      private
+
+      def scheme_and_uri(url)
         url_sections = url.split('://')
         if url_sections.length < 2
           raise ArgumentError, "Invaild URL:#{url}"
         end
-        # removing wildcard character to get real scheme
         scheme = url_sections[0].gsub('*', '')
         uri = "#{scheme}://#{url_sections[1]}"
-        signed_content = signature(
-          resource: resource(scheme, uri),
-          expires: time(params[:expires]),
-          policy: params[:policy]
-        )
-
-        start_flag = URI.parse(uri).query ? '&' : '?'
-        uri = "#{uri}#{start_flag}#{signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')}"
-
-        if scheme == 'rtmp'
-          rtmp_url(URI(uri))
-        else
-          uri
-        end
+        [scheme, uri]
       end
-
-      private
 
       def time(expires)
         case expires

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
@@ -39,7 +39,8 @@ module Aws
         )
 
         start_flag = URI.parse(uri).query ? '&' : '?'
-        uri = "#{uri}#{start_flag}#{signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')}"
+        signature = signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')
+        uri = "#{uri}#{start_flag}#{signature}"
 
         if scheme == 'rtmp'
           rtmp_url(URI(uri))

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/url_signer.rb
@@ -25,13 +25,7 @@ module Aws
       # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
       # @option params [String<JSON>] :policy
       def signed_url(url, params = {})
-        url_sections = url.split('://')
-        if url_sections.length < 2
-          raise ArgumentError, "Invaild URL:#{url}"
-        end
-        # removing wildcard character to get real scheme
-        scheme = url_sections[0].gsub('*', '')
-        uri = "#{scheme}://#{url_sections[1]}"
+        scheme, uri = scheme_and_uri(url)
         signed_content = signature(
           resource: resource(scheme, uri),
           expires: time(params[:expires]),

--- a/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
+++ b/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
@@ -33,20 +33,18 @@ module Aws
             "http://abc.cloudfront.net/images/image.jpg",
             policy: policy.to_json
           )
-          expected = {'CloudFront-Policy' => 'eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__',
-                      'CloudFront-Signature' => 'n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_',
-                      'CloudFront-Key-Pair-Id' => 'CF_KEYPAIR_ID'}
-          expect(cookie).to eq(expected)
+          expect(cookie['CloudFront-Policy']).to eq('eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__')
+          expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')
+          expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')
         end
         it 'can generate signed cookies with canned policy' do
           cookie = signer.signed_cookie(
             "https://abc.cloudfront.net/images/image.jpg?color=red",
             expires: expires
           )
-          expected = {'CloudFront-Expires' => '1357034400',
-                      'CloudFront-Signature' => 'GvrDx3aAG1u1sAQF68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehwh~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLGUSfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_',
-                      'CloudFront-Key-Pair-Id' => 'CF_KEYPAIR_ID'}
-          expect(cookie).to eq(expected)
+          expect(cookie['CloudFront-Expires']).to eq('1357034400')
+          expect(cookie['CloudFront-Signature']).to eq('GvrDx3aAG1u1sAQF68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehwh~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLGUSfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_')
+          expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')
         end
       end
     end

--- a/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
+++ b/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
@@ -33,14 +33,20 @@ module Aws
             "http://abc.cloudfront.net/images/image.jpg",
             policy: policy.to_json
           )
-          expect(cookie.keys).to match_array(["CloudFront-Policy", "CloudFront-Signature", "CloudFront-Key-Pair-Id"])
+          expected = {'CloudFront-Policy' => 'eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__',
+                      'CloudFront-Signature' => 'n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_',
+                      'CloudFront-Key-Pair-Id' => 'CF_KEYPAIR_ID'}
+          expect(cookie).to eq(expected)
         end
         it 'can generate signed cookies with canned policy' do
           cookie = signer.signed_cookie(
             "https://abc.cloudfront.net/images/image.jpg?color=red",
             expires: expires
           )
-          expect(cookie.keys).to match_array(["CloudFront-Expires", "CloudFront-Signature", "CloudFront-Key-Pair-Id"])
+          expected = {'CloudFront-Expires' => '1357034400',
+                      'CloudFront-Signature' => 'GvrDx3aAG1u1sAQF68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehwh~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLGUSfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_',
+                      'CloudFront-Key-Pair-Id' => 'CF_KEYPAIR_ID'}
+          expect(cookie).to eq(expected)
         end
       end
     end

--- a/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
+++ b/aws-sdk-core/spec/aws/cloud_front/cookie_signer_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+module Aws
+  module CloudFront
+    describe CookieSigner do
+
+      let(:options) {
+        {
+          :key_pair_id => "CF_KEYPAIR_ID",
+          :private_key_path =>"#{File.dirname(__FILE__)}/cf_private_key.pem"
+        }
+      }
+      let(:signer) { Aws::CloudFront::CookieSigner.new(options) }
+      let(:expires) { 1357034400 } # January 1, 2013 10:00 am UTC (Unix timestamp)
+
+      describe '#signed_cookie' do
+        it 'raises error if url is invaild' do
+          expect {
+            signer.signed_cookie("what_ever_ilegal/url")
+          }.to raise_error(ArgumentError)
+        end
+        it 'can generate signed urls with custom policy' do
+          policy =  {
+            'Statement' => [
+              'Resource' => 'images/image.jpg',
+                'Condition' => {
+                'IpAddress' => {'AWS:SourceIp' => '10.52.176.0/24'},
+                'DateLessThan' => {'AWS:EpochTime' => expires}
+                }
+              ]
+          }
+          cookie = signer.signed_cookie(
+            "http://abc.cloudfront.net/images/image.jpg",
+            policy: policy.to_json
+          )
+          expect(cookie.keys).to match_array(["CloudFront-Policy", "CloudFront-Signature", "CloudFront-Key-Pair-Id"])
+        end
+        it 'can generate signed cookies with canned policy' do
+          cookie = signer.signed_cookie(
+            "https://abc.cloudfront.net/images/image.jpg?color=red",
+            expires: expires
+          )
+          expect(cookie.keys).to match_array(["CloudFront-Expires", "CloudFront-Signature", "CloudFront-Key-Pair-Id"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is re-opened PR to clean-up unnecessary commits.
https://github.com/aws/aws-sdk-ruby/pull/1261

comment from the original PR.
----
As the PHP library has, CookieSigner#signed_cookie is added.

PHP Library
https://github.com/aws/aws-sdk-php/blob/master/src/CloudFront/CookieSigner.php
the related section of document
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-canned-policy.html
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html