### PR TITLE
Add Resource#wait_until regression with deprecate warnings

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
@@ -15,6 +15,7 @@ module AwsSdkCodeGenerator
         @client_load_method = Underscore.underscore(resource['load']['request']['operation']) if resource['load']
         @data_class = "Types::#{resource['shape']}"
         @waiters = ResourceWaiter.build_list(resource, options[:waiters])
+        @wait_until = options[:waiters] # add #wait_until method if service has waiters
         @actions = ResourceAction.build_list(@class_name, resource, api)
         @associations = build_associations(options)
         @batch_actions = ResourceBatchAction.build_list(@class_name, resource, api)
@@ -50,6 +51,9 @@ module AwsSdkCodeGenerator
 
       # @return [Array<Waiter>]
       attr_reader :waiters
+
+      # @return [Boolean]
+      attr_reader :wait_until
 
       # @return [Array<ResourceAction>]
       attr_reader :actions

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
@@ -643,6 +643,15 @@ describe 'Interfaces' do
 
     describe 'waiters' do
 
+      it 'has default #wait_until method' do
+        band = Sample::Band.new(name:'band-name', client: client)
+        expect(band).to respond_to(:wait_until)
+
+        # Tag doesn't have waiter entry at `resource.json`
+        tag = Sample::Tag.new(resource_id: 'foo', key: 'bar', value: 'baz', client: client)
+        expect(tag).to respond_to(:wait_until)
+      end
+
       it 'defines a single #wait_until_* method for each named waiter' do
         band = Sample::Band.new(name:'band-name', client: client)
         expect(band).to respond_to(:wait_until_exists)

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -112,6 +112,103 @@ module {{module_name}}
       })
     end
     {{/waiters}}
