### PR TITLE
Close and unlink tempfiles when encryption is complete

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Delete encryption tempfiles after use. Issue #1624
 
 1.4.0 (2017-09-14)
 ------------------

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
@@ -39,7 +39,7 @@ module Aws
 
         # @api private
         def close
-          @encrypted.close if Tempfile === @encrypted
+          @encrypted.close! if Tempfile === @encrypted
         end
 
         private


### PR DESCRIPTION
This adds a delete to the close of a tempfile. Otherwise tempfiles stick around until the ruby process is ended.

Issue #1624. 