### PR TITLE
Update Ec2 resource model identifier

### DIFF
--- a/aws-sdk-core/apis/ec2/2016-11-15/resources-1.json
+++ b/aws-sdk-core/apis/ec2/2016-11-15/resources-1.json
@@ -1444,11 +1444,7 @@
     },
     "Route": {
       "identifiers": [
-        { "name": "RouteTableId" },
-        {
-          "name": "DestinationCidrBlock",
-          "memberName": "DestinationCidrBlock"
-        }
+        { "name": "RouteTableId" }
       ],
       "shape": "Route",
       "actions": {
@@ -1456,8 +1452,7 @@
           "request": {
             "operation": "DeleteRoute",
             "params": [
-              { "target": "RouteTableId", "source": "identifier", "name": "RouteTableId" },
-              { "target": "DestinationCidrBlock", "source": "identifier", "name": "DestinationCidrBlock" }
+              { "target": "RouteTableId", "source": "identifier", "name": "RouteTableId" }
             ]
           }
         },
@@ -1465,8 +1460,7 @@
           "request": {
             "operation": "ReplaceRoute",
             "params": [
-              { "target": "RouteTableId", "source": "identifier", "name": "RouteTableId" },
-              { "target": "DestinationCidrBlock", "source": "identifier", "name": "DestinationCidrBlock" }
+              { "target": "RouteTableId", "source": "identifier", "name": "RouteTableId" }
             ]
           }
         }
@@ -1524,8 +1518,7 @@
           "resource": {
             "type": "Route",
             "identifiers": [
-              { "target": "RouteTableId", "source": "identifier", "name": "Id" },
-              { "target": "DestinationCidrBlock", "source": "requestParameter", "path": "DestinationCidrBlock" }
+              { "target": "RouteTableId", "source": "identifier", "name": "Id" }
             ]
           }
         },
@@ -1568,8 +1561,7 @@
           "resource": {
             "type": "Route",
             "identifiers": [
-              { "target": "RouteTableId", "source": "identifier", "name": "Id" },
-              { "target": "DestinationCidrBlock", "source": "data", "path": "Routes[].DestinationCidrBlock" }
+              { "target": "RouteTableId", "source": "identifier", "name": "Id" }
             ],
             "path": "Routes[]"
           }


### PR DESCRIPTION
Fix issue #1510 

Once EC2 VPC added support for IPv6 with `destination_ipv_6_cidr_block`, `destination_cidr_block` is not the identifier for route of a routing table anymore. For one route of a routing table, either of these 2 parameter will be nil.

Tested with:
``` ruby
table = Aws::EC2::RouteTable.new(id: "rtb-1234abcd")
res = table.routes
res.each do |r|
   puts "Ipv4: "
   puts r.destination_cidr_block
   puts "Ipv6: "
   puts r.destination_ipv_6_cidr_block
end
```

@awood45 