### PR TITLE
[Version 2] Fix ec2 stubbing test

### DIFF
--- a/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
+++ b/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
@@ -64,8 +64,6 @@ module Aws
                   <requestId>stubbed-request-id</requestId>
                   <reservationSet>
                       <item>
-                          <reservationId>reservation-id</reservationId>
-                          <ownerId>owner-id</ownerId>
                           <groupSet>
                               <item>
                                   <groupName>group-name</groupName>
@@ -74,8 +72,8 @@ module Aws
                           </groupSet>
                           <instancesSet>
                               <item>
-                                  <instanceId>i-12345678</instanceId>
                                   <imageId>ami-12345678</imageId>
+                                  <instanceId>i-12345678</instanceId>
                                   <instanceState>
                                       <code>16</code>
                                       <name>running</name>
@@ -92,6 +90,8 @@ module Aws
                                   </tagSet>
                               </item>
                           </instancesSet>
+                          <ownerId>owner-id</ownerId>
+                          <reservationId>reservation-id</reservationId>
                       </item>
                   </reservationSet>
               </DescribeInstancesResponse>


### PR DESCRIPTION
In latest EC2 model update, the order of members in response shape has been changed, which caused stubbing unit test failed (due to hard coded XML).

This PR update the spec test to match the latest model.

@awood45 