### PR TITLE
Handle unlinked (temporary) files in logging formatter

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Handle unlinked (temporary) files in logging formatter.
 
 3.14.0 (2018-01-15)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
@@ -49,6 +49,7 @@ module Aws
         when String   then summarize_string(value)
         when Hash     then '{' + summarize_hash(value) + '}'
         when Array    then summarize_array(value)
+        when Tempfile then summarize_file_io(value)
         when File     then summarize_file_io(value)
         when Pathname then summarize_file(value)
         else value.inspect

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
@@ -49,10 +49,14 @@ module Aws
         when String   then summarize_string(value)
         when Hash     then '{' + summarize_hash(value) + '}'
         when Array    then summarize_array(value)
-        when File     then summarize_file(value.path)
+        when File     then summarize_file_io(value)
         when Pathname then summarize_file(value)
         else value.inspect
         end
+      end
+
+      def summarize_file_io(io)
+        "#<File:#{io.path} (#{io.size} bytes)>"
       end
 
       def summarize_file(path)

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -213,6 +213,7 @@ module Seahorse
           when String   then summarize_string(value)
           when Hash     then '{' + summarize_hash(value) + '}'
           when Array    then summarize_array(value)
+          when Tempfile then summarize_file_io(value)
           when File     then summarize_file_io(value)
           when Pathname then summarize_file(value)
           else value.inspect

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -213,7 +213,7 @@ module Seahorse
           when String   then summarize_string(value)
           when Hash     then '{' + summarize_hash(value) + '}'
           when Array    then summarize_array(value)
-          when File     then summarize_file(value.path)
+          when File     then summarize_file_io(value)
           when Pathname then summarize_file(value)
           else value.inspect
           end
@@ -228,6 +228,14 @@ module Seahorse
           else
             str.inspect
           end
+        end
+
+        # Given an open file, this method returns a summarized inspecton
+        # string that includes the file size.
+        # @param [IO] file
+        # @return [String]
+        def summarize_file_io io
+          "#<File:#{io.path} (#{io.size} bytes)>"
         end
 
         # Given the path to a file on disk, this method returns a summarized

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -24,6 +24,10 @@ module Aws
         end
 
         it 'provides a :request_params replacement' do
+          file = Tempfile.open('') do |tempfile|
+            tempfile.write('#' * 2000)
+            File.open(tempfile.path)
+          end
           response.context.params = {
             foo: 'bar',
             attributes: {
@@ -32,7 +36,7 @@ module Aws
             },
             config: {
               nested: true,
-              file: File.open(__FILE__),
+              file: file,
               path: Pathname.new(__FILE__),
               complex: double('obj', inspect: '"inspected"')
             },
@@ -41,7 +45,7 @@ module Aws
           formatted = format('{:request_params}', max_string_size: 20)
           size = File.size(__FILE__)
           expect(formatted).to eq(<<-FORMATTED.strip)
-{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,file:#<File:#{__FILE__} (#{size} bytes)>,path:#<File:#{__FILE__} (#{size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
+{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,file:#<File:#{file.path} (2000 bytes)>,path:#<File:#{__FILE__} (#{size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
           FORMATTED
         end
 

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
@@ -25,6 +25,10 @@ module Seahorse
           end
 
           it 'provides a :request_params replacement' do
+            file = Tempfile.open('') do |tempfile|
+              tempfile.write('#' * 2000)
+              File.open(tempfile.path)
+            end
             response.context.params = {
               foo: 'bar',
               attributes: {
@@ -34,7 +38,7 @@ module Seahorse
               config: {
                 nested: true,
                 values: [1,2,3],
-                file: File.open(__FILE__),
+                file: file,
                 path: Pathname.new(__FILE__),
                 complex: double('obj', inspect: '"inspected"')
               },
@@ -43,7 +47,7 @@ module Seahorse
             formatted = format('{:request_params}', max_string_size: 20)
             size = File.size(__FILE__)
             expect(formatted).to eq(<<-FORMATTED.strip)
-{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,values:[1,2,3],file:#<File:#{__FILE__} (#{size} bytes)>,path:#<File:#{__FILE__} (#{size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
+{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,values:[1,2,3],file:#<File:#{file.path} (2000 bytes)>,path:#<File:#{__FILE__} (#{size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
             FORMATTED
           end
 


### PR DESCRIPTION
Uploading a temporary file to S3 fails with "TypeError: no implicit conversion of nil into String", when running under JRuby (many versions), with logging enabled, and the file was unlinked after it was opened.

The stack trace ends in `summarize_file` that basically prints roughly the same as `tempfile.inspect`, but also includes the size of the file. To handle paths and files the same way, the code uses `File.size(tempfile.path)` instead of `tempfile.size`, but this doesn't work if the file has been unlinked (in which case `tempfile.path` is nil).

The problem only affects JRuby, as `File === Tempfile.new` is false in MRI (but true in JRuby), but this means that the code just prints `#<Tempfile:/some/path>` for MRI 2.x and `#<File:/some/path>` for MRI 1.9.3.

This PR changes the implementation to use `tempfile.size` instead, meaning that opened files will be handled correctly even after unlinked (or renamed), but also adds explicit handling of `Tempfile` so that the output contains `#<File:/some/path (X bytes)>` for temporary files on both MRI and JRuby.

I changed the existing test cases to make use of unlinked regular `File` objects, but I was uncertain how I could add another test case for a `Tempfile` without duplicating the whole formatting test.