### PR TITLE
Reduce memory allocation when generating checksums and signatures

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
@@ -56,14 +56,12 @@ module Aws
       end
 
       def read_from_file(bytes, output_buffer)
-        if bytes
-          data = @file.read([remaining_bytes, bytes].min)
-          data = nil if data == ''
-        else
-          data = @file.read(remaining_bytes)
-        end
+        length = [remaining_bytes, *bytes].min
+        data   = @file.read(length, output_buffer)
+
         @position += data ? data.bytesize : 0
-        output_buffer ? output_buffer.replace(data || '') : data
+
+        data.to_s unless bytes && (data.nil? || data.empty?)
       end
 
       def remaining_bytes

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -45,7 +45,7 @@ module Aws
           end
 
           def update_in_chunks(digest, io)
-            while chunk = io.read(CHUNK_SIZE)
+            while chunk = io.read(CHUNK_SIZE, buffer ||= "")
               digest.update(chunk)
             end
             io.rewind

--- a/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
@@ -50,7 +50,7 @@ module Aws
 
           it 'computes the MD5 by reading the body 1MB at a time' do
             body = StringIO.new('.' * 5 * 1024 * 1024) # 5MB
-            allow(body).to receive(:read).with(1024 * 1024).and_call_original
+            allow(body).to receive(:read).with(1024 * 1024, instance_of(String)).and_call_original
             client = Client.new(stub_responses: true)
             resp = client.put_object(
               bucket: 'bucket-name',
@@ -101,7 +101,7 @@ module Aws
 
           it 'computes the MD5 by reading the body 1MB at a time' do
             body = StringIO.new('.' * 5 * 1024 * 1024) # 5MB
-            allow(body).to receive(:read).with(1024 * 1024).and_call_original
+            allow(body).to receive(:read).with(1024 * 1024, instance_of(String)).and_call_original
             client = Client.new(stub_responses: true)
             resp = client.upload_part(
               bucket: 'bucket-name',

--- a/gems/aws-sdk-s3/spec/file_part_spec.rb
+++ b/gems/aws-sdk-s3/spec/file_part_spec.rb
@@ -80,7 +80,7 @@ module Aws
         it 'closes the opened file handle' do
           file = double('fake-file')
           expect(File).to receive(:open).with(path, 'rb').and_return(file)
-          expect(file).to receive(:read).with(5).and_return('bytes')
+          expect(file).to receive(:read).with(5, nil).and_return('bytes')
           expect(file).to receive(:seek).with(1)
           expect(file).to receive(:close)
           part = FilePart.new(source:path, offset:1, size:5)

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -473,7 +473,7 @@ module Aws
           OpenSSL::Digest::SHA256.file(value).hexdigest
         elsif value.respond_to?(:read)
           sha256 = OpenSSL::Digest::SHA256.new
-          while chunk = value.read(1024 * 1024) # 1MB
+          while chunk = value.read(1024 * 1024, buffer ||= "") # 1MB
             sha256.update(chunk)
           end
           value.rewind


### PR DESCRIPTION
When IO is #read without a buffer string, it allocates a new string for each read chunk. Even though by reading the file in chunks we keep memory usage low, we still give GC work to clean up all those strings.

However, if we pass an additional buffer string to #read, instead of allocating new string for each chunk, each chunk will be read into the existing buffer string (replacing any previous value). That means that the buffer string is the only string that's allocated.

The IO body already has to accept the additional buffer argument, because Net::HTTP uses IO.copy_stream to stream the IO to the TCP socket, and IO.copy_stream will throw an exception if the IO body only accepts the length argument.