### PR TITLE
Require only cgi/util for escaping and unescaping

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/plugins/s3_url_encoded_keys.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/plugins/s3_url_encoded_keys.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'cgi/util'
 
 module Aws
   module Plugins

--- a/aws-sdk-core/lib/aws-sdk-core/signers/s3.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/signers/s3.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'time'
 require 'openssl'
+require 'cgi/util'
 require 'webrick/httputils'
 
 module Aws

--- a/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
@@ -1,4 +1,4 @@
-require 'cgi'
+require 'cgi/util'
 
 module Aws
   module Xml

--- a/aws-sdk-core/lib/seahorse/client/plugins/restful_bindings.rb
+++ b/aws-sdk-core/lib/seahorse/client/plugins/restful_bindings.rb
@@ -1,5 +1,3 @@
-require 'cgi'
-
 module Seahorse
   module Client
     module Plugins

--- a/aws-sdk-core/lib/seahorse/util.rb
+++ b/aws-sdk-core/lib/seahorse/util.rb
@@ -1,4 +1,4 @@
-require 'cgi'
+require 'cgi/util'
 
 module Seahorse
   # @api private

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'cgi/util'
 
 module Aws
   module S3


### PR DESCRIPTION
For CGI escaping it's not needed to require the whole cgi.rb standard library, it's enough to require only cgi/util.rb, which is almost 5x smaller.

While here we also remove superfluous cgi.rb requires, and add cgi/util.rb requires that were missing.