### PR TITLE
Update gemspec metadate with correct information

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
@@ -27,6 +27,11 @@ module AwsSdkCodeGenerator
         desc
       end
 
+      # @return [String]
+      def code_uri
+        "https://github.com/aws/aws-sdk-ruby/tree/master/gems/#{gem_name}"
+      end
+
       # @return [Array<Dependency>]
       def dependencies
         @service.gem_dependencies.map do |gem, version|

--- a/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
@@ -13,6 +13,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => '{{code_uri}}',
+    'changelog_uri'   => '{{code_uri}}/CHANGELOG.md'
+  }
+
   {{#dependencies}}
   spec.add_dependency('{{gem}}', '{{&version}}')
   {{/dependencies}}

--- a/gems/aws-partitions/CHANGELOG.md
+++ b/gems/aws-partitions/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update the `aws-partitions` gemspec metadata
+
 1.16.0 (2017-08-23)
 ------------------
 

--- a/gems/aws-partitions/aws-partitions.gemspec
+++ b/gems/aws-partitions/aws-partitions.gemspec
@@ -7,4 +7,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = ['partitions.json'] + Dir['lib/**/*.rb']
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-partitions',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-partitions/CHANGELOG.md',
+  }
 end

--- a/gems/aws-sdk-acm/CHANGELOG.md
+++ b/gems/aws-sdk-acm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-acm` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-acm/aws-sdk-acm.gemspec
+++ b/gems/aws-sdk-acm/aws-sdk-acm.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-acm',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-acm/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-apigateway/CHANGELOG.md
+++ b/gems/aws-sdk-apigateway/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-apigateway` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
+++ b/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-apigateway',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-apigateway/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-applicationautoscaling/CHANGELOG.md
+++ b/gems/aws-sdk-applicationautoscaling/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-applicationautoscaling` gemspec metadata.
+
 1.1.0 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
+++ b/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationautoscaling',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationautoscaling/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-applicationdiscoveryservice/CHANGELOG.md
+++ b/gems/aws-sdk-applicationdiscoveryservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-applicationdiscoveryservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
+++ b/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationdiscoveryservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationdiscoveryservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-appstream/CHANGELOG.md
+++ b/gems/aws-sdk-appstream/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-appstream` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
+++ b/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-appstream',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-appstream/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-athena/CHANGELOG.md
+++ b/gems/aws-sdk-athena/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-athena` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-athena/aws-sdk-athena.gemspec
+++ b/gems/aws-sdk-athena/aws-sdk-athena.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-athena',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-athena/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-autoscaling/CHANGELOG.md
+++ b/gems/aws-sdk-autoscaling/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-autoscaling` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
+++ b/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-autoscaling',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-autoscaling/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-batch/CHANGELOG.md
+++ b/gems/aws-sdk-batch/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-batch` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-batch/aws-sdk-batch.gemspec
+++ b/gems/aws-sdk-batch/aws-sdk-batch.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-batch',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-batch/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-budgets/CHANGELOG.md
+++ b/gems/aws-sdk-budgets/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-budgets` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
+++ b/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-budgets',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-budgets/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-clouddirectory/CHANGELOG.md
+++ b/gems/aws-sdk-clouddirectory/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-clouddirectory` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
+++ b/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-clouddirectory',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-clouddirectory/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudformation/CHANGELOG.md
+++ b/gems/aws-sdk-cloudformation/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudformation` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
+++ b/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudformation',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudformation/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudfront` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
+++ b/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudfront',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudfront/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudhsm/CHANGELOG.md
+++ b/gems/aws-sdk-cloudhsm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudhsm` gemspec metadata.
+
 1.1.0 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
+++ b/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsm',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsm/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudhsmv2/CHANGELOG.md
+++ b/gems/aws-sdk-cloudhsmv2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudhsmv2` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
+++ b/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsmv2',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsmv2/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudsearch/CHANGELOG.md
+++ b/gems/aws-sdk-cloudsearch/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudsearch` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
+++ b/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearch',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearch/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudsearchdomain/CHANGELOG.md
+++ b/gems/aws-sdk-cloudsearchdomain/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudsearchdomain` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
+++ b/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearchdomain',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearchdomain/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudtrail/CHANGELOG.md
+++ b/gems/aws-sdk-cloudtrail/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudtrail` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
+++ b/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudtrail',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudtrail/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudwatch/CHANGELOG.md
+++ b/gems/aws-sdk-cloudwatch/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudwatch` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
+++ b/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatch',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatch/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudwatchevents/CHANGELOG.md
+++ b/gems/aws-sdk-cloudwatchevents/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudwatchevents` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
+++ b/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchevents',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchevents/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cloudwatchlogs/CHANGELOG.md
+++ b/gems/aws-sdk-cloudwatchlogs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cloudwatchlogs` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
+++ b/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchlogs',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchlogs/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-codebuild/CHANGELOG.md
+++ b/gems/aws-sdk-codebuild/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-codebuild` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
+++ b/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codebuild',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codebuild/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-codecommit/CHANGELOG.md
+++ b/gems/aws-sdk-codecommit/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-codecommit` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
+++ b/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codecommit',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codecommit/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-codedeploy/CHANGELOG.md
+++ b/gems/aws-sdk-codedeploy/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-codedeploy` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
+++ b/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codedeploy',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codedeploy/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-codepipeline/CHANGELOG.md
+++ b/gems/aws-sdk-codepipeline/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-codepipeline` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
+++ b/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codepipeline',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codepipeline/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-codestar/CHANGELOG.md
+++ b/gems/aws-sdk-codestar/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-codestar` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
+++ b/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codestar',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codestar/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cognitoidentity/CHANGELOG.md
+++ b/gems/aws-sdk-cognitoidentity/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cognitoidentity` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
+++ b/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentity',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentity/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cognitoidentityprovider/CHANGELOG.md
+++ b/gems/aws-sdk-cognitoidentityprovider/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cognitoidentityprovider` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
+++ b/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentityprovider',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentityprovider/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-cognitosync/CHANGELOG.md
+++ b/gems/aws-sdk-cognitosync/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-cognitosync` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
+++ b/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitosync',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitosync/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-configservice/CHANGELOG.md
+++ b/gems/aws-sdk-configservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-configservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
+++ b/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-configservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-configservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-core` gemspec metadata.
+
+* Issue - Update `aws-sdk-core` gemspec metadata
+
 3.1.0 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -15,4 +15,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-partitions', '~> 1.0')
   spec.add_dependency('aws-sigv4', '~> 1.0') # necessary for making Aws::STS API calls
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-core',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-core/CHANGELOG.md'
+  }
 end

--- a/gems/aws-sdk-costandusagereportservice/CHANGELOG.md
+++ b/gems/aws-sdk-costandusagereportservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-costandusagereportservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
+++ b/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-costandusagereportservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-costandusagereportservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-databasemigrationservice/CHANGELOG.md
+++ b/gems/aws-sdk-databasemigrationservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-databasemigrationservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
+++ b/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-databasemigrationservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-databasemigrationservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-datapipeline/CHANGELOG.md
+++ b/gems/aws-sdk-datapipeline/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-datapipeline` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
+++ b/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-datapipeline',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-datapipeline/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-dax/CHANGELOG.md
+++ b/gems/aws-sdk-dax/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-dax` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-dax/aws-sdk-dax.gemspec
+++ b/gems/aws-sdk-dax/aws-sdk-dax.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dax',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dax/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-devicefarm/CHANGELOG.md
+++ b/gems/aws-sdk-devicefarm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-devicefarm` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
+++ b/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-devicefarm',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-devicefarm/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-directconnect/CHANGELOG.md
+++ b/gems/aws-sdk-directconnect/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-directconnect` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
+++ b/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directconnect',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directconnect/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-directoryservice/CHANGELOG.md
+++ b/gems/aws-sdk-directoryservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-directoryservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
+++ b/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directoryservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directoryservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-dynamodb/CHANGELOG.md
+++ b/gems/aws-sdk-dynamodb/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-dynamodb` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
+++ b/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodb',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodb/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-dynamodbstreams/CHANGELOG.md
+++ b/gems/aws-sdk-dynamodbstreams/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-dynamodbstreams` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
+++ b/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodbstreams',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodbstreams/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-ec2/CHANGELOG.md
+++ b/gems/aws-sdk-ec2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-ec2` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
+++ b/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ec2',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ec2/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sigv4', '~> 1.0')
   spec.add_dependency('aws-sdk-core', '~> 3')
 

