### PR TITLE
Add :phone_number to SNS::Client#publish

### DIFF
--- a/lib/aws/api_config/SNS-2010-03-31.yml
+++ b/lib/aws/api_config/SNS-2010-03-31.yml
@@ -325,6 +325,8 @@
     - :string
     MessageStructure:
     - :string
+    PhoneNumber:
+    - :string
   :outputs:
     :children:
       PublishResult:


### PR DESCRIPTION
This PR patches SNS::Client#publish to also allow sending a PhoneNumber. This was already possible in v2, but backport the feature in v1 of the SDK.

This is documented in v2 here: http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Client.html#publish-instance_method and on the original AWS documentation here http://docs.aws.amazon.com/sns/latest/api/API_Publish.html.

