### PR TITLE
Fix EC2 resource path bug

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
@@ -28,7 +28,7 @@ module AwsSdkCodeGenerator
       if param['path'] == '@'
         'resp.data'
       else
-        'resp.data.' + underscore_path(param['path'])
+        'resp.data.' + underscore_path(param['path'].gsub(/\[\]/, "[0]"))
       end
     end
 


### PR DESCRIPTION
Address #1675 
This is a resource model [bug](https://github.com/aws/aws-sdk-ruby/blob/master/apis/ec2/2016-11-15/resources-1.json#L1795), yet SDK should be able to handle the pattern.
After re-build all gems, ec2 snapshot is the only diff:
![image](https://user-images.githubusercontent.com/10790394/34056725-059f7136-e189-11e7-8d7d-76bde409585e.png)