+    {{#wait_until}}
+
+    # @deprecated Use [{{module_name}}::Client] #wait_until instead
+    #
+    # Waiter polls an API operation until a resource enters a desired
+    # state.
+    #
+    # @note The waiting operation is performed on a copy. The original resource remains unchanged
+    #
+    # ## Basic Usage
+    #
+    # Waiter will polls until it is successful, it fails by
+    # entering a terminal state, or until a maximum number of attempts
+    # are made.
+    #
+    #     # polls in a loop until condition is true
+    #     resource.wait_until(options) {|resource| condition}
+    #
+    # ## Example
+    #
+    #     instance.wait_until(max_attempts:10, delay:5) {|instance| instance.state.name == 'running' }
+    #
+    # ## Configuration
+    #
+    # You can configure the maximum number of polling attempts, and the
+    # delay (in seconds) between each polling attempt. The waiting condition is set
+    # by passing a block to {#wait_until}:
+    #
+    #     # poll for ~25 seconds
+    #     resource.wait_until(max_attempts:5,delay:5) {|resource|...}
+    #
+    # ## Callbacks
+    #
+    # You can be notified before each polling attempt and before each
+    # delay. If you throw `:success` or `:failure` from these callbacks,
+    # it will terminate the waiter.
+    #
+    #     started_at = Time.now
+    #     # poll for 1 hour, instead of a number of attempts
+    #     proc = Proc.new do |attempts, response|
+    #       throw :failure if Time.now - started_at > 3600
+    #     end
+    #
+    #       # disable max attempts
+    #     instance.wait_until(before_wait:proc, max_attempts:nil) {...}
+    #
+    # ## Handling Errors
+    #
+    # When a waiter is successful, it returns the Resource. When a waiter
+    # fails, it raises an error.
+    #
+    #     begin
+    #       resource.wait_until(...)
+    #     rescue Aws::Waiters::Errors::WaiterFailed
+    #       # resource did not enter the desired state in time
+    #     end
+    #
+    #
+    # @yield param [Resource] resource to be used in the waiting condition
+    #
+    # @raise [Aws::Waiters::Errors::FailureStateError] Raised when the waiter terminates
+    #   because the waiter has entered a state that it will not transition
+    #   out of, preventing success.
+    #
+    #   yet successful.
+    #
+    # @raise [Aws::Waiters::Errors::UnexpectedError] Raised when an error is encountered
+    #   while polling for a resource that is not expected.
+    #
+    # @raise [NotImplementedError] Raised when the resource does not
+    #
+    # @option options [Integer] :max_attempts (10) Maximum number of
+    # attempts
+    # @option options [Integer] :delay (10) Delay between each
+    # attempt in seconds
+    # @option options [Proc] :before_attempt (nil) Callback
+    # invoked before each attempt
+    # @option options [Proc] :before_wait (nil) Callback
+    # invoked before each wait
+    # @return [Resource] if the waiter was successful
+    def wait_until(options = {}, &block)
+      self_copy = self.dup
+      attempts = 0
+      options[:max_attempts] = 10 unless options.key?(:max_attempts)
+      options[:delay] ||= 10
+      options[:poller] = Proc.new do
+        attempts += 1
+        if block.call(self_copy)
+          [:success, self_copy]
+        else
+          self_copy.reload unless attempts == options[:max_attempts]
+          :retry
+        end
+      end
+      Aws::Waiters::Waiter.new(options).wait({})
+    end
+    {{/wait_until}}
     {{#actions?}}
 
     # @!group Actions

--- a/gems/aws-sdk-ec2/features/resource.feature
+++ b/gems/aws-sdk-ec2/features/resource.feature
@@ -5,4 +5,4 @@ Feature: Aws::EC2::Volume
   Scenario: Wait until volume is available
     Given I create a volume
     When I use #wait_until to wait until volume is available
-    Then Waiter works and volume is cleaned up
+    Then Waiter works as expected

--- a/gems/aws-sdk-ec2/features/resource.feature
+++ b/gems/aws-sdk-ec2/features/resource.feature
@@ -1,0 +1,8 @@
+# language: en
+@ec2 @resource
+Feature: Aws::EC2::Volume
+
+  Scenario: Wait until volume is available
+    Given I create a volume
+    When I use #wait_until to wait until volume is available
+    Then Waiter works and volume is cleaned up

--- a/gems/aws-sdk-ec2/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/step_definitions.rb
@@ -1,7 +1,6 @@
 Before("@ec2") do
   @service = Aws::EC2::Resource.new
   @client = @service.client
-  @volume_ids = []
 end
 
 After("@ec2") do

--- a/gems/aws-sdk-ec2/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/step_definitions.rb
@@ -1,8 +1,28 @@
 Before("@ec2") do
   @service = Aws::EC2::Resource.new
   @client = @service.client
+  @volume_ids = []
 end
 
 After("@ec2") do
-  # shared cleanup logic
+end
+
+Given(/^I create a volume$/) do
+  @volume = @service.create_volume(size: 1, availability_zone: 'us-west-2a', volume_type: 'gp2')
+  @volume_id = @volume.id
+end
+
+When(/^I use \#wait_until to wait until volume is available$/) do
+  expect {
+    @resp = @volume.wait_until {|v| v.state == 'available'}
+  }.not_to raise_error
+end
+
+Then(/^Waiter works and volume is cleaned up$/) do
+  expect(ApiCallTracker.called_operations).to include(:describe_volumes)
+  expect(@resp.id).to eq(@volume_id)
+
+  # clean up
+  @client.delete_volume(volume_id: @volume_id)
+  @client.wait_until(:volume_deleted, volume_ids: [@volume_id])
 end

--- a/gems/aws-sdk-ec2/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/step_definitions.rb
@@ -1,14 +1,20 @@
 Before("@ec2") do
   @service = Aws::EC2::Resource.new
   @client = @service.client
+  @volume_ids = []
 end
 
 After("@ec2") do
+  @volume_ids.each do |id|
+    @client.delete_volume(volume_id: id)
+  end
+  @client.wait_until(:volume_deleted, volume_ids: @volume_ids)
 end
 
 Given(/^I create a volume$/) do
   @volume = @service.create_volume(size: 1, availability_zone: 'us-west-2a', volume_type: 'gp2')
   @volume_id = @volume.id
+  @volume_ids << @volume_id
 end
 
 When(/^I use \#wait_until to wait until volume is available$/) do
@@ -17,11 +23,7 @@ When(/^I use \#wait_until to wait until volume is available$/) do
   }.not_to raise_error
 end
 
-Then(/^Waiter works and volume is cleaned up$/) do
+Then(/^Waiter works as expected$/) do
   expect(ApiCallTracker.called_operations).to include(:describe_volumes)
   expect(@resp.id).to eq(@volume_id)
-
-  # clean up
-  @client.delete_volume(volume_id: @volume_id)
-  @client.wait_until(:volume_deleted, volume_ids: [@volume_id])
 end


### PR DESCRIPTION
Address #1610 

Some background, in V2 those resource [objects](http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Volume.html) all inherits [`Aws::Resources::Resource`](http://docs.aws.amazon.com/sdkforruby/api/Aws/Resources/Resource.html). This [`#wait_until`](https://github.com/aws/aws-sdk-ruby/blob/version-2/aws-sdk-resources/lib/aws-sdk-resources/resource.rb#L101) method looks like the only that make sense and need extra port over to V3. This PR ported this over to all resource objects that has waiters for their service, avoid depending on `resource.json` waiter check because `resource.json` usually quite outdated. Tested manually.

Other alternative approaches considered yet not followed:
I have considered port this over to` resource.rb`s solo, and let those objects' `#wait_until` just call the one of service resource. However this won't work for block usage [here](https://github.com/aws/aws-sdk-ruby/blob/version-2/aws-sdk-resources/lib/aws-sdk-resources/resource.rb#L102).

Notes, this usage behavior looks like should have be been [deprecated](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb#L21323), so I have added @deprecated tag as well

Sample diff almost the same with the mustache diff : )