### PR TITLE
Remove redundant version file at core gem

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove redundant version file.
+
 3.2.0 (2017-08-31)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -28,7 +28,6 @@ require_relative 'aws-sdk-core/shared_config'
 require_relative 'aws-sdk-core/structure'
 require_relative 'aws-sdk-core/type_builder'
 require_relative 'aws-sdk-core/util'
-require_relative 'aws-sdk-core/version'
 
 # resource classes
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/version.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/version.rb
@@ -1,3 +1,0 @@
-module Aws
-  VERSION = '2.8.2'
-end

--- a/gems/aws-sdk-core/spec/aws_spec.rb
+++ b/gems/aws-sdk-core/spec/aws_spec.rb
@@ -6,7 +6,7 @@ module Aws
   describe 'VERSION' do
 
     it 'is a semver compatible string' do
-      expect(VERSION).to match(/\d+\.\d+\.\d+/)
+      expect(CORE_GEM_VERSION).to match(/\d+\.\d+\.\d+/)
     end
 
   end


### PR DESCRIPTION
As described, address #1592 

The core gem version is [here](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/VERSION), and extracted [here](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core.rb#L71)