--- a/gems/aws-sdk-ecr/CHANGELOG.md
+++ b/gems/aws-sdk-ecr/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-ecr` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
+++ b/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecr',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecr/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-ecs/CHANGELOG.md
+++ b/gems/aws-sdk-ecs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-ecs` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
+++ b/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecs',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecs/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-efs/CHANGELOG.md
+++ b/gems/aws-sdk-efs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-efs` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-efs/aws-sdk-efs.gemspec
+++ b/gems/aws-sdk-efs/aws-sdk-efs.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-efs',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-efs/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elasticache/CHANGELOG.md
+++ b/gems/aws-sdk-elasticache/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elasticache` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
+++ b/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticache',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticache/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elasticbeanstalk/CHANGELOG.md
+++ b/gems/aws-sdk-elasticbeanstalk/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elasticbeanstalk` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
+++ b/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticbeanstalk',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticbeanstalk/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elasticloadbalancing/CHANGELOG.md
+++ b/gems/aws-sdk-elasticloadbalancing/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elasticloadbalancing` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
+++ b/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancing',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancing/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elasticloadbalancingv2/CHANGELOG.md
+++ b/gems/aws-sdk-elasticloadbalancingv2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elasticloadbalancingv2` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
+++ b/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancingv2',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancingv2/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elasticsearchservice/CHANGELOG.md
+++ b/gems/aws-sdk-elasticsearchservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elasticsearchservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
+++ b/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticsearchservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticsearchservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-elastictranscoder/CHANGELOG.md
+++ b/gems/aws-sdk-elastictranscoder/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-elastictranscoder` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
+++ b/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elastictranscoder',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elastictranscoder/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-emr/CHANGELOG.md
+++ b/gems/aws-sdk-emr/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-emr` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-emr/aws-sdk-emr.gemspec
+++ b/gems/aws-sdk-emr/aws-sdk-emr.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-emr',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-emr/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-firehose/CHANGELOG.md
+++ b/gems/aws-sdk-firehose/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-firehose` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
+++ b/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-firehose',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-firehose/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-gamelift/CHANGELOG.md
+++ b/gems/aws-sdk-gamelift/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-gamelift` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
+++ b/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-gamelift',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-gamelift/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-glacier/CHANGELOG.md
+++ b/gems/aws-sdk-glacier/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-glacier` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
+++ b/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glacier',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glacier/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-glue/CHANGELOG.md
+++ b/gems/aws-sdk-glue/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-glue` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-glue/aws-sdk-glue.gemspec
+++ b/gems/aws-sdk-glue/aws-sdk-glue.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glue',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glue/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-greengrass/CHANGELOG.md
+++ b/gems/aws-sdk-greengrass/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-greengrass` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
+++ b/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-greengrass',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-greengrass/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-health/CHANGELOG.md
+++ b/gems/aws-sdk-health/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-health` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-health/aws-sdk-health.gemspec
+++ b/gems/aws-sdk-health/aws-sdk-health.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-health',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-health/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-iam/CHANGELOG.md
+++ b/gems/aws-sdk-iam/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-iam` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-iam/aws-sdk-iam.gemspec
+++ b/gems/aws-sdk-iam/aws-sdk-iam.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iam',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iam/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-importexport/CHANGELOG.md
+++ b/gems/aws-sdk-importexport/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-importexport` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
+++ b/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-importexport',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-importexport/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv2', '~> 1.0')
 

--- a/gems/aws-sdk-inspector/CHANGELOG.md
+++ b/gems/aws-sdk-inspector/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-inspector` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
+++ b/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-inspector',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-inspector/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-iot/CHANGELOG.md
+++ b/gems/aws-sdk-iot/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-iot` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-iot/aws-sdk-iot.gemspec
+++ b/gems/aws-sdk-iot/aws-sdk-iot.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iot',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iot/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-iotdataplane/CHANGELOG.md
+++ b/gems/aws-sdk-iotdataplane/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-iotdataplane` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
+++ b/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iotdataplane',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iotdataplane/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-kinesis/CHANGELOG.md
+++ b/gems/aws-sdk-kinesis/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-kinesis` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesis',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesis/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-kinesisanalytics/CHANGELOG.md
+++ b/gems/aws-sdk-kinesisanalytics/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-kinesisanalytics` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
+++ b/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisanalytics',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisanalytics/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-kms/CHANGELOG.md
+++ b/gems/aws-sdk-kms/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-kms` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-kms/aws-sdk-kms.gemspec
+++ b/gems/aws-sdk-kms/aws-sdk-kms.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kms',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kms/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-lambda/CHANGELOG.md
+++ b/gems/aws-sdk-lambda/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-lambda` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
+++ b/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambda',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambda/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-lambdapreview/CHANGELOG.md
+++ b/gems/aws-sdk-lambdapreview/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-lambdapreview` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
+++ b/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambdapreview',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambdapreview/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-lex/CHANGELOG.md
+++ b/gems/aws-sdk-lex/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-lex` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-lex/aws-sdk-lex.gemspec
+++ b/gems/aws-sdk-lex/aws-sdk-lex.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lex',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lex/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-lexmodelbuildingservice/CHANGELOG.md
+++ b/gems/aws-sdk-lexmodelbuildingservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-lexmodelbuildingservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
+++ b/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lexmodelbuildingservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lexmodelbuildingservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-lightsail/CHANGELOG.md
+++ b/gems/aws-sdk-lightsail/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-lightsail` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
+++ b/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lightsail',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lightsail/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-machinelearning/CHANGELOG.md
+++ b/gems/aws-sdk-machinelearning/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-machinelearning` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
+++ b/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-machinelearning',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-machinelearning/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-marketplacecommerceanalytics/CHANGELOG.md
+++ b/gems/aws-sdk-marketplacecommerceanalytics/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-marketplacecommerceanalytics` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
+++ b/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacecommerceanalytics',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacecommerceanalytics/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-marketplaceentitlementservice/CHANGELOG.md
+++ b/gems/aws-sdk-marketplaceentitlementservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-marketplaceentitlementservice` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
+++ b/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplaceentitlementservice',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplaceentitlementservice/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-marketplacemetering/CHANGELOG.md
+++ b/gems/aws-sdk-marketplacemetering/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-marketplacemetering` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
+++ b/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacemetering',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacemetering/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-migrationhub/CHANGELOG.md
+++ b/gems/aws-sdk-migrationhub/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-migrationhub` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
+++ b/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-migrationhub',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-migrationhub/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-mturk/CHANGELOG.md
+++ b/gems/aws-sdk-mturk/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-mturk` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
+++ b/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mturk',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mturk/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-opsworks/CHANGELOG.md
+++ b/gems/aws-sdk-opsworks/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-opsworks` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
+++ b/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworks',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworks/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-opsworkscm/CHANGELOG.md
+++ b/gems/aws-sdk-opsworkscm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-opsworkscm` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
+++ b/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworkscm',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworkscm/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-organizations/CHANGELOG.md
+++ b/gems/aws-sdk-organizations/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-organizations` gemspec metadata.
+
 1.1.0 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
