### PR TITLE
support timestamp shape at querystring

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-xml.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-xml.json
@@ -760,7 +760,7 @@
         },
         "serialized": {
           "body": "",
-          "uri": "/path?time=2015-01-25%2000%3A00%3A00%20-0800",
+          "uri": "/path?time=Sun%2C%2025%20Jan%202015%2008%3A00%3A00%20GMT",
           "headers": {}
         }
       }

--- a/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-xml.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-xml.json
@@ -723,6 +723,50 @@
     ]
   },
   {
+    "description": "Querystring contains timestamp",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2018-03-16"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Time": {
+            "shape": "TimestampShape",
+            "location": "querystring",
+            "locationName": "time"
+          }
+        }
+      },
+      "TimestampShape": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Time": 1422172800
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?time=2015-01-25%2000%3A00%3A00%20-0800",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "Querystring list of strings",
     "metadata": {
       "protocol": "rest-xml",

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support timestamp shape in querystring
+
 3.17.0 (2018-02-27)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
@@ -31,7 +31,7 @@ module Aws
         def build_part(shape_ref, param_value)
           case shape_ref.shape
           # supported scalar types
-          when StringShape, BooleanShape, FloatShape, IntegerShape, StringShape
+          when StringShape, BooleanShape, FloatShape, IntegerShape, StringShape, TimestampShape
             param_name = shape_ref.location_name
             "#{param_name}=#{escape(param_value.to_s)}"
           when MapShape

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
@@ -31,9 +31,12 @@ module Aws
         def build_part(shape_ref, param_value)
           case shape_ref.shape
           # supported scalar types
-          when StringShape, BooleanShape, FloatShape, IntegerShape, StringShape, TimestampShape
+          when StringShape, BooleanShape, FloatShape, IntegerShape, StringShape
             param_name = shape_ref.location_name
             "#{param_name}=#{escape(param_value.to_s)}"
+          when TimestampShape
+            param_name = shape_ref.location_name
+            "#{param_name}=#{escape(param_value.utc.httpdate)}"
           when MapShape
             if StringShape === shape_ref.shape.value.shape
               query_map_of_string(param_value)


### PR DESCRIPTION
Addressing #1730 
Timestamp shape param value is already converted based on API model definition, just need to serialized onto querystring

tested with #get_object and #presigned_url, updated protocol tests