### PR TITLE
Set Thread#abort_on_exception on spawned threads

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb
@@ -37,12 +37,15 @@ module Aws
       # @option options [required,String] :key
       # @return [void]
       def upload(source, options = {})
-        if File.size(source) < MIN_PART_SIZE
-          raise ArgumentError, FILE_TOO_SMALL
-        else
-          upload_id = initiate_upload(options)
+        raise ArgumentError, FILE_TOO_SMALL if File.size(source) < MIN_PART_SIZE
+
+        upload_id = initiate_upload(options)
+        begin
           parts = upload_parts(upload_id, source, options)
           complete_upload(upload_id, parts, options)
+        rescue => error
+          abort_upload(upload_id, options, error)
+          raise error
         end
       end
 
@@ -61,29 +64,50 @@ module Aws
       end
 
       def upload_parts(upload_id, source, options)
-        pending = PartList.new(compute_parts(upload_id, source, options))
-        completed = PartList.new
-        errors = upload_in_threads(pending, completed)
-        if errors.empty?
-          completed.to_a.sort_by { |part| part[:part_number] }
-        else
-          abort_upload(upload_id, options, errors)
+        queue = PartQueue.new(compute_parts(upload_id, source, options))
+        threads = []
+        @thread_count.times do
+          threads << upload_part_thread(queue)
+        end
+        threads.map(&:value).flatten.sort_by { |part| part[:part_number] }
+      end
+
+      def upload_part_thread(queue)
+        Thread.new do
+          begin
+            completed = []
+            while part = queue.shift
+              completed << upload_part(part)
+            end
+            completed
+          rescue => error
+            # keep other threads from uploading other parts
+            queue.clear!
+            raise error
+          end
         end
       end
 
-      def abort_upload(upload_id, options, errors)
+      def upload_part(part)
+        resp = @client.upload_part(part)
+        part[:body].close
+
+        { etag: resp.etag, part_number: part[:part_number] }
+      end
+
+      def abort_upload(upload_id, options, error)
         @client.abort_multipart_upload(
           bucket: options[:bucket],
           key: options[:key],
           upload_id: upload_id
         )
-        msg = "multipart upload failed: #{errors.map(&:message).join("; ")}"
-        raise MultipartUploadError.new(msg, errors)
-      rescue MultipartUploadError => error
-        raise error
-      rescue => error
-        msg = "failed to abort multipart upload: #{error.message}"
-        raise MultipartUploadError.new(msg, errors + [error])
+        msg = "multipart upload failed: #{error.message}"
+        raise MultipartUploadError.new(msg, [error])
+      rescue MultipartUploadError => exception
+        raise exception
+      rescue => exception
+        msg = "failed to abort multipart upload: #{exception.message}"
+        raise MultipartUploadError.new(msg, [error, exception])
       end
 
       def compute_parts(upload_id, source, options)
@@ -122,29 +146,6 @@ module Aws
         end
       end
 
-      def upload_in_threads(pending, completed)
-        threads = []
-        @thread_count.times do
-          thread = Thread.new do
-            begin
-              while part = pending.shift
-                resp = @client.upload_part(part)
-                part[:body].close
-                completed.push(etag: resp.etag, part_number: part[:part_number])
-              end
-              nil
-            rescue => error
-              # keep other threads from uploading other parts
-              pending.clear!
-              error
-            end
-          end
-          thread.abort_on_exception = true
-          threads << thread
-        end
-        threads.map(&:value).compact
-      end
-
       def compute_default_part_size(source_size)
         [(source_size.to_f / MAX_PARTS).ceil, MIN_PART_SIZE].max.to_i
       end
@@ -158,7 +159,7 @@ module Aws
       end
 
       # @api private
-      class PartList
+      class PartQueue
 
         def initialize(parts = [])
           @parts = parts

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb
@@ -74,6 +74,8 @@ module Aws
 
       def upload_part_thread(queue)
         Thread.new do
+          Thread.current.abort_on_exception = true
+
           begin
             completed = []
             while part = queue.shift

--- a/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/services/s3/object_multipart_copier.rb
@@ -57,6 +57,8 @@ module Aws
 
       def copy_part_thread(queue)
         Thread.new do
+          Thread.current.abort_on_exception = true
+
           begin
             completed = []
             while part = queue.shift


### PR DESCRIPTION
By default threads won't propagate exceptions that occur inside them to the main thread, unless we call `Thread#value` on a thread that exited with an exception, in which case its exception will be raised in the main thread. Because some folks might not know that last bit, for readability we explicitly set `Thread#abort_on_exception` on spawned threads.

While we're here, we also refactor `MultipartFileUploader` to be like `ObjectMultipartCopier`, so that we can make the same `Thread#abort_on_exception` update.