### PR TITLE
Fix typo in documentation

### DIFF
--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -253,7 +253,7 @@ module Aws
       # To generate a presigned URL, you must provide a HTTP URI and
       # the http method.
       #
-      #     url = signer.presigned_url(
+      #     url = signer.presign_url(
       #       http_method: 'GET',
       #       url: 'https://my-bucket.s3-us-east-1.amazonaws.com/key',
       #       expires_in: 60
@@ -262,7 +262,7 @@ module Aws
       # By default, signatures are valid for 15 minutes. You can specify
       # the number of seconds for the URL to expire in.
       #
-      #     url = signer.presigned_url(
+      #     url = signer.presign_url(
       #       http_method: 'GET',
       #       url: 'https://my-bucket.s3-us-east-1.amazonaws.com/key',
       #       expires_in: 3600 # one hour
@@ -273,7 +273,7 @@ module Aws
       # **must** be provided, or the signature is invalid. Other headers
       # are optional, but should be provided for security reasons.
       #
-      #     url = signer.presigned_url(
+      #     url = signer.presign_url(
       #       http_method: 'PUT',
       #       url: 'https://my-bucket.s3-us-east-1.amazonaws.com/key',
       #       headers: {


### PR DESCRIPTION
Aws::Sigv4::Signer has `presign_url`.  s/presigned_url/presign_url/