### PR TITLE
Add Aws.empty_connection_pools! API

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -411,6 +411,9 @@ module Aws
     # there are no race conditions between the parent process and its children
     # for the pooled TCP connections.
     #
+    # Child processes that make multi-threaded calls to the SDK should block on
+    # this call before beginning work.
+    #
     # @return [nil]
     def empty_connection_pools!
       Seahorse::Client::NetHttp::ConnectionPool.pools.each do |pool|

--- a/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/aws-sdk-core/lib/aws-sdk-core.rb
@@ -403,6 +403,21 @@ module Aws
       ))
     end
 
+    # Close any long-lived connections maintained by the SDK's internal
+    # connection pool.
+    #
+    # Applications that rely heavily on the `fork()` system call on POSIX systems
+    # should call this method in the child process directly after fork to ensure
+    # there are no race conditions between the parent process and its children
+    # for the pooled TCP connections.
+    #
+    # @return [nil]
+    def empty_connection_pools!
+      Seahorse::Client::NetHttp::ConnectionPool.pools.each do |pool|
+        pool.empty!
+      end
+    end
+
     # Loads modules that are normally loaded with Ruby's `autoload`.
     # This can avoid thread-safety issues that some Ruby versions have
     # with `autoload`.

--- a/aws-sdk-core/spec/aws_spec.rb
+++ b/aws-sdk-core/spec/aws_spec.rb
@@ -138,4 +138,23 @@ module Aws
     end
 
   end
+
+  describe '.empty_connection_pools!' do
+    it 'close any existing sessions' do
+      expect_any_instance_of(
+        Seahorse::Client::NetHttp::ConnectionPool::ExtendedSession
+      ).to receive(:finish)
+
+      Aws.empty_connection_pools!
+    end
+
+    it 'clears any pool' do
+      # ConnectionPool maintains its pool as a hash in a instance variable
+      expect_any_instance_of(
+        Hash
+      ).to receive(:clear)
+
+      Aws.empty_connection_pools!
+    end
+  end
 end

--- a/aws-sdk-core/spec/aws_spec.rb
+++ b/aws-sdk-core/spec/aws_spec.rb
@@ -141,20 +141,16 @@ module Aws
 
   describe '.empty_connection_pools!' do
     it 'closes any existing sessions' do
-      expect_any_instance_of(
-        Seahorse::Client::NetHttp::ConnectionPool::ExtendedSession
-      ).to receive(:finish).at_least(:once)
+      endpoint = "http://example.com"
+      conn_pool = Seahorse::Client::NetHttp::ConnectionPool.for({})
+      session = conn_pool.send(:start_session, endpoint)
+      conn_pool.instance_variable_get(:@pool)[endpoint] = [session]
+
+      expect(conn_pool.size).to eq(1)
 
       Aws.empty_connection_pools!
-    end
 
-    it 'clears any pool' do
-      # ConnectionPool maintains its pool as a hash in a instance variable
-      expect_any_instance_of(
-        Hash
-      ).to receive(:clear)
-
-      Aws.empty_connection_pools!
+      expect(conn_pool.size).to eq(0)
     end
   end
 end

--- a/aws-sdk-core/spec/aws_spec.rb
+++ b/aws-sdk-core/spec/aws_spec.rb
@@ -140,10 +140,10 @@ module Aws
   end
 
   describe '.empty_connection_pools!' do
-    it 'close any existing sessions' do
+    it 'closes any existing sessions' do
       expect_any_instance_of(
         Seahorse::Client::NetHttp::ConnectionPool::ExtendedSession
-      ).to receive(:finish)
+      ).to receive(:finish).at_least(:once)
 
       Aws.empty_connection_pools!
     end


### PR DESCRIPTION
This pull request is in response to #1438 and adds an empty connection pool API to the top level `Aws` name space.