### PR TITLE
Support block streaming for resource object as well

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
@@ -19,7 +19,7 @@ module AwsSdkCodeGenerator
             examples: examples,
             client_examples: client_examples[method_name] || []
           ).to_s,
-          streaming: streaming(operation, api)
+          streaming: AwsSdkCodeGenerator::Helper.operation_streaming?(operation, api)
         )
       end
     end
@@ -27,21 +27,6 @@ module AwsSdkCodeGenerator
     # @return [Enumerable<Operation>]
     def each(&block)
       @operations.each(&block)
-    end
-
-    def streaming(operation, api)
-      return unless operation.key? 'output'
-      output = operation['output']['shape']
-      if api['shapes'][output].key? 'payload'
-        output_shape = api['shapes'][output]
-        payload = output_shape['payload']
-        if output_shape.key? 'members'
-          payload_ref = output_shape['members'][payload]
-        elsif output_shape.key? 'member'
-          payload_ref = output_shape['member'][payload]
-        end
-        Api.streaming?(payload_ref, api)
-      end
     end
 
     class Operation

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -134,6 +134,21 @@ module AwsSdkCodeGenerator
       Docstring.html_to_markdown(html, options)
     end
 
+    def operation_streaming?(operation, api)
+      return unless operation.key? 'output'
+      output = operation['output']['shape']
+      if api['shapes'][output].key? 'payload'
+        output_shape = api['shapes'][output]
+        payload = output_shape['payload']
+        if output_shape.key? 'members'
+          payload_ref = output_shape['members'][payload]
+        elsif output_shape.key? 'member'
+          payload_ref = output_shape['member'][payload]
+        end
+        Api.streaming?(payload_ref, api)
+      end
+    end
+
     def deep_copy(obj)
       case obj
       when nil then nil
@@ -151,7 +166,7 @@ module AwsSdkCodeGenerator
         end
       end
     end
-    module_function :deep_copy
+    module_function :deep_copy, :operation_streaming?
 
   end
 end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
@@ -2,6 +2,8 @@ module AwsSdkCodeGenerator
   class ResourceAction
     class << self
 
+      include Helper
+
       # @return [Array<ResourceMethod>]
       def build_list(resource_name, resource, api)
         resource.fetch('actions', {}).map do |action_name, action|
@@ -22,6 +24,12 @@ module AwsSdkCodeGenerator
         ResourceMethod.new.tap do |m|
           m.method_name = Underscore.underscore(options.fetch(:action_name))
           m.arguments = 'options = {}'
+          operation_name = options.fetch(:action)['request']['operation']
+          api = options.fetch(:api)
+          if operation_streaming?(api['operations'][operation_name], api)
+            m.arguments += ', &block'
+            options[:streaming] = true
+          end
           m.code = ResourceActionCode.new(options).build
           m.documentation = documentation(options)
         end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
@@ -5,6 +5,7 @@ module AwsSdkCodeGenerator
       action = options.fetch(:action)
       @request = action.fetch('request')
       @resource = action.fetch('resource', nil)
+      @streaming = options.fetch(:streaming, false)
     end
 
     def build
@@ -27,7 +28,7 @@ module AwsSdkCodeGenerator
     private
 
     def client_request
-      ResourceClientRequest.build(request: @request, resp: true)
+      ResourceClientRequest.build(request: @request, resp: true, streaming: @streaming)
     end
 
     def resource_type

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
@@ -8,13 +8,14 @@ module AwsSdkCodeGenerator
       def build(options)
         request = options.fetch(:request)
         merge = options.fetch(:merge, true)
+        streaming = options.fetch(:streaming, false)
         params = ResourceClientRequestParams.new(params: request['params'])
         parts = []
         parts << request_options(params) if merge
         parts << assignment(options)
         parts << "@client."
         parts << operation_name(request)
-        parts << arguments(merge, params)
+        parts << arguments(merge, params, streaming)
         parts.join
       end
 
@@ -44,13 +45,13 @@ module AwsSdkCodeGenerator
         Underscore.underscore(request['operation'])
       end
 
-      def arguments(merge, params)
+      def arguments(merge, params, streaming)
         if merge
-          '(options)'
+          streaming ? '(options, &block)' : '(options)'
         elsif params.empty?
           ''
         else
-          "(#{params})"
+          streaming ? "(#{params}, &block)" : "(#{params})"
         end
       end
 

--- a/gems/aws-sdk-s3/features/resources/object.feature
+++ b/gems/aws-sdk-s3/features/resources/object.feature
@@ -16,3 +16,7 @@ Feature: Aws::S3::Object
     Given I have a 15MB file
     When I upload the file to the "large" object with SSE/CPK
     Then the file should have been uploaded as a multipart upload
+
+   Scenario: Support object streaming
+    Given I put "hello world" to the object with key "hello"
+    Then I can streaming download object with key "hello"

--- a/gems/aws-sdk-s3/features/resources/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/resources/step_definitions.rb
@@ -210,3 +210,15 @@ Then(/^these test file has been cleaned up$/) do
     expect(File.exist?(file)).to be(false)
   end
 end
+
+Given(/^I put "([^"]*)" to the object with key "([^"]*)"$/) do |body, key|
+  @obj = @bucket.object(key)
+  @obj.put(body: body)
+end
+
+Then(/^I can streaming download object with key "([^"]*)"$/) do |key|
+  resp = @obj.get do |chunk|
+    expect(chunk).to eq("hello world")
+  end
+  expect(resp.body).to be_a(Seahorse::Client::BlockIO)
+end


### PR DESCRIPTION
Follow up on #1588 

Move streaming check to helper module and add block behavior support for resources object. Also added smoke test for s3 object.

Below are auto generated diffs output after rebuilding all gems:
at `aws-sdk-glacier`
![image](https://user-images.githubusercontent.com/10790394/30138478-71ce62f0-931d-11e7-8e84-32498b2de466.png)
at `aws-sdk-s3`
![image](https://user-images.githubusercontent.com/10790394/30138482-7993ba62-931d-11e7-9005-7cf7343c5ef2.png)
