### PR TITLE
Allow resource constructor taking data hash

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
@@ -65,7 +65,7 @@ module AwsSdkCodeGenerator
       if path && path.include?('[]')
         prefix = loops.last.match(/\|(.+)\|/)[1]
         suffix = underscore(path[common_prefix.length..-1])
-        if @context == :options
+        unless @context == :response
           suffix = suffix.gsub(/\.\w+/) { |word| "[:#{word[1..-1]}]" }
         end
         suffix.length == 0 ? prefix : prefix + suffix
@@ -110,7 +110,7 @@ module AwsSdkCodeGenerator
     def loops
       loop_var =
         case @context
-        when :data then 'data.'
+        when :data then 'data'
         when :options then 'options'
         when :response then "#{@resp_var_name}.data."
         end
@@ -121,7 +121,7 @@ module AwsSdkCodeGenerator
       parts = common_prefix.split('[]')
       parts = parts.map.with_index do |part,n|
         part = underscore(part)
-        if @context == :options
+        unless @context == :response
           part = part.gsub(/\w+/) { |word| "[:#{word}]" }
           part = part.gsub(/\./, '')
         end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
@@ -16,7 +16,9 @@ module AwsSdkCodeGenerator
       if path == '@'
         'data'
       elsif path.match(/^(\w(\[0\])?)+(\.\w+)*$/)
-        'data.' + underscore_path(path)
+        data_path = underscore_path(path).gsub(/\w+/) { |word| "[:#{word}]" }
+        # In case resource model path contains x.[:0].y
+        'data' + data_path.gsub(/\[\[\:/, '[').gsub(/\]\]/, ']').gsub(/\./, '')
       else
         raise "unsupported path: #{path.inspect}"
       end

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -46,7 +46,7 @@ module {{module_name}}
 
     {{> documentation}}
     def {{name}}
-      data.{{name}}
+      data[:{{name}}]
     end
     {{/data_attributes}}
 


### PR DESCRIPTION
Addressing #1607, #1608

To keep v2 compatibility, allow resource object taking data hash, spec test is added as well.
Will follow up with generated diff.

Notes:
Here is the (only place in) original V2 code that make it appears hash is [ok](https://github.com/aws/aws-sdk-ruby/blob/version-2/aws-sdk-resources/lib/aws-sdk-resources/resource.rb#L222).

In this PR I tried to just switch struct usage from `#.` to `#[]` in the minimal scope to be less error prone.
