### PR TITLE
Make travis wait for running jruby test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       env: OLD_OJ=1
     - rvm: 2.3.0
       env: OLD_OX=1
+  allow_failures:
+    - rvm: jruby-9.1.5.0
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ bundler_args: --without docs release repl
 
 matrix:
   exclude:
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby
       env: KITCHEN_SINK=1
   include:
     - rvm: 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - PURE_RUBY=1
   - KITCHEN_SINK=1
 
-script: travis_wait bundle exec rake test:spec
+script: travis_wait 30 bundle exec rake test:spec
 
 bundler_args: --without docs release repl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.0
   - 2.4.0
-  - jruby-9.1.5.0
+  - jruby
 
 sudo: false
 
@@ -15,7 +15,7 @@ env:
   - PURE_RUBY=1
   - KITCHEN_SINK=1
 
-script: travis_wait bundle exec rake test:spec --verbose
+script: bundle exec rake test:spec --verbose
 
 bundler_args: --without docs release repl
 
@@ -28,8 +28,6 @@ matrix:
       env: OLD_OJ=1
     - rvm: 2.3.0
       env: OLD_OX=1
-  allow_failures:
-    - rvm: jruby-9.1.5.0
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - PURE_RUBY=1
   - KITCHEN_SINK=1
 
-script: travis_wait 30 bundle exec rake test:spec
+script: travis_wait bundle exec rake test:spec --verbose
 
 bundler_args: --without docs release repl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - PURE_RUBY=1
   - KITCHEN_SINK=1
 
-script: bundle exec rake test:spec
+script: travis_wait bundle exec rake test:spec
 
 bundler_args: --without docs release repl
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -34,7 +34,7 @@ end
 
 desc 'Execute spec tests.'
 task 'test:spec' do
-  sh("bundle exec rspec #{Dir.glob('**/spec').join(' ')}")
+  sh("bundle exec rspec #{Dir.glob('**/spec').join(' ')} --profile")
 end
 
 ##


### PR DESCRIPTION
Travis jruby suit for code-gen is failing due to timeout, the PR proposes a fix.

Reference: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received