### PR TITLE
Ensure SpotInstanceRequestFulfilled waiter retries on request not found

### DIFF
--- a/aws-sdk-core/apis/ec2/2016-11-15/waiters-2.json
+++ b/aws-sdk-core/apis/ec2/2016-11-15/waiters-2.json
@@ -413,6 +413,11 @@
           "matcher": "pathAny",
           "argument": "SpotInstanceRequests[].Status.Code",
           "expected": "system-error"
+        },
+        {
+          "state": "retry",
+          "matcher": "error",
+          "expected": "InvalidSpotInstanceRequestID.NotFound"
         }
       ]
     },


### PR DESCRIPTION
The EC2 spot instance API appears to be eventually consistent.

If you make a `DescribeSpotInstanceRequests` API call immediately after
a `RequestSpotInstances` call then you may get a
`InvalidSpotinstanceRequestID.NotFound` error.

The waiter should continue waiting if it encounters this error.

It seems there are no tests for the contents of this file, so I presume this is ok?

See issue for more details.

fixes aws/aws-sdk-ruby#1559