+++ b/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-organizations',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-organizations/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-pinpoint/CHANGELOG.md
+++ b/gems/aws-sdk-pinpoint/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-pinpoint` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
+++ b/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pinpoint',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pinpoint/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-polly/CHANGELOG.md
+++ b/gems/aws-sdk-polly/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-polly` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-polly/aws-sdk-polly.gemspec
+++ b/gems/aws-sdk-polly/aws-sdk-polly.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-polly',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-polly/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-rds/CHANGELOG.md
+++ b/gems/aws-sdk-rds/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-rds` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-rds/aws-sdk-rds.gemspec
+++ b/gems/aws-sdk-rds/aws-sdk-rds.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rds',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rds/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sigv4', '~> 1.0')
   spec.add_dependency('aws-sdk-core', '~> 3')
 

--- a/gems/aws-sdk-redshift/CHANGELOG.md
+++ b/gems/aws-sdk-redshift/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-redshift` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
+++ b/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-redshift',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-redshift/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-rekognition/CHANGELOG.md
+++ b/gems/aws-sdk-rekognition/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-rekognition` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
+++ b/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rekognition',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rekognition/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-resourcegroupstaggingapi/CHANGELOG.md
+++ b/gems/aws-sdk-resourcegroupstaggingapi/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-resourcegroupstaggingapi` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
+++ b/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resourcegroupstaggingapi',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resourcegroupstaggingapi/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-resources/CHANGELOG.md
+++ b/gems/aws-sdk-resources/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-resources` gemspec metadata
+
 3.0.1 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-resources/CHANGELOG.md
+++ b/gems/aws-sdk-resources/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Issue - Update `aws.rb` executable to `aws-v3.rb` in aws-sdk-resources.gemspec
-
 3.0.1 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-resources/CHANGELOG.md
+++ b/gems/aws-sdk-resources/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws.rb` executable to `aws-v3.rb` in aws-sdk-resources.gemspec
+
 3.0.1 (2017-08-30)
 ------------------
 

