### PR TITLE
Add support for ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
   - jruby
 
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -28,12 +28,17 @@ gem 'oga'
 group :test do
   gem 'rspec'
   gem 'cucumber'
-  # webmock dropped support for Ruby 1.9.3 after version 2.2.0
-  gem 'webmock', '2.2.0'
-  # webmock depends on addressable, but the latest version of addressable
-  # has a dependency on ~> 2.0 of public_suffix which is not compatible
-  # with Ruby 1.9.3
-  gem 'addressable', '2.4.0'
+  if RUBY_VERSION == '1.9.3'
+    # webmock dropped support for Ruby 1.9.3 after version 2.2.0
+    gem 'webmock', '2.2.0'
+    # webmock depends on addressable, but the latest version of addressable
+    # has a dependency on ~> 2.0 of public_suffix which is not compatible
+    # with Ruby 1.9.3
+    gem 'addressable', '2.4.0'
+  else
+    gem 'webmock'
+    gem 'addressable'
+  end
   gem 'simplecov', require: false
   gem 'coveralls', require: false if RUBY_VERSION > '1.9.3'
   gem 'json-schema'

--- a/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/cloudfront/signer.rb
@@ -34,7 +34,7 @@ module Aws
         when Time then expires.to_i
         when DateTime, Date then expires.to_time.to_i
         when String then Time.parse(expires).to_i
-        when Integer, NIL then expires
+        when Integer, nil then expires
         else
           msg = "expected a time value for :expires, got `#{expires.class}'"
           raise ArgumentError, msg

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -71,7 +71,12 @@ module Aws
           # supports integers, floats, and big decimals
           expect(value.marshal(123)).to eq(n: '123')
           expect(value.marshal(12.34)).to eq(n: '12.34')
-          expect(value.marshal(BigDecimal.new("0.1E125"))).to eq(n: "0.1E125")
+
+          # Ruby 2.4 changed the casing of BigDecimal's to_s value.
+          # We need to check in a case insensitive manner
+          big_decimal_value = value.marshal(BigDecimal.new("0.1E125"))
+          expect(big_decimal_value.keys).to eq([:n])
+          expect(big_decimal_value[:n]).to match(/0.1E125/i)
         end
 
         it 'converts strings to :s' do

--- a/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -115,13 +115,13 @@ module Aws
       it 'validates map keys' do
         validate({ string_map: { 'abc' => 'mno' }})
         validate({ string_map: { 123 => 'xyz' }},
-          'expected params[:string_map] 123 key to be a String, got value 123 (class: Fixnum) instead.')
+          [/expected params\[:string_map\] 123 key to be a String, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
       it 'validates map values' do
         validate({ string_map: { 'foo' => 'bar' }})
         validate({ string_map: { 'foo' => 123 }},
-          'expected params[:string_map]["foo"] to be a String, got value 123 (class: Fixnum) instead.')
+          [/expected params\[:string_map\]\["foo"\] to be a String, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
     end
@@ -141,7 +141,7 @@ module Aws
       it 'accepts integers' do
         validate(float: 123.0)
         validate({ float: 123 },
-          'expected params[:float] to be a Float, got value 123 (class: Fixnum) instead.')
+          [/expected params\[:float\] to be a Float, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
     end
@@ -174,7 +174,7 @@ module Aws
         validate(blob: double('d', :read => 'abc', :size => 3, :rewind => 0))
         validate({ blob: 'abc' })
         validate({ blob: 123 },
-          'expected params[:blob] to be a String or IO object, got value 123 (class: Fixnum) instead.')
+          [/expected params\[:blob\] to be a String or IO object, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
     end
@@ -184,7 +184,7 @@ module Aws
       it 'accepts string objects' do
         validate(string: 'john doe')
         validate({ string: 123 },
-          'expected params[:string] to be a String, got value 123 (class: Fixnum) instead.')
+          [/expected params\[:string\] to be a String, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
     end


### PR DESCRIPTION
Tracking issue: #1492, #1461 Includes PR #1382

Notes, besides #1382 fix, the sock error is caused by [`webmock`](https://github.com/bblimke/webmock/blob/master/webmock.gemspec)
Their support for ruby 2.4 was landed in webmock [2.3.1](https://github.com/bblimke/webmock/blob/v2.3.1/CHANGELOG.md). And originally our test environment was tied with `2.2.0` for ruby `1.9.3` concerns.

cc: @awood45 