### PR TITLE
Close file descriptor in case of exceptions in Object#put

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
@@ -45,9 +45,7 @@ module Aws
 
       def open_file(source)
         if String === source || Pathname === source
-          file = File.open(source, 'rb')
-          yield(file)
-          file.close
+          File.open(source, 'rb') { |file| yield(file) }
         else
           yield(source)
         end

--- a/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
@@ -86,8 +86,7 @@ module Aws
           it 'accepts paths to files to upload' do
             file = double('file')
             expect(File).to receive(:open).with(ten_meg_file.path, 'rb').
-              and_return(file)
-            expect(file).to receive(:close)
+              and_yield(file)
             expect(client).to receive(:put_object).with(
               bucket: 'bucket',
               key: 'key',


### PR DESCRIPTION
When a block is passed to `File.open`, file descriptor will be automatically closed even if an exception occurs while executing the block (e.g. the `Object#put` call fails with a timeout error).