### PR TITLE
[Feature] CloudSearchDomain #search, convert GET to POST to support long query

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -186,6 +186,7 @@ module Aws
   module Plugins
     autoload :APIGatewayHeader, 'aws-sdk-core/plugins/api_gateway_header'
     autoload :CSDConditionalSigning, 'aws-sdk-core/plugins/csd_conditional_signing'
+    autoload :CSDSwitchToPost, 'aws-sdk-core/plugins/csd_switch_to_post'
     autoload :DynamoDBExtendedRetries, 'aws-sdk-core/plugins/dynamodb_extended_retries'
     autoload :DynamoDBSimpleAttributes, 'aws-sdk-core/plugins/dynamodb_simple_attributes'
     autoload :DynamoDBCRC32Validation, 'aws-sdk-core/plugins/dynamodb_crc32_validation'

--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -64,7 +64,8 @@ module Aws
       end
 
       plugins('cloudsearchdomain',
-        add: %w(Aws::Plugins::CSDConditionalSigning),
+        add: %w(Aws::Plugins::CSDConditionalSigning
+          Aws::Plugins::CSDSwitchToPost),
         remove: %w(Aws::Plugins::RegionalEndpoint),
       )
 

--- a/aws-sdk-core/lib/aws-sdk-core/plugins/csd_switch_to_post.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/csd_switch_to_post.rb
@@ -1,0 +1,36 @@
+module Aws
+  module Plugins 
+ 
+    # CloudSearchDomain has query length limits for #search in GET
+    # Convert #search operation request from GET to POST
+    class CSDSwitchToPost < Seahorse::Client::Plugin
+
+      # @api private
+      class Handler < Seahorse::Client::Handler
+
+        def call(context)
+          convert_get_2_post(context)
+          @handler.call(context)
+        end
+
+        private
+
+        def convert_get_2_post(context)
+          context.http_request.http_method = 'POST'
+          uri = context.http_request.endpoint
+          context.http_request.body = uri.query
+          context.http_request.headers['Content-Length'] = uri.query.length
+          context.http_request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+          context.http_request.endpoint.query = nil
+        end
+
+      end
+
+      handler(
+        Handler,
+        step: :build,
+        operations: [:search]
+      )
+    end
+  end
+end

--- a/aws-sdk-core/spec/aws/cloud_search_domain/client_spec.rb
+++ b/aws-sdk-core/spec/aws/cloud_search_domain/client_spec.rb
@@ -19,7 +19,7 @@ module Aws
         expect(resp.context.http_request.headers['Authorization']).to be(nil)
       end
 
-      it 'signs reqeusts when credentials given' do
+      it 'signs requests when credentials given' do
         creds = Credentials.new('akid', 'secret')
         endpoint = 'https://domain.us-west-1.amazonaws.com'
         csd = Client.new(endpoint: endpoint, credentials: creds)
@@ -47,6 +47,19 @@ module Aws
         expect {
           csd.search(query:'test')
         }.to raise_error(Errors::RequestEntityTooLarge)
+      end
+
+      it 'use `POST` for #search operation' do
+        creds = Credentials.new('akid', 'secret')
+        endpoint = 'https://domain.us-west-1.amazonaws.com'
+        csd = Client.new(endpoint: endpoint, credentials: creds)
+        csd.handle(NoSendHandler, step: :send)
+        resp = csd.search(query: 'query')
+        expect(resp.context.http_request.http_method).to eql('POST')
+        expect(resp.context.http_request.endpoint.query).to be_nil
+        expect(resp.context.http_request.body_contents).to eql('format=sdk&pretty=true&q=query')
+        expect(resp.context.http_request.headers['Content-Type']).to eql('application/x-www-form-urlencoded')
+        expect(resp.context.http_request.headers['Content-Length']).to eql('30')
       end
 
     end


### PR DESCRIPTION
`CloudSearchDomain#search` operation has query length limitation due to being `GET` request.
This PR adds a feature plugin for converting `#search` operation to `POST`. (Similar to JS, PHP and Java)

Addressing feature request #1181 

@awood45 @trevorrowe 