### PR TITLE
Fixed ox parsing of xml documents containing significant whitespace

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fixed ox parsing of xml documents containing significant whitespace
+
 3.14.0 (2018-01-15)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
@@ -14,7 +14,7 @@ module Aws
           Ox.sax_parse(
             @stack, StringIO.new(xml),
             :convert_special => true,
-            :skip => :skip_white
+            :skip => :skip_none
           )
         end
 


### PR DESCRIPTION
...*semantically*-significant whitespace, that is.

The `:skip_white` flag being passed to Ox parser clobbers all whitespace during parsing. This strips out whitespace that may be semantically significant, such as in the case of sending YAML documents via SQS. The setting proposed in this pull request strips only trailing spaces from contained content, which should leave most real-world white-space significant documents semantically intact. It certainly fixes Ox for use with YAML over SQS.

This proposed change explicitly changes a prior fix made in #1496, related to issue #1495. ~~I was unable to locate the "kitchen_sink" test harness referenced there, so was unable to manually check this change against whatever the undesirable behavior for that issue was.~~ [Edit: I see now that KITCHEN_SINK is a Travis target.]