### PR TITLE
Document dynamic S3 stubbing

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -77,6 +77,19 @@ module Aws
     #     Aws::S3::Resource.new.buckets.map(&:name)
     #     #=> ['my-bucket']
     #
+    # ## Dynamic Stubbing
+    #
+    # In addition to creating static stubs, it's also possible to generate
+    # stubs dynamically based on the parameters with which operations were
+    # called, by passing a `Proc` object:
+    #
+    #     s3 = Aws::S3::Resource.new(stub_responses: true)
+    #     s3.client.stub_responses(:put_object, -> (context) {
+    #       s3.client.stub_responses(:get_object, content_type: context.params[:content_type])
+    #     })
+    #
+    # The yielded object is an instance of {Seahorse::Client::RequestContext}.
+    #
     # ## Stubbing Errors
     #
     # When stubbing is enabled, the SDK will default to generate


### PR DESCRIPTION
I found out about this feature when I was looking at the test suite for aws-sdk itself, and it helped me immensely when I was rewriting test suite for [Shrine](https://github.com/janko-m/shrine/blob/90ea7693e6ac32c0bf361b041d9e9cdfaf8c24d0/test/s3_test.rb) and [tus-ruby-server](https://github.com/janko-m/tus-ruby-server/blob/ff3890b5d05b7a05f904488a880c1365de46d034/test/s3_test.rb) to use stubs, because I was able to test the parameters which the operations were being called with, and dynamically create new stubs based those parameters.