### PR TITLE
Tell Rubygems correct sourcecode and changelog links

### DIFF
--- a/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
@@ -13,6 +13,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/{{gem_name}}',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/{{gem_name}}/CHANGELOG.md'
+  }
+
   {{#dependencies}}
   spec.add_dependency('{{gem}}', '{{&version}}')
   {{/dependencies}}

--- a/gems/aws-partitions/aws-partitions.gemspec
+++ b/gems/aws-partitions/aws-partitions.gemspec
@@ -7,4 +7,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = ['partitions.json'] + Dir['lib/**/*.rb']
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-partitions',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-partitions/CHANGELOG.md'
+  }
 end

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -11,6 +11,11 @@ Gem::Specification.new do |spec|
   spec.files         = ['ca-bundle.crt', 'VERSION']
   spec.files         += Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-core',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-core/CHANGELOG.md'
+  }
+
   spec.add_dependency('jmespath', '~> 1.0')
   spec.add_dependency('aws-partitions', '~> 1.0')
   spec.add_dependency('aws-sigv4', '~> 1.0') # necessary for making Aws::STS API calls

--- a/gems/aws-sdk/aws-sdk.gemspec
+++ b/gems/aws-sdk/aws-sdk.gemspec
@@ -10,6 +10,11 @@ Gem::Specification.new do |spec|
   spec.email         = ['trevrowe@amazon.com']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-sdk',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/blob/code-generation/gems/aws-sdk/CHANGELOG.md'
+  }
+
   # gem dependency
   spec.add_dependency('aws-sdk-resources', '~> 3')
   # end gem dependency


### PR DESCRIPTION
Add metadata to each gem's `gemspec` which tells Rubygems where to find its source code and changelog.