### PR TITLE
Add serviceId for metadata field check

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -69,6 +69,7 @@ module AwsSdkCodeGenerator
         'globalEndpoint' => false,
         'serviceAbbreviation' => false,
         'uid' => false,
+        'serviceId' => false,
       }
 
       # @option options [required, Service] :service

--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample/api.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample/api.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "endpointPrefix": "svcname",
+    "serviceId": "sample_svc",
     "protocol": "rest-json"
   },
   "operations": {


### PR DESCRIPTION
If service metadata now has serviceId, make sure it doesn't break build
