### PR TITLE
Allow string keys for required options

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -39,7 +39,7 @@ module Aws
       # ensure required members are present
       if @validate_required
         shape.required.each do |member_name|
-          if values[member_name].nil?
+          if values[member_name].nil? && values[member_name.to_s].nil?
             param = "#{context}[#{member_name.inspect}]"
             errors << "missing required parameter #{param}"
           end

--- a/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -52,7 +52,7 @@ module Aws
         validate({})
       end
 
-      it 'raises an error when a required paramter is missing' do
+      it 'raises an error when a required parameter is missing' do
         shapes['StructureShape']['required'] = %w(String)
         validate({}, 'missing required parameter params[:string]')
       end
@@ -64,6 +64,11 @@ module Aws
       it 'accepts members that pass validation' do
         shapes['StructureShape']['required'] = %w(String)
         validate(string: 'abc')
+      end
+
+      it 'accepts members with string keys that pass validation' do
+        shapes['StructureShape']['required'] = %w(String)
+        validate('string' => 'abc')
       end
 
       it 'aggregates errors for members' do


### PR DESCRIPTION
This fix updates the parameter check to also see if the values are present under string keys in addition to symbols. With my testing the API calls still work correctly when string keys are used.

In some cases we have some symbols that end up getting converted to strings before being passed to the SDK calls. These work fine on all methods except ones with required options. 
