### PR TITLE
Allow resource constructor taking data hash

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
@@ -309,6 +309,16 @@ describe 'Interfaces' do
           expect(ticket.purchase_price).to be(10)
         end
 
+        it 'allows data to be provided as hash' do
+          data = client.stub_data(:get_ticket, ticket:{purchase_price:10}).ticket
+          expect(client).not_to receive(:get_ticket)
+          data_hash = data.to_h
+          ticket = Sample::Ticket.new(123, data: data_hash, client: client)
+          expect(ticket.data).to be(data_hash)
+          expect(ticket.data_loaded?).to be(true)
+          expect(ticket.purchase_price).to be(10)
+        end
+
       end
 
       describe 'shape without load' do

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -46,7 +46,11 @@ module {{module_name}}
 
     {{> documentation}}
     def {{name}}
-      data.{{name}}
+      if data.is_a? Hash
+        data[:{{name}}]
+      else
+        data.{{name}}
+      end
     end
     {{/data_attributes}}
 

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -46,11 +46,7 @@ module {{module_name}}
 
     {{> documentation}}
     def {{name}}
-      if data.is_a? Hash
-        data[:{{name}}]
-      else
-        data.{{name}}
-      end
+      data[:{{name}}]
     end
     {{/data_attributes}}
 


### PR DESCRIPTION
Addressing #1607 

To keep v2 compatibility, allow resource object taking data hash, spec test is added as well.

Some sample generated diff, e.g s3:
![image](https://user-images.githubusercontent.com/10790394/30293894-ede37aee-96ef-11e7-8219-74511ca731ca.png)
