### PR TITLE
add a space to address binary operator warning

### DIFF
--- a/aws-sdk-resources/lib/aws-sdk-resources/documenter/has_many_operation_documenter.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/documenter/has_many_operation_documenter.rb
@@ -4,7 +4,7 @@ module Aws
       class HasManyOperationDocumenter < BaseOperationDocumenter
 
         def docstring
-          super + ' ' +<<-DOCSTRING.lstrip
+          super + ' ' + <<-DOCSTRING.lstrip
 Returns a {Resources::Collection Collection} of {#{target_resource_class_name}}
 resources. No API requests are made until you call an enumerable method on the
 collection. {#{called_operation}} will be called multiple times until every


### PR DESCRIPTION
add a space to address warnings such as:

```
aws-sdk-resources-2.7.14/lib/aws-sdk-resources/documenter/has_many_operation_documenter.rb:7: warning: `+' after local variable or literal is interpreted as binary operator
aws-sdk-resources-2.7.14/lib/aws-sdk-resources/documenter/has_many_operation_documenter.rb:7: warning: even though it seems like unary operator
```

these warnings are thrown at require time by every JRuby app that requires the gem