### PR TITLE
Proposed Patch: Safely Check Shapes and Members

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
@@ -25,9 +25,17 @@ module AwsSdkCodeGenerator
           ref_shape, ref_member = ref.split('$')
           case @api['shapes'][ref_shape]['type']
           when 'structure'
-            @api['shapes'][ref_shape]['members'][ref_member]['documentation'] = ref_docs
+            shape = @api['shapes'][ref_shape]
+            if shape
+              member = shape['members'][ref_member]
+              member['documentation'] = ref_docs if member
+            end
           when 'list', 'map'
-            @api['shapes'][ref_shape][ref_member]['documentation'] = ref_docs
+            shape = @api['shapes'][ref_shape]
+            if shape
+              member = shape[ref_member]
+              member['documentation'] = ref_docs if member
+            end
           end
         end
       end


### PR DESCRIPTION
In the case of issues with the API and Doc models (which can and do exist in production), the modular SDK doc generation hard-crashes where the monolith SDK's doc generation just skips. This is intended to bring these behaviors in line.