### PR TITLE
Use Digest#base64digest method

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -1,5 +1,4 @@
 require 'openssl'
-require 'base64'
 
 module Aws
   module S3
@@ -34,13 +33,13 @@ module Aws
           # @return [String<MD5>]
           def md5(value)
             if (File === value || Tempfile === value) && !value.path.nil? && File.exist?(value.path)
-              Base64.encode64(OpenSSL::Digest::MD5.file(value).digest).strip
+              OpenSSL::Digest::MD5.file(value).base64digest
             elsif value.respond_to?(:read)
               md5 = OpenSSL::Digest::MD5.new
               update_in_chunks(md5, value)
-              Base64.encode64(md5.digest).strip
+              md5.base64digest
             else
-              Base64.encode64(OpenSSL::Digest::MD5.digest(value)).strip
+              OpenSSL::Digest::MD5.digest(value).base64digest
             end
           end
 


### PR DESCRIPTION
Other than being shorter, it has two qualities over `Base64.encode64` that are desirable in this case. One is that it doesn't include a trailing newline at the end of the result. Other one is that it doesn't wrap the result in 60 columns, meaning it doesn't add a newline after each 60 characters.

A general alternative to `Base64.encode64` is `Base64.strict_encode64`, which should have the same desirable behaviour, but calling `#base64digest` is shorter.