### PR TITLE
Allow `__` in shape names

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
@@ -7,9 +7,15 @@ module AwsSdkCodeGenerator
       # @return [String, nil]
       def docstring(shape_or_shape_ref, api)
         ref, shape = resolve(shape_or_shape_ref, api)
+        # APIG models, downcase shape name in origin or "__" prefix in origin
         if shape.nil?
-          # APIG models, downcase shape name in origin
           ref, shape = resolve(AwsSdkCodeGenerator::Helper.downcase_first(shape_or_shape_ref), api)
+          if shape.nil?
+            ref, shape = resolve(AwsSdkCodeGenerator::Helper.apig_prefix(shape_or_shape_ref), api)
+            if shape.nil?
+              ref, shape = resolve(AwsSdkCodeGenerator::Helper.apig_prefix(downcase_first(shape_or_shape_ref)), api)
+            end
+          end
         end
         ref['documentation'] || shape['documentation']
       end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
@@ -8,6 +8,9 @@ module AwsSdkCodeGenerator
       def docstring(shape_or_shape_ref, api)
         ref, shape = resolve(shape_or_shape_ref, api)
         # APIG models, downcase shape name in origin or "__" prefix in origin
+        # code-gen shape name might have been changed (upcased_first/lstrip_prefix/both),
+        # when shape cannot be located with current shape name, try to resolve shape with
+        # (downcase_fist/apig_prefix/both) original names
         if shape.nil?
           ref, shape = resolve(AwsSdkCodeGenerator::Helper.downcase_first(shape_or_shape_ref), api)
           if shape.nil?

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -136,6 +136,14 @@ module AwsSdkCodeGenerator
       end
     end
 
+    def lstrip_prefix(name)
+      name.start_with?("__") ? name[2..-1] : name
+    end
+
+    def apig_prefix(name)
+      "__" << name
+    end
+
     def shape(ref)
       if ref.nil?
         nil
@@ -189,7 +197,7 @@ module AwsSdkCodeGenerator
       str.gsub(/(.{1,#{width}})(\s+|\Z)/, "#{indent}\\1\n").chomp
     end
 
-    module_function :deep_copy, :operation_streaming?, :downcase_first, :wrap_string
+    module_function :deep_copy, :operation_streaming?, :downcase_first, :wrap_string, :apig_prefix
 
   end
 end

--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/white_label/service.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/white_label/service.json
@@ -207,22 +207,6 @@
       "errors" : [ ],
       "authtype" : "none"
     },
-    "PutNoauthMultiLocation" : {
-      "name" : "PutNoauthMultiLocation",
-      "http" : {
-        "method" : "PUT",
-        "requestUri" : "/test/noauth/{multi-location}",
-        "responseCode" : 200
-      },
-      "input" : {
-        "shape" : "PutNoauthMultiLocationRequest"
-      },
-      "output" : {
-        "shape" : "PutNoauthMultiLocationResponse"
-      },
-      "errors" : [ ],
-      "authtype" : "none"
-    },
     "PutNoauthRefsCanonList" : {
       "name" : "PutNoauthRefsCanonList",
       "http" : {
@@ -235,22 +219,6 @@
       },
       "output" : {
         "shape" : "PutNoauthRefsCanonListResponse"
-      },
-      "errors" : [ ],
-      "authtype" : "none"
-    },
-    "PutNoauthRefsCanonListOfScalars" : {
-      "name" : "PutNoauthRefsCanonListOfScalars",
-      "http" : {
-        "method" : "PUT",
-        "requestUri" : "/test/noauth/refs/canon/list-of-scalars",
-        "responseCode" : 200
-      },
-      "input" : {
-        "shape" : "PutNoauthRefsCanonListOfScalarsRequest"
-      },
-      "output" : {
-        "shape" : "PutNoauthRefsCanonListOfScalarsResponse"
       },
       "errors" : [ ],
       "authtype" : "none"
@@ -302,22 +270,6 @@
       },
       "errors" : [ ],
       "authtype" : "none"
-    },
-    "lowercaseOperationName" : {
-      "name" : "lowercaseOperationName",
-      "http" : {
-        "method" : "PUT",
-        "requestUri" : "/test/noauth/lowercase-operation-name",
-        "responseCode" : 200
-      },
-      "input" : {
-        "shape" : "lowercaseOperationNameRequest"
-      },
-      "output" : {
-        "shape" : "lowercaseOperationNameResponse"
-      },
-      "errors" : [ ],
-      "authtype" : "none"
     }
   },
   "shapes" : {
@@ -325,7 +277,7 @@
       "type" : "structure",
       "members" : {
         "AnonymousList" : {
-          "shape" : "ListOfAnonymousListItem",
+          "shape" : "__listOf__AnonymousListElement",
           "locationName" : "anonymousList"
         }
       }
@@ -334,7 +286,7 @@
       "type" : "structure",
       "members" : {
         "AnonMapStringToString" : {
-          "shape" : "MapOf__string",
+          "shape" : "__mapOf__string",
           "locationName" : "anonMapStringToString"
         }
       }
@@ -351,15 +303,6 @@
     "AnonymousEnum" : {
       "type" : "string",
       "enum" : [ "VALUE_ONE", "VALUE_TWO", "VALUE_THREE" ]
-    },
-    "AnonymousListItem" : {
-      "type" : "structure",
-      "members" : {
-        "StrProperty" : {
-          "shape" : "__string",
-          "locationName" : "strProperty"
-        }
-      }
     },
     "AnonymousObject" : {
       "type" : "structure",
@@ -413,19 +356,6 @@
       "required" : [ "ScalarTypes" ],
       "payload" : "ScalarTypes"
     },
-    "InlineEnumRef" : {
-      "type" : "string",
-      "enum" : [ "foo", "bar", "baz" ]
-    },
-    "InlineRefMember" : {
-      "type" : "structure",
-      "members" : {
-        "StrProperty" : {
-          "shape" : "__string",
-          "locationName" : "strProperty"
-        }
-      }
-    },
     "InternalServerError" : {
       "type" : "structure",
       "members" : {
@@ -448,127 +378,13 @@
         "httpStatusCode" : 500
       }
     },
-    "ListOfAnonymousListItem" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "AnonymousListItem"
-      }
-    },
-    "ListOfScalarTypes" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ScalarTypes"
-      }
-    },
-    "ListOfScalars" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ScalarTypes"
-      }
-    },
     "ListOfStrings" : {
       "type" : "list",
       "member" : {
         "shape" : "__string"
       }
     },
