### PR TITLE
Assume Role Chaining Support

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -58,6 +58,8 @@ module Aws
     # a credential_source, and that source doesn't provide credentials.
     class NoSourceCredentialsError < RuntimeError; end
 
+    class SourceProfileLoopError < RuntimeError; end
+
     # Raised when a client is constructed and credentials are not
     # set, or the set credentials are empty.
     class MissingCredentialsError < RuntimeError

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -58,6 +58,8 @@ module Aws
     # a credential_source, and that source doesn't provide credentials.
     class NoSourceCredentialsError < RuntimeError; end
 
+    # Raised when a profile used in client construction contains looping
+    # references amongst source_profile values.
     class SourceProfileLoopError < RuntimeError; end
 
     # Raised when a client is constructed and credentials are not

--- a/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
+++ b/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
@@ -11,6 +11,10 @@ aws_session_token = TOKEN_SHARED
 role_arn = arn:aws:iam:123456789012:role/foo
 source_profile = default
 
+[profile assumerole_chain]
+role_arn = arn:aws:iam:123456789012:role/chain
+source_profile = assumerole_prof
+
 [profile assumerole_mfa]
 role_arn = arn:aws:iam:123456789012:role/foo
 source_profile = default
@@ -89,3 +93,24 @@ role_arn = arn:aws:iam:123456789012:role/bar
 aws_access_key_id = ACCESS_KEY_ARPC
 aws_secret_access_key = SECRET_KEY_ARPC
 aws_session_token = TOKEN_ARPC
+region = us-east-1
+
+[profile assumerole_loop]
+role_arn = arn:aws:iam:123456789012:role/bar
+source_profile = arl_inner_a
+
+[profile arl_inner_a]
+role_arn = arn:aws:iam:123456789012:role/bar
+source_profile = arl_inner_b
+
+[profile arl_inner_b]
+role_arn = arn:aws:iam:123456789012:role/bar
+source_profile = arl_inner_c
+
+[profile arl_inner_c]
+role_arn = arn:aws:iam:123456789012:role/bar
+source_profile = arl_inner_a
+
+[profile ar_chain_to_selfref]
+role_arn = arn:aws:iam:123456789012:role/chain
+source_profile = ar_from_self

--- a/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
+++ b/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
@@ -93,7 +93,6 @@ role_arn = arn:aws:iam:123456789012:role/bar
 aws_access_key_id = ACCESS_KEY_ARPC
 aws_secret_access_key = SECRET_KEY_ARPC
 aws_session_token = TOKEN_ARPC
-region = us-east-1
 
 [profile assumerole_loop]
 role_arn = arn:aws:iam:123456789012:role/bar


### PR DESCRIPTION
Current drawback is that it is required to specify a profile region in
inner roles, if AWS_REGION env variable is not set. This will likely be
changed before shipping.

See related GitHub issue #1677