--- a/gems/aws-sdk-resources/aws-sdk-resources.gemspec
+++ b/gems/aws-sdk-resources/aws-sdk-resources.gemspec
@@ -119,4 +119,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sdk-xray', '~> 1')
   # end service gems
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resources',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resources/CHANGELOG.md'
+  }
 end

--- a/gems/aws-sdk-route53/CHANGELOG.md
+++ b/gems/aws-sdk-route53/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-route53` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-route53/aws-sdk-route53.gemspec
+++ b/gems/aws-sdk-route53/aws-sdk-route53.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-route53domains/CHANGELOG.md
+++ b/gems/aws-sdk-route53domains/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-route53domains` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
+++ b/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53domains',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53domains/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-s3` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-s3/aws-sdk-s3.gemspec
+++ b/gems/aws-sdk-s3/aws-sdk-s3.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-s3',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-s3/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-kms', '~> 1')
   spec.add_dependency('aws-sigv4', '~> 1.0')
   spec.add_dependency('aws-sdk-core', '~> 3')

--- a/gems/aws-sdk-servicecatalog/CHANGELOG.md
+++ b/gems/aws-sdk-servicecatalog/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-servicecatalog` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
+++ b/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-servicecatalog',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-servicecatalog/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-ses/CHANGELOG.md
+++ b/gems/aws-sdk-ses/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-ses` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-ses/aws-sdk-ses.gemspec
+++ b/gems/aws-sdk-ses/aws-sdk-ses.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ses',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ses/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-shield/CHANGELOG.md
+++ b/gems/aws-sdk-shield/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-shield` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-shield/aws-sdk-shield.gemspec
+++ b/gems/aws-sdk-shield/aws-sdk-shield.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-shield',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-shield/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-simpledb/CHANGELOG.md
+++ b/gems/aws-sdk-simpledb/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-simpledb` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
+++ b/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-simpledb',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-simpledb/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv2', '~> 1.0')
 

