### PR TITLE
Add details of version 3.0.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Unreleased Changes
 
 * Issue - Aws::CloudHSM - This has been deprecated, remove smoke test
 
+3.0.0 (2017-08-29)
+------------------
+
+* Packaging - Version 3 modularizes the monolithic SDK into service specific gems. Aside from gem packaging differences, version 3 interfaces are backwards compatible with version 2. For more information, see https://github.com/aws/aws-sdk-ruby/tree/code-generation.
+
 2.10.35 (2017-08-29)
 ------------------
 
@@ -892,7 +897,7 @@ Unreleased Changes
 
 * Issue - Aws::CloudFront::UrlSigner - Fixed an issue where failures could occur
   when the `UrlSigner` was used in a Rails environment with more than one query
-  parameter. See 
+  parameter. See
   [related GitHub issue #1386](https://github.com/aws/aws-sdk-ruby/issues/1386).
 
 2.6.44 (2017-01-04)


### PR DESCRIPTION
Follow-up from https://github.com/aws/aws-sdk-ruby/issues/1583.

Whilst V2 is on master, it makes sense to have a link in the changelog to the code for V3 (for anyone who has just installed V3 and comes looking for it. If/when V3 becomes master, this changelog entry could be deleted (from the v2 branch).