### PR TITLE
Fix downloader tmp dir issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::S3 - Fix Multipart Downloader bug issue #1566, now file batches exist in a newly created tmp directory under destination directory.
+
 2.10.26 (2017-08-14)
 ------------------
 

--- a/aws-sdk-resources/features/s3/download_file.feature
+++ b/aws-sdk-resources/features/s3/download_file.feature
@@ -75,7 +75,7 @@ Feature: Managed file download
 
   # Create tmp dir folder for batches each time
   # Thread safe for downloading several files at same time
-  @auto @large-file @wip @multithread
+  @auto @large-file @multithread
   Scenario: Download 2 large objects in auto mode multithread
     Given I have a 16M file
     And I upload the file

--- a/aws-sdk-resources/features/s3/download_file.feature
+++ b/aws-sdk-resources/features/s3/download_file.feature
@@ -64,7 +64,7 @@ Feature: Managed file download
   # It is possible for the user to control the chunk size of each
   # part downloaded, by specifing a mode "get-range" and also
   # an option to define how large each chunk is.
-  @mode @get_range @large-file
+  @mode @get-range @large-file
   Scenario: Download a large object using chunk size
     Given I have a 16M file
     And I upload the file
@@ -72,3 +72,14 @@ Feature: Managed file download
     Then 2 get_object requests should have been made
     And the downloaded file should match the uploaded file
     And this test file has been cleaned up
+
+  # Create tmp dir folder for batches each time
+  # Thread safe for downloading several files at same time
+  @auto @large-file @wip @multithread
+  Scenario: Download 2 large objects in auto mode multithread
+    Given I have a 16M file
+    And I upload the file
+    When I download the file 2 times with mode "auto" with 3M chunk size
+    Then 12 get_object requests should have been made
+    And those downloaded files should match the uploaded file
+    And these test file has been cleaned up


### PR DESCRIPTION
Addressing issue #1566 

Now creating tmp dir for batches under the destination file directory each time
@awood45 