--- a/gems/aws-sdk-sms/CHANGELOG.md
+++ b/gems/aws-sdk-sms/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-sms` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-sms/aws-sdk-sms.gemspec
+++ b/gems/aws-sdk-sms/aws-sdk-sms.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sms',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sms/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-snowball/CHANGELOG.md
+++ b/gems/aws-sdk-snowball/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-snowball` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
+++ b/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-snowball',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-snowball/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-sns/CHANGELOG.md
+++ b/gems/aws-sdk-sns/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-sns` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-sns/aws-sdk-sns.gemspec
+++ b/gems/aws-sdk-sns/aws-sdk-sns.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sns',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sns/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-sqs` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
+++ b/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sqs',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sqs/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-ssm/CHANGELOG.md
+++ b/gems/aws-sdk-ssm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-ssm` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
+++ b/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ssm',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ssm/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-states/CHANGELOG.md
+++ b/gems/aws-sdk-states/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-states` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-states/aws-sdk-states.gemspec
+++ b/gems/aws-sdk-states/aws-sdk-states.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-states',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-states/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-storagegateway/CHANGELOG.md
+++ b/gems/aws-sdk-storagegateway/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-storagegateway` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
+++ b/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-storagegateway',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-storagegateway/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-support/CHANGELOG.md
+++ b/gems/aws-sdk-support/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-support` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-support/aws-sdk-support.gemspec
+++ b/gems/aws-sdk-support/aws-sdk-support.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-support',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-support/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-swf/CHANGELOG.md
+++ b/gems/aws-sdk-swf/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-swf` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-swf/aws-sdk-swf.gemspec
+++ b/gems/aws-sdk-swf/aws-sdk-swf.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-swf',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-swf/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-waf/CHANGELOG.md
+++ b/gems/aws-sdk-waf/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-waf` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-waf/aws-sdk-waf.gemspec
+++ b/gems/aws-sdk-waf/aws-sdk-waf.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-waf',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-waf/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-wafregional/CHANGELOG.md
+++ b/gems/aws-sdk-wafregional/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-wafregional` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
+++ b/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-wafregional',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-wafregional/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-workdocs/CHANGELOG.md
+++ b/gems/aws-sdk-workdocs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-workdocs` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
+++ b/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workdocs',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workdocs/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-workspaces/CHANGELOG.md
+++ b/gems/aws-sdk-workspaces/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-workspaces` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
+++ b/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workspaces',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workspaces/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk-xray/CHANGELOG.md
+++ b/gems/aws-sdk-xray/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk-xray` gemspec metadata.
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk-xray/aws-sdk-xray.gemspec
+++ b/gems/aws-sdk-xray/aws-sdk-xray.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb']
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-xray',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-xray/CHANGELOG.md'
+  }
+
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sigv4', '~> 1.0')
 