-    "ListOf__boolean" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "__boolean"
-      }
-    },
-    "ListOf__double" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "__double"
-      }
-    },
-    "ListOf__integer" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "__integer"
-      }
-    },
-    "ListOf__string" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "__string"
-      }
-    },
-    "MapOfListOfScalarTypes" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "ListOfScalarTypes"
-      }
-    },
-    "MapOfListOf__string" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "ListOf__string"
-      }
-    },
-    "MapOfMapOf__string" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "MapOf__string"
-      }
-    },
-    "MapOfScalarTypes" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "ScalarTypes"
-      }
-    },
     "MapOfStringToString" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__string"
-      }
-    },
-    "MapOf__boolean" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__boolean"
-      }
-    },
-    "MapOf__double" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__double"
-      }
-    },
-    "MapOf__integer" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__integer"
-      }
-    },
-    "MapOf__string" : {
       "type" : "map",
       "key" : {
         "shape" : "__string"
@@ -614,23 +430,23 @@
       "type" : "structure",
       "members" : {
         "ListOfStructures" : {
-          "shape" : "ListOfScalarTypes",
+          "shape" : "__listOfScalarTypes",
           "locationName" : "listOfStructures"
         },
         "MapOfStringToListOfString" : {
-          "shape" : "MapOfListOf__string",
+          "shape" : "__mapOf__listOf__string",
           "locationName" : "mapOfStringToListOfString"
         },
         "MapOfStringToListOfStructure" : {
-          "shape" : "MapOfListOfScalarTypes",
+          "shape" : "__mapOf__listOfScalarTypes",
           "locationName" : "mapOfStringToListOfStructure"
         },
         "MapOfStringToMapOfStringToString" : {
-          "shape" : "MapOfMapOf__string",
+          "shape" : "__mapOf__mapOf__string",
           "locationName" : "mapOfStringToMapOfStringToString"
         },
         "MapOfStringToStructure" : {
-          "shape" : "MapOfScalarTypes",
+          "shape" : "__mapOfScalarTypes",
           "locationName" : "mapOfStringToStructure"
         }
       }
@@ -639,35 +455,35 @@
       "type" : "structure",
       "members" : {
         "ListOfBooleans" : {
-          "shape" : "ListOf__boolean",
+          "shape" : "__listOf__boolean",
           "locationName" : "listOfBooleans"
         },
         "ListOfDoubles" : {
-          "shape" : "ListOf__double",
+          "shape" : "__listOf__double",
           "locationName" : "listOfDoubles"
         },
         "ListOfIntegers" : {
-          "shape" : "ListOf__integer",
+          "shape" : "__listOf__integer",
           "locationName" : "listOfIntegers"
         },
         "ListOfStrings" : {
-          "shape" : "ListOf__string",
+          "shape" : "__listOf__string",
           "locationName" : "listOfStrings"
         },
         "MapOfStringToBoolean" : {
-          "shape" : "MapOf__boolean",
+          "shape" : "__mapOf__boolean",
           "locationName" : "mapOfStringToBoolean"
         },
         "MapOfStringToDouble" : {
-          "shape" : "MapOf__double",
+          "shape" : "__mapOf__double",
           "locationName" : "mapOfStringToDouble"
         },
         "MapOfStringToInteger" : {
-          "shape" : "MapOf__integer",
+          "shape" : "__mapOf__integer",
           "locationName" : "mapOfStringToInteger"
         },
         "MapOfStringToString" : {
-          "shape" : "MapOf__string",
+          "shape" : "__mapOf__string",
           "locationName" : "mapOfStringToString"
         }
       }
@@ -696,8 +512,17 @@
       "type" : "structure",
       "members" : {
         "InlineRefMember" : {
-          "shape" : "InlineRefMember",
+          "shape" : "PutDefinitionsInputInlineRefMember",
           "locationName" : "inlineRefMember"
+        }
+      }
+    },
+    "PutDefinitionsInputInlineRefMember" : {
+      "type" : "structure",
+      "members" : {
+        "StrProperty" : {
+          "shape" : "__string",
+          "locationName" : "strProperty"
         }
       }
     },
@@ -861,81 +686,6 @@
       "required" : [ "PutSimpleEnumsInput" ],
       "payload" : "PutSimpleEnumsInput"
     },
