### PR TITLE
Update ruby 1.9.3 dependency on kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :test do
     gem 'webmock', '2.2.0'
     # oj drop support for Ruby under 2.0 since 3.3.5
     gem 'oj', '<= 3.3.4'
+    # kramdown drop support for Ruby under 2.0 since 1.15.0
+    gem 'kramdown', '<= 1.14.0'
   else
     gem 'addressable'
     gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,6 @@ group :test do
     gem 'webmock', '2.2.0'
     # oj drop support for Ruby under 2.0 since 3.3.5
     gem 'oj', '<= 3.3.4'
-    # kramdown drop support for Ruby under 2.0 since 1.15.0
-    gem 'kramdown', '<= 1.14.0'
   else
     gem 'addressable'
     gem 'webmock'
@@ -51,7 +49,8 @@ group :test do
 end
 
 group :build do
-  gem 'kramdown' # using this to fix poorly formatted HTML in API docs
+  # using this to fix poorly formatted HTML in API docs
+  gem 'kramdown', '1.14.0' # pinned to support Ruby 1.9.3
   gem 'mustache', '0.99.8' # pinned to support Ruby 1.9.3
 end
 


### PR DESCRIPTION
The master travis [build]() is failing on ruby 1.9.3 due to:
```
Gem::InstallError: kramdown requires Ruby version >= 2.0.
An error occurred while installing kramdown (1.15.0), and Bundler cannot
continue.
Make sure that `gem install kramdown -v '1.15.0'` succeeds before bundling.
The command "eval bundle install --without docs release repl " failed. Retrying, 2 of 3.
```
Kramdown releases `1.15.0` 2 hours ago today, last build with `1.14.0` [succeed](https://travis-ci.org/aws/aws-sdk-ruby/jobs/272745807) with ruby 1.9.3