### PR TITLE
Reduce string allocations in `Seahorse::Util.underscore`.

### DIFF
--- a/aws-sdk-core/lib/seahorse/util.rb
+++ b/aws-sdk-core/lib/seahorse/util.rb
@@ -13,11 +13,12 @@ module Seahorse
       # @param [String] string
       # @return [String] Returns the underscored version of the given string.
       def underscore(string)
-        string.
-          gsub(@irregular_regex) { |word| '_' + @irregular_inflections[word] }.
-          gsub(/([A-Z0-9]+)([A-Z][a-z])/, '\1_\2').
-          scan(/[a-z0-9]+|\d+|[A-Z0-9]+[a-z]*/).
-          join('_').downcase
+        new_string = string.dup
+        new_string.gsub!(@irregular_regex) { |word| "_#{@irregular_inflections[word]}" }
+        new_string.gsub!(/([A-Z0-9]+)([A-Z][a-z])/, '\1_\2'.freeze)
+        new_string = new_string.scan(/[a-z0-9]+|\d+|[A-Z0-9]+[a-z]*/).join('_'.freeze)
+        new_string.downcase!
+        new_string
       end
 
       def uri_escape(string)


### PR DESCRIPTION
Profiling script

```
require 'aws-sdk'
require 'memory_profiler'

MemoryProfiler.report do
  Aws::S3
end.pretty_print
```

Before:

```
Total allocated: 12037984 bytes (134157 objects)
Total retained:  1823217 bytes (19143 objects)

allocated memory by gem
-----------------------------------
   5607016  aws-sdk-core-2.9.43
   4182950  rubygems
   1078153  2.4.1/lib
    995943  aws-sdk-resources-2.9.43
    172234  oj-3.1.4
      1688  2.4.0

allocated memory by file
-----------------------------------
   3895019  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb
   1838731  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/seahorse/util.rb
   1321647  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/aws-sdk-core/json.rb
   1200598  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/aws-sdk-core/api/shape_map.rb
    842413  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/seahorse/model/shapes.rb
```

After:

```
Total allocated: 11210399 bytes (119690 objects)
Total retained:  1823257 bytes (19144 objects)

allocated memory by gem
-----------------------------------
   4779351  aws-sdk-core-2.9.43
   4183030  rubygems
   1078153  2.4.1/lib
    995943  aws-sdk-resources-2.9.43
    172234  oj-3.1.4
      1688  2.4.0

allocated memory by file
-----------------------------------
   3895099  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb
   1321647  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/aws-sdk-core/json.rb
   1203579  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/aws-sdk-core/api/shape_map.rb
   1006020  /home/tgxworld/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/aws-sdk-core-2.9.43/lib/seahorse/util.rb
```