### PR TITLE
Enhance multipart downloader performance

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Enhance S3 Multipart Downloader performance #1709
+
 * Issue - Fix Ruby 2.5 warnings.
 
 1.8.0 (2017-11-29)

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -124,25 +124,6 @@ module Aws
           }.to raise_error(ArgumentError, ":chunk_size shouldn't exceed total file size.")
         end
 
-        it 'cleans up downloaded files parts when error occurs' do
-          mock_client = Aws::S3::Client.new(stub_responses: {
-            head_object: {content_length: 20 * one_meg, parts_count: 4},
-            get_object: [ {body: 'data'}, {body: 'data'}, Timeout::Error]
-          })
-          obj = S3::Object.new(
-            bucket_name: 'bucket',
-            key: 'large',
-            client: mock_client
-          )
-          obj.upload_file(large_file)
-          expect {
-            obj.download_file(path)
-          }.to raise_error(Timeout::Error)
-          Dir.glob(tmpdir + '/*').each do |file|
-            expect(file).not_to match(/part_number=/)
-            expect(file).not_to match(/bytes=/)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
**This PR adds:**
1. instead of concatenates file parts in the end, write chunk(response body) to target file once single request succeed.
2. remove tmp dir/files usage

**Open discussion:**
Error handling? checking each chunk size written meet expected length?

**Notes**
Tests (including integ) passed.
Benchmarking data using
``` ruby
require 'benchmark'

obj = Aws::S3::Resource.new.bucket('bkt').object('a-500mb-obj')
Benchmark.measure{ obj.download_file(path)}
```
For my local Mac environment (Mac OS Sierra, 10.12.6)
Before this enhancement:
```
=> #<Benchmark::Tms:0x007fed82654538
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=39.52513399999589,
 @stime=5.17,
 @total=11.05,
 @utime=5.880000000000001>
```
After this enhancement:
```
=> #<Benchmark::Tms:0x007fabc98dc7d8
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=31.79380200000014,
 @stime=3.7800000000000002,
 @total=9.54,
 @utime=5.76>
```