### PR TITLE
[Version 3] Fix pagable response empty stub regression

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update empty struct stubbing shape
+
 3.6.0 (2017-09-20)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
@@ -24,7 +24,7 @@ module Aws
             stub[key] = nil
           end
           if more_results = @pager.instance_variable_get('@more_results')
-            stub[more_results] = nil
+            stub[more_results] = false
           end
         end
       end

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -44,11 +44,12 @@ module Aws
                 'members' => {
                   'MaxResults' => { 'shape' => 'String' },
                   'NextToken' => { 'shape' => 'String' },
-                  'IsTruncated' => { 'shape' => 'String' },
+                  'IsTruncated' => { 'shape' => 'Boolean' },
                   'Results' => { 'shape' => 'StringList' }
                 }
               },
               'String' => { 'type' => 'string' },
+              'Boolean' => { 'type' => 'boolean'},
               'StringList' => {
                 'type' => 'list',
                 'member' => { 'shape' => 'String' }
@@ -71,7 +72,7 @@ module Aws
         stub = client.operation_name
         expect(stub[:results]).to eq([])
         expect(stub[:next_token]).to be(nil)
-        expect(stub[:is_truncated]).to be(nil)
+        expect(stub[:is_truncated]).to be(false)
       end
 
     end


### PR DESCRIPTION
Address issue #1654 

Short description of the issue, the `is_truncated` member is required in the operation response, yet current v3 empty stub is returning `nil` instead of `false`, thus cause param validator errors.

Short summary of the fix, in V2 there is no check for pagers' more result, default value (`false`) is stubbed for empty struct, I have checked all `is_truncate` shapes, all of them are boolean type, stubbing them to false instead of nil to avoid regression.

Let me know if i'm missing something since I noticed the previous spec is assuming a string.