--- a/gems/aws-sdk/CHANGELOG.md
+++ b/gems/aws-sdk/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sdk` gemspec metadata
+
 3.0.0 (2017-08-29)
 ------------------
 

--- a/gems/aws-sdk/aws-sdk.gemspec
+++ b/gems/aws-sdk/aws-sdk.gemspec
@@ -14,4 +14,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sdk-resources', '~> 3')
   # end gem dependency
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk/CHANGELOG.md'
+  }
 end

--- a/gems/aws-sigv2/CHANGELOG.md
+++ b/gems/aws-sigv2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sigv2` gemspec metadata.
+
 1.0.0 (2016-12-05)
 ------------------
 

--- a/gems/aws-sigv2/aws-sigv2.gemspec
+++ b/gems/aws-sigv2/aws-sigv2.gemspec
@@ -7,4 +7,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sigv2',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sigv2/CHANGELOG.md'
+  }
 end

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update `aws-sigv4` gemspec metadata
+
 1.0.1 (2017-07-12)
 ------------------
 

--- a/gems/aws-sigv4/aws-sigv4.gemspec
+++ b/gems/aws-sigv4/aws-sigv4.gemspec
@@ -7,4 +7,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
+
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sigv4',
+    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sigv4/CHANGELOG.md'
+  }
 end


### PR DESCRIPTION
Address #1583 #1585 

Note, this PR included
1. manual edit for `aws-sdk`, `aws-sdk-core`, `aws-sdk-resources`, `aws-sigv4`, `aws-sigv2` and `aws-partitions` gems 
2. generated file changes for service gems (at gemspec and CHAMGELOG.md)