### PR TITLE
[Perf] Time.iso8601 is 3x faster than Time.parse

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -85,7 +85,7 @@ module Aws
           c['SecretAccessKey'],
           c['Token']
         )
-        @expiration = c['Expiration'] ? Time.parse(c['Expiration']) : nil
+        @expiration = c['Expiration'] ? Time.iso8601(c['Expiration']) : nil
       end
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -76,7 +76,7 @@ module Aws
           c['SecretAccessKey'],
           c['Token']
         )
-        @expiration = c['Expiration'] ? Time.parse(c['Expiration']) : nil
+        @expiration = c['Expiration'] ? Time.iso8601(c['Expiration']) : nil
       end
     end
 


### PR DESCRIPTION
The "Expiration" key in response is always ISO8601, for example "2017-11-19T18:08:11Z".

Here is the simple bechmark

```ruby
require 'time'
require 'benchmark/ips'

Benchmark.ips do |x|
  TIME = "2017-11-19T18:08:11Z".freeze
  x.config(:time => 10, :warmup => 4)
  x.report("using Parse") { Time.parse(TIME) }
  x.report("using iso8601") { Time.iso8601(TIME) }
  x.compare!
end
```

```
Warming up --------------------------------------
         using Parse     4.104k i/100ms
       using iso8601    11.737k i/100ms
Calculating -------------------------------------
         using Parse     42.068k (± 4.3%) i/s -    422.712k in  10.068115s
       using iso8601    124.765k (± 2.5%) i/s -      1.256M in  10.072182s

Comparison:
       using iso8601:   124764.6 i/s
         using Parse:    42067.5 i/s - 2.97x  slower
```

Good Idea?