-    "PutNoauthMultiLocationRequest" : {
-      "type" : "structure",
-      "members" : {
-        "HeaderOne" : {
-          "shape" : "__string",
-          "location" : "header",
-          "locationName" : "x-header-one"
-        },
-        "HeaderTwo" : {
-          "shape" : "__string",
-          "location" : "header",
-          "locationName" : "x-header-two"
-        },
-        "MultiLocation" : {
-          "shape" : "__string",
-          "location" : "uri",
-          "locationName" : "multi-location"
-        },
-        "QueryParamOne" : {
-          "shape" : "__string",
-          "location" : "querystring",
-          "locationName" : "queryParamOne"
-        },
-        "QueryParamTwo" : {
-          "shape" : "__string",
-          "location" : "querystring",
-          "locationName" : "queryParamTwo"
-        },
-        "ScalarTypes" : {
-          "shape" : "ScalarTypes"
-        }
-      },
-      "required" : [ "MultiLocation", "ScalarTypes" ],
-      "payload" : "ScalarTypes"
-    },
-    "PutNoauthMultiLocationResponse" : {
-      "type" : "structure",
-      "members" : {
-        "HeaderOne" : {
-          "shape" : "__string",
-          "location" : "header",
-          "locationName" : "x-header-one"
-        },
-        "HeaderTwo" : {
-          "shape" : "__string",
-          "location" : "header",
-          "locationName" : "x-header-two"
-        },
-        "ScalarTypes" : {
-          "shape" : "ScalarTypes"
-        }
-      },
-      "required" : [ "ScalarTypes" ],
-      "payload" : "ScalarTypes"
-    },
-    "PutNoauthRefsCanonListOfScalarsRequest" : {
-      "type" : "structure",
-      "members" : {
-        "ListOfScalars" : {
-          "shape" : "ListOfScalars"
-        }
-      },
-      "required" : [ "ListOfScalars" ],
-      "payload" : "ListOfScalars"
-    },
-    "PutNoauthRefsCanonListOfScalarsResponse" : {
-      "type" : "structure",
-      "members" : {
-        "ListOfScalars" : {
-          "shape" : "ListOfScalars"
-        }
-      },
-      "required" : [ "ListOfScalars" ],
-      "payload" : "ListOfScalars"
-    },
     "PutNoauthRefsCanonListRequest" : {
       "type" : "structure",
       "members" : {
@@ -1028,10 +778,14 @@
           "locationName" : "canonicalEnumRef"
         },
         "InlineEnumRef" : {
-          "shape" : "InlineEnumRef",
+          "shape" : "PutSimpleEnumsInputInlineEnumRef",
           "locationName" : "inlineEnumRef"
         }
       }
+    },
+    "PutSimpleEnumsInputInlineEnumRef" : {
+      "type" : "string",
+      "enum" : [ "foo", "bar", "baz" ]
     },
     "ResourceNotFound" : {
       "type" : "structure",
@@ -1047,9 +801,6 @@
       "members" : {
         "BooleanMember" : {
           "shape" : "__boolean"
-        },
-        "DateMember" : {
-          "shape" : "__timestamp"
         },
         "Foo" : {
           "shape" : "__string",
@@ -1089,6 +840,15 @@
     "String" : {
       "type" : "string"
     },
+    "__AnonymousListElement" : {
+      "type" : "structure",
+      "members" : {
+        "StrProperty" : {
+          "shape" : "__string",
+          "locationName" : "strProperty"
+        }
+      }
+    },
     "__boolean" : {
       "type" : "boolean"
     },
@@ -1098,31 +858,127 @@
     "__integer" : {
       "type" : "integer"
     },
+    "__listOfScalarTypes" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ScalarTypes"
+      }
+    },
+    "__listOf__AnonymousListElement" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__AnonymousListElement"
+      }
+    },
+    "__listOf__boolean" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__boolean"
+      }
+    },
+    "__listOf__double" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__double"
+      }
+    },
+    "__listOf__integer" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__integer"
+      }
+    },
+    "__listOf__string" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "__long" : {
+      "type" : "long"
+    },
+    "__mapOfScalarTypes" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "ScalarTypes"
+      }
+    },
+    "__mapOf__boolean" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__boolean"
+      }
+    },
+    "__mapOf__double" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__double"
+      }
+    },
+    "__mapOf__integer" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__integer"
+      }
+    },
+    "__mapOf__listOfScalarTypes" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__listOfScalarTypes"
+      }
+    },
+    "__mapOf__listOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__listOf__string"
+      }
+    },
+    "__mapOf__mapOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__mapOf__string"
+      }
+    },
+    "__mapOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__string"
+      }
+    },
     "__string" : {
       "type" : "string"
     },
-    "__timestamp" : {
-      "type" : "timestamp"
+    "__timestampIso8601" : {
+      "type" : "timestamp",
+      "timestampFormat" : "iso8601"
     },
-    "lowercaseOperationNameRequest" : {
-      "type" : "structure",
-      "members" : {
-        "ScalarTypes" : {
-          "shape" : "ScalarTypes"
-        }
-      },
-      "required" : [ "ScalarTypes" ],
-      "payload" : "ScalarTypes"
-    },
-    "lowercaseOperationNameResponse" : {
-      "type" : "structure",
-      "members" : {
-        "ScalarTypes" : {
-          "shape" : "ScalarTypes"
-        }
-      },
-      "required" : [ "ScalarTypes" ],
-      "payload" : "ScalarTypes"
+    "__timestampUnix" : {
+      "type" : "timestamp",
+      "timestampFormat" : "unixTimestamp"
     }
   },
   "authorizers" : {

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
@@ -55,7 +55,6 @@ describe 'Client Interface:' do
       resp = client.put_apikey({
         scalar_types: {
           boolean_member: false,
-          date_member: Time.now
         }
       })
       expect(resp.context.http_request.headers['User-Agent']).to start_with('aws-apig-ruby')
@@ -74,7 +73,6 @@ describe 'Client Interface:' do
       resp = client_w_ua.put_apikey({
         scalar_types: {
           boolean_member: false,
-          date_member: Time.now
         }
       })
       expect(resp.context.http_request.headers['User-Agent']).to include('foo')


### PR DESCRIPTION
Tested with generated SDK with API call, request succeed.
Below changes do look messy, the thing is even though I want to strip as many as invalid characters, I need to find the reference in the model the other way around. Thus I limit it to known limitations. Let me know if you have other ideas.
