### PR TITLE
Fix Mutation Bug in DynamoDB Simple Attributes

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/dynamodb_simple_attributes.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/dynamodb_simple_attributes.rb
@@ -157,10 +157,9 @@ module Aws
         def structure(ref, values)
           shape = ref.shape
           if values.is_a?(Struct)
-            values.members.each do |key|
-              values[key] = translate(shape.member(key), values[key])
+            values.members.each.with_object(values.class.new) do |key, st|
+              st[key] = translate(shape.member(key), values[key])
             end
-            values
           elsif values.is_a?(Hash)
             values.each.with_object({}) do |(key, value), hash|
               hash[key] = translate(shape.member(key), value)


### PR DESCRIPTION
Under a particular set of circumstances, a return value struct can have
SimpleAttributes transformations applied multiple times, which can case
incorrect types and values to be written (or more likely, fail to be
written).

This doesn't happen for hashes, but we hadn't applied the same approach
to structs. This change applies the same approach to type structs,
including a previously failing test case.

Resolves GitHub issue #1406