### PR TITLE
Fix travis failure on OJ etc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'jmespath'
 group :test do
 
   gem 'rspec'
-  gem 'cucumber'
 
   if RUBY_VERSION == '1.9.3'
     # webmock depends on addressable, but the latest version of addressable
@@ -17,9 +16,12 @@ group :test do
     gem 'webmock', '2.2.0'
     # oj drop support for Ruby under 2.0 since 3.3.5
     gem 'oj', '<= 3.3.4'
+    # cucumber drop support for Ruby under 2.0 after 3.0.0
+    gem 'cucumber', '3.0.0'
   else
     gem 'addressable'
     gem 'webmock'
+    gem 'cucumber'
   end
   gem 'json-schema'
   gem 'multipart-post'

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update OJ Json parser error code
+
 1.4.0 (2017-09-14)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -47,7 +47,7 @@ module Aws
         def validate_desc(description)
           Json.load(description)
           description
-        rescue Json::ParseError
+        rescue Json::ParseError, EncodingError
           msg = "expected description to be a valid JSON document string"
           raise ArgumentError, msg
         end


### PR DESCRIPTION
1. cucumber drop support for ruby under 2.0
2. OJ introduce an error change for their `3.3.7` [release](https://github.com/ohler55/oj/pull/438)

Will wait for ci finish
