### PR TITLE
Add ClientRequestToken support to CloudFormation::Client operations

### DIFF
--- a/aws-sdk-core/apis/cloudformation/2010-05-15/api-2.json
+++ b/aws-sdk-core/apis/cloudformation/2010-05-15/api-2.json
@@ -366,7 +366,8 @@
       "type":"structure",
       "required":["StackName"],
       "members":{
-        "StackName":{"shape":"StackName"}
+        "StackName":{"shape":"StackName"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"}
       }
     },
     "Capabilities":{
@@ -479,6 +480,11 @@
       "type":"list",
       "member":{"shape":"Change"}
     },
+    "ClientRequestToken":{
+      "type":"string",
+      "max":128,
+      "min":1
+    },
     "ClientToken":{
       "type":"string",
       "max":128,
@@ -489,6 +495,7 @@
       "required":["StackName"],
       "members":{
         "StackName":{"shape":"StackNameOrId"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"},
         "RoleARN":{"shape":"RoleARN"},
         "ResourcesToSkip":{"shape":"ResourcesToSkip"}
       }
@@ -536,6 +543,7 @@
         "TemplateBody":{"shape":"TemplateBody"},
         "TemplateURL":{"shape":"TemplateURL"},
         "Parameters":{"shape":"Parameters"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"},
         "DisableRollback":{"shape":"DisableRollback"},
         "TimeoutInMinutes":{"shape":"TimeoutMinutes"},
         "NotificationARNs":{"shape":"NotificationARNs"},
@@ -573,6 +581,7 @@
       "required":["StackName"],
       "members":{
         "StackName":{"shape":"StackName"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"},
         "RetainResources":{"shape":"RetainResources"},
         "RoleARN":{"shape":"RoleARN"}
       }
@@ -712,6 +721,7 @@
       "required":["ChangeSetName"],
       "members":{
         "ChangeSetName":{"shape":"ChangeSetNameOrId"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"},
         "StackName":{"shape":"StackNameOrId"}
       }
     },
@@ -1389,6 +1399,7 @@
         "StackPolicyDuringUpdateURL":{"shape":"StackPolicyDuringUpdateURL"},
         "Parameters":{"shape":"Parameters"},
         "Capabilities":{"shape":"Capabilities"},
+        "ClientRequestToken":{"shape":"ClientRequestToken"},
         "ResourceTypes":{"shape":"ResourceTypes"},
         "RoleARN":{"shape":"RoleARN"},
         "StackPolicyBody":{"shape":"StackPolicyBody"},

--- a/aws-sdk-core/apis/cloudformation/2010-05-15/docs-2.json
+++ b/aws-sdk-core/apis/cloudformation/2010-05-15/docs-2.json
@@ -188,6 +188,17 @@
         "DescribeChangeSetOutput$Changes": "<p>A list of <code>Change</code> structures that describes the resources AWS CloudFormation changes if you execute the change set.</p>"
       }
     },
+    "ClientRequestToken": {
+      "base": null,
+      "refs": {
+        "CancelUpdateStackInput$ClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to cancel an update on a stack with the same name.</p>",
+        "ContinueUpdateRollbackInput$ClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to continue the rollback to a stack with the same name.</p>",
+        "CreateStackInput$ClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to create a stack with the same name.</p>",
+        "DeleteStackInput$ClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to delete a stack with the same name.</p>",
+        "ExecuteChangeSetInput$ExportingClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to execute a change set to update a stack with the same name.</p>",
+        "UpdateStackInput$ClientRequestToken": "<p>A unique identifier for this request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to update a stack with the same name. </p>"
+      }
+    },
     "ClientToken": {
       "base": null,
       "refs": {


### PR DESCRIPTION
Per https://github.com/aws/aws-sdk-ruby/issues/1497, the `ClientRequestToken` param isn't supported in the ruby sdk for any of the CloudFormation operations that support it.

I've taken a stab at adding support for this param.  I know @cjyclaire mentioned support would be coming soon, but I thought perhaps I could expedite "soon".  😄 

As far as I can tell, this shouldn't cause any breakages / backwards incompatibility, though I noticed the "We may choose not to accept pull requests that change service descriptions" note in `CONTRIBUTING.md`.  It looks harmless to me, but I'm not familiar with the code base at all.