### PR TITLE
Add Disable Flag to Instance Profile Credentials

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -83,17 +83,26 @@ module Aws
     def get_credentials
       # Retry loading credentials a configurable number of times if
       # the instance metadata service is not responding.
-      begin
-        retry_errors(NETWORK_ERRORS, max_retries: @retries) do
-          open_connection do |conn|
-            path = '/latest/meta-data/iam/security-credentials/'
-            profile_name = http_get(conn, path).lines.first.strip
-            http_get(conn, path + profile_name)
-          end
-        end
-      rescue
+      if _metadata_disabled?
         '{}'
+      else
+        begin
+          retry_errors(NETWORK_ERRORS, max_retries: @retries) do
+            open_connection do |conn|
+              path = '/latest/meta-data/iam/security-credentials/'
+              profile_name = http_get(conn, path).lines.first.strip
+              http_get(conn, path + profile_name)
+            end
+          end
+        rescue
+          '{}'
+        end
       end
+    end
+
+    def _metadata_disabled?
+      flag = ENV["AWS_EC2_METADATA_DISABLED"]
+      !flag.nil? && flag.downcase == "true"
     end
 
     def open_connection


### PR DESCRIPTION
When the `AWS_EC2_METADATA_DISABLED` environment variable is present
with the value `true` (not case sensitive), the
`Aws::InstanceProfileCredentials` credential source will not be used.