### PR TITLE
Add frozen_string_literal: true to freeze strings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $REPO_ROOT = File.dirname(__FILE__)
 $GEMS_DIR = "#{$REPO_ROOT}/gems"
 $CORE_LIB = "#{$REPO_ROOT}/gems/aws-sdk-core/lib"

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sdk-code-generator/api'
 require_relative 'aws-sdk-code-generator/apply_docs'
 require_relative 'aws-sdk-code-generator/client_constructor'

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Api
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ApplyDocs
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientConstructor
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientOperationDocumentation
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientOperationList
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class CodeBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/crosslink.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/crosslink.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Crosslink
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # kramdown
 require 'kramdown'
 # end kramdown

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/errors.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Errors
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/gem_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/gem_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class GemBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class HashFormatter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 # kramdown
 require 'kramdown'
@@ -141,7 +143,7 @@ module AwsSdkCodeGenerator
     end
 
     def apig_prefix(name)
-      "__" << name
+      "__#{name}"
     end
 
     def shape(ref)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class PluginList
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAction
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceActionCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_attribute.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAttribute
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchAction
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchActionCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchActionDocumentation
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceClientRequest
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_params.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceClientRequestParams < String
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_data_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_data_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceDataMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasManyAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasManyAssociationCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifier.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceIdentifier
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifiers_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifiers_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceIdentifiersMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_load_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_load_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceLoadMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceMethod
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_skip_params.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_skip_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceSkipParams
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceValueSource < String
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_waiter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceWaiter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class Service
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/shared_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/shared_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class SharedExample
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example_hash.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/underscore.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/underscore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Underscore
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/view.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mustache'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gemspec'
 
 module Views; end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_endpoint_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_endpoint_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_readme.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_readme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class APIGReadme < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/authorizer_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/authorizer_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ClientApiModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ClientClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/docstring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ErrorsModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/env.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/step_definitions.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class Gemspec < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ResourceClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/root_resource_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/root_resource_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class RootResourceClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/service_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/service_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/spec_helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Spec

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/version.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class Version < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/waiters_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/waiters_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class WaitersModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/waiter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class Waiter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class YardOptionTag
 

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/hash_formatter_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/hash_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/shared_example_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/shared_example_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/syntax_example_hash.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/syntax_example_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/underscore_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/underscore_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/configuration_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/idempotency_tokens_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/idempotency_tokens_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/jsonvalue_converter_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/jsonvalue_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/streaming_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/streaming_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'Interfaces' do

--- a/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'rexml/document'
 

--- a/build_tools/aws-sdk-code-generator/spec/spec_helper.rb
+++ b/build_tools/aws-sdk-code-generator/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../gems/aws-sdk-core/spec/shared_spec_helper'
 
 $:.unshift(File.expand_path('../../lib', __FILE__))

--- a/build_tools/build_tools.rb
+++ b/build_tools/build_tools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../aws-sdk-code-generator/lib', __FILE__))
 
 require 'aws-sdk-code-generator'

--- a/build_tools/changelog.rb
+++ b/build_tools/changelog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
   # A utility class for managing a CHANGELOG file.
   class Changelog

--- a/build_tools/custom_service.rb
+++ b/build_tools/custom_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/build_tools/customizations.rb
+++ b/build_tools/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
   module Customizations
 

--- a/build_tools/file_writer.rb
+++ b/build_tools/file_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module BuildTools

--- a/build_tools/load_client_examples.rb
+++ b/build_tools/load_client_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
 
   # @return [Hash]

--- a/build_tools/replace_lines.rb
+++ b/build_tools/replace_lines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/build_tools/spec/changelog_spec.rb
+++ b/build_tools/spec/changelog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module BuildTools

--- a/build_tools/spec/changelog_verifier_spec.rb
+++ b/build_tools/spec/changelog_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 # Note: this spec test helps checking all gems CHANGELOG.mds 

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Note: this spec test helps checking all source code:
 # no hard-coded regions unless have to
 
@@ -9,13 +11,13 @@ end
 def whitelist
   {
     "core" => {
-      "errors.rb" => 102,
-      "signature_v4.rb" => 35,
-      "stub_responses.rb" => 19
+      "errors.rb" => 104,
+      "signature_v4.rb" => 37,
+      "stub_responses.rb" => 21
     },
     "s3" => {
-      "location_constraint.rb" => 12,
-      "s3_signer.rb" => 195
+      "location_constraint.rb" => 14,
+      "s3_signer.rb" => 197
     }
   }
 end
@@ -28,7 +30,7 @@ describe "ensure no hard-coded region" do
     Dir.glob("#{dir}**/*").sort.each do |path|
       next if File.directory? path
 
-      file = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read } 
+      file = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
       lines = file.lines.to_a
 
       it "#{path} has no hard-coded region" do
@@ -37,7 +39,7 @@ describe "ensure no hard-coded region" do
           next if val.strip[0] == "#"
           # skip known whitelists
           next if whitelist[key] && whitelist[key][File.basename(path)] == idx
-          expect(val).not_to match(/(us|eu|ap|sa|ca)-\w+-\d+/)        
+          expect(val).not_to match(/(us|eu|ap|sa|ca)-\w+-\d+/)
         end
       end
 

--- a/build_tools/spec/spec_helper.rb
+++ b/build_tools/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../changelog'
 
 require 'tempfile'

--- a/build_tools/wrap_list.rb
+++ b/build_tools/wrap_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/doc-src/examples/ec2/client/copy_snapshot/01_copy_snapshot_example.rb
+++ b/doc-src/examples/ec2/client/copy_snapshot/01_copy_snapshot_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source_snapshot_id = 'snapshot-id'
 source_region = 'us-east-1'
 target_region = 'us-west-2'

--- a/doc-src/examples/ec2/client/copy_snapshot/02_copy_an_encrypted_snapshot.rb
+++ b/doc-src/examples/ec2/client/copy_snapshot/02_copy_an_encrypted_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # same as above, expect you must pass `encrypted: true`
 resp = ec2.copy_snapshot({
     source_region: source_region,

--- a/doc-src/examples/ec2/client/describe_instances/01_filtering_by_tags_examples.rb
+++ b/doc-src/examples/ec2/client/describe_instances/01_filtering_by_tags_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # filtering by tag keys "key1" or "key2"
 ec2.describe_instances(filters:[{ name: 'tag-key', values: ['key1', 'key2'] }])
 

--- a/doc-src/examples/s3/client/get_object/01_download_an_object_to_disk.rb
+++ b/doc-src/examples/s3/client/get_object/01_download_an_object_to_disk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # stream object directly to disk
 resp = s3.get_object(
   response_target: '/path/to/file',

--- a/doc-src/examples/s3/client/get_object/02_download_object_into_memory.rb
+++ b/doc-src/examples/s3/client/get_object/02_download_object_into_memory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # omit :response_target to download to a StringIO in memory
 resp = s3.get_object(bucket: 'bucket-name', key: 'object-key')
 

--- a/doc-src/examples/s3/client/get_object/03_streaming_data_to_a_block.rb
+++ b/doc-src/examples/s3/client/get_object/03_streaming_data_to_a_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING: yielding data to a block disables retries of networking errors
 File.open('/path/to/file', 'wb') do |file|
   s3.get_object(bucket: 'bucket-name', key: 'object-key') do |chunk|

--- a/doc-src/examples/s3/client/put_object/01_streaming_a_file_from_disk.rb
+++ b/doc-src/examples/s3/client/put_object/01_streaming_a_file_from_disk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # upload file from disk in a single request, may not exceed 5GB
 File.open('/source/file/path', 'rb') do |file|
   s3.put_object(bucket: 'bucket-name', key: 'object-key', body: file)

--- a/doc-src/plugins/service_tag.rb
+++ b/doc-src/plugins/service_tag.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 YARD::Tags::Library.define_tag('SERVICE', :service)

--- a/doc-src/templates/default/fulldoc/html/setup.rb
+++ b/doc-src/templates/default/fulldoc/html/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def javascripts_full_list
   super + ['js/nolink.js']
 end

--- a/doc-src/templates/default/layout/html/setup.rb
+++ b/doc-src/templates/default/layout/html/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def javascripts
   (super + %w(js/tabs.js)).uniq
 end

--- a/doc-src/templates/default/module/setup.rb
+++ b/doc-src/templates/default/module/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def groups(list, type = "Method")
   if groups_data = object.groups
     list.each {|m| groups_data |= [m.group] if m.group && owner != m.namespace }

--- a/gems/aws-partitions/lib/aws-partitions.rb
+++ b/gems/aws-partitions/lib/aws-partitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-partitions/endpoint_provider'
 require_relative 'aws-partitions/partition'
 require_relative 'aws-partitions/partition_list'

--- a/gems/aws-partitions/lib/aws-partitions/endpoint_provider.rb
+++ b/gems/aws-partitions/lib/aws-partitions/endpoint_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     # @api private

--- a/gems/aws-partitions/lib/aws-partitions/partition.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class Partition
@@ -22,8 +24,8 @@ module Aws
         if @regions.key?(region_name)
           @regions[region_name]
         else
-          msg = "invalid region name #{region_name.inspect}; valid region "
-          msg << "names include %s" % [@regions.keys.join(', ')]
+          msg = "invalid region name #{region_name.inspect}; valid region "\
+                "names include %s" % [@regions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition_list.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class PartitionList
@@ -19,8 +21,8 @@ module Aws
         if @partitions.key?(partition_name)
           @partitions[partition_name]
         else
-          msg = "invalid partition name #{partition_name.inspect}; valid "
-          msg << "partition names include %s" % [@partitions.keys.join(', ')]
+          msg = "invalid partition name #{partition_name.inspect}; valid "\
+                "partition names include %s" % [@partitions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/region.rb
+++ b/gems/aws-partitions/lib/aws-partitions/region.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-partitions/lib/aws-partitions/service.rb
+++ b/gems/aws-partitions/lib/aws-partitions/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-partitions/spec/aws_partitions_spec.rb
+++ b/gems/aws-partitions/spec/aws_partitions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-partitions/spec/spec_helper.rb
+++ b/gems/aws-partitions/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require_relative '../lib/aws-partitions'
 require 'rspec'

--- a/gems/aws-sdk-acm/features/env.rb
+++ b/gems/aws-sdk-acm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/features/step_definitions.rb
+++ b/gems/aws-sdk-acm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@acm") do
   @service = Aws::ACM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/client.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/client_api.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/customizations.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/errors.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/resource.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/types.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/spec/spec_helper.rb
+++ b/gems/aws-sdk-acm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/features/env.rb
+++ b/gems/aws-sdk-alexaforbusiness/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/features/step_definitions.rb
+++ b/gems/aws-sdk-alexaforbusiness/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@alexaforbusiness") do
   @service = Aws::AlexaForBusiness::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client_api.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/errors.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/resource.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/types.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/spec/spec_helper.rb
+++ b/gems/aws-sdk-alexaforbusiness/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/features/env.rb
+++ b/gems/aws-sdk-apigateway/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/features/step_definitions.rb
+++ b/gems/aws-sdk-apigateway/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@apigateway") do
   @service = Aws::APIGateway::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client_api.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/customizations.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/errors.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/plugins/apply_content_type_header.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/plugins/apply_content_type_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module APIGateway
     module Plugins

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/resource.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/types.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/spec/client_spec.rb
+++ b/gems/aws-sdk-apigateway/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-apigateway/spec/spec_helper.rb
+++ b/gems/aws-sdk-apigateway/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/features/env.rb
+++ b/gems/aws-sdk-applicationautoscaling/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/features/step_definitions.rb
+++ b/gems/aws-sdk-applicationautoscaling/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@applicationautoscaling") do
   @service = Aws::ApplicationAutoScaling::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client_api.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/customizations.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/errors.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/resource.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/types.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/spec/spec_helper.rb
+++ b/gems/aws-sdk-applicationautoscaling/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/features/env.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/features/step_definitions.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@applicationdiscoveryservice") do
   @service = Aws::ApplicationDiscoveryService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client_api.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/customizations.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/errors.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/resource.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/types.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/features/env.rb
+++ b/gems/aws-sdk-appstream/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/features/step_definitions.rb
+++ b/gems/aws-sdk-appstream/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appstream") do
   @service = Aws::AppStream::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client_api.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/errors.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/resource.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/types.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/waiters.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/spec/spec_helper.rb
+++ b/gems/aws-sdk-appstream/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/features/env.rb
+++ b/gems/aws-sdk-appsync/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/features/step_definitions.rb
+++ b/gems/aws-sdk-appsync/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appsync") do
   @service = Aws::AppSync::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client_api.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/errors.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/resource.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/types.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/spec/spec_helper.rb
+++ b/gems/aws-sdk-appsync/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/features/env.rb
+++ b/gems/aws-sdk-athena/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/features/step_definitions.rb
+++ b/gems/aws-sdk-athena/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@athena") do
   @service = Aws::Athena::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/client.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/client_api.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/errors.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/resource.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/types.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/spec/spec_helper.rb
+++ b/gems/aws-sdk-athena/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/features/env.rb
+++ b/gems/aws-sdk-autoscaling/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/features/step_definitions.rb
+++ b/gems/aws-sdk-autoscaling/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@autoscaling") do
   @service = Aws::AutoScaling::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/activity.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/activity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client_api.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/customizations.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/errors.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/instance.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/launch_configuration.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/launch_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/lifecycle_hook.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/lifecycle_hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/load_balancer.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/load_balancer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/notification_configuration.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/notification_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scaling_policy.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scaling_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scheduled_action.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scheduled_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/tag.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/types.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/waiters.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/spec/client_spec.rb
+++ b/gems/aws-sdk-autoscaling/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-autoscaling/spec/spec_helper.rb
+++ b/gems/aws-sdk-autoscaling/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/features/env.rb
+++ b/gems/aws-sdk-autoscalingplans/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/features/step_definitions.rb
+++ b/gems/aws-sdk-autoscalingplans/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@autoscalingplans") do
   @service = Aws::AutoScalingPlans::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client_api.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/errors.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/resource.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/types.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/spec/spec_helper.rb
+++ b/gems/aws-sdk-autoscalingplans/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/features/env.rb
+++ b/gems/aws-sdk-batch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/features/step_definitions.rb
+++ b/gems/aws-sdk-batch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@batch") do
   @service = Aws::Batch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/client.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/client_api.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/errors.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/resource.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/types.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/spec/spec_helper.rb
+++ b/gems/aws-sdk-batch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/features/env.rb
+++ b/gems/aws-sdk-budgets/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/features/step_definitions.rb
+++ b/gems/aws-sdk-budgets/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client_api.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/customizations.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/errors.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/resource.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/types.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/spec/spec_helper.rb
+++ b/gems/aws-sdk-budgets/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/features/env.rb
+++ b/gems/aws-sdk-cloud9/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/features/step_definitions.rb
+++ b/gems/aws-sdk-cloud9/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloud9") do
   @service = Aws::Cloud9::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/resource.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloud9/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/features/env.rb
+++ b/gems/aws-sdk-clouddirectory/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/features/step_definitions.rb
+++ b/gems/aws-sdk-clouddirectory/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@clouddirectory") do
   @service = Aws::CloudDirectory::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client_api.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/errors.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/resource.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/types.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/spec/spec_helper.rb
+++ b/gems/aws-sdk-clouddirectory/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/features/env.rb
+++ b/gems/aws-sdk-cloudformation/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudformation/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudformation") do
   @service = Aws::CloudFormation::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/customizations.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/event.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource_summary.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudformation/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/features/env.rb
+++ b/gems/aws-sdk-cloudfront/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudfront/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudfront") do
   @client = Aws::CloudFront::Client.new
 end

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/customizations.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-cloudfront/signer'
 require 'aws-sdk-cloudfront/url_signer'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/errors.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/resource.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/types.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/waiters.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudfront/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudfront/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudhsm/features/env.rb
+++ b/gems/aws-sdk-cloudhsm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudhsm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudhsm") do
   @service = Aws::CloudHSM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/customizations.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/resource.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudhsm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/features/env.rb
+++ b/gems/aws-sdk-cloudhsmv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudhsmv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudhsmv2") do
   @service = Aws::CloudHSMV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client_api.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/errors.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/resource.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/types.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudhsmv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/features/env.rb
+++ b/gems/aws-sdk-cloudsearch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudsearch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudsearch") do
   @service = Aws::CloudSearch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/customizations.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/resource.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudsearch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/features/env.rb
+++ b/gems/aws-sdk-cloudsearchdomain/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudsearchdomain/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudsearchdomain") do
   @service = Aws::CloudSearchDomain::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client_api.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/customizations.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/errors.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/conditional_signing.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/conditional_signing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/switch_to_post.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/switch_to_post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module CloudSearchDomain
     module Plugins

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/resource.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/types.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudsearchdomain/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 # Simply returns the request context without any http response info.

--- a/gems/aws-sdk-cloudsearchdomain/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudsearchdomain/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/features/env.rb
+++ b/gems/aws-sdk-cloudtrail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudtrail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudtrail") do
   @service = Aws::CloudTrail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/customizations.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/resource.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudtrail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/features/env.rb
+++ b/gems/aws-sdk-cloudwatch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatch") do
   @service = Aws::CloudWatch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/customizations.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/resource.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/waiters.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/features/env.rb
+++ b/gems/aws-sdk-cloudwatchevents/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchevents/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatchevents") do
   @service = Aws::CloudWatchEvents::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/customizations.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/resource.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatchevents/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/features/env.rb
+++ b/gems/aws-sdk-cloudwatchlogs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchlogs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatchlogs") do
   @service = Aws::CloudWatchLogs::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/customizations.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/resource.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudwatchlogs/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudwatchlogs/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatchlogs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/features/env.rb
+++ b/gems/aws-sdk-codebuild/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/features/step_definitions.rb
+++ b/gems/aws-sdk-codebuild/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codebuild") do
   @service = Aws::CodeBuild::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/resource.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/spec/spec_helper.rb
+++ b/gems/aws-sdk-codebuild/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/features/env.rb
+++ b/gems/aws-sdk-codecommit/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/features/step_definitions.rb
+++ b/gems/aws-sdk-codecommit/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codecommit") do
   @service = Aws::CodeCommit::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/customizations.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/resource.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/spec/spec_helper.rb
+++ b/gems/aws-sdk-codecommit/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/features/env.rb
+++ b/gems/aws-sdk-codedeploy/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/features/step_definitions.rb
+++ b/gems/aws-sdk-codedeploy/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codedeploy") do
   @service = Aws::CodeDeploy::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/customizations.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/resource.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/waiters.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/spec/spec_helper.rb
+++ b/gems/aws-sdk-codedeploy/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/features/env.rb
+++ b/gems/aws-sdk-codepipeline/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/features/step_definitions.rb
+++ b/gems/aws-sdk-codepipeline/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codepipeline") do
   @service = Aws::CodePipeline::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/customizations.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/resource.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/spec/spec_helper.rb
+++ b/gems/aws-sdk-codepipeline/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/features/env.rb
+++ b/gems/aws-sdk-codestar/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/features/step_definitions.rb
+++ b/gems/aws-sdk-codestar/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codestar") do
   @service = Aws::CodeStar::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/resource.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/spec/spec_helper.rb
+++ b/gems/aws-sdk-codestar/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/features/env.rb
+++ b/gems/aws-sdk-cognitoidentity/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitoidentity/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitoidentity") do
   @client = Aws::CognitoIdentity::Client.new
 end

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client_api.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/errors.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/resource.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/types.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/spec/client_spec.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cognitoidentity/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/features/env.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitoidentityprovider") do
   @service = Aws::CognitoIdentityProvider::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/customizations.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/errors.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/resource.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/types.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cognitoidentityprovider/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/features/env.rb
+++ b/gems/aws-sdk-cognitosync/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitosync/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitosync") do
   @service = Aws::CognitoSync::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client_api.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/customizations.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/errors.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/resource.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/types.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitosync/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/features/env.rb
+++ b/gems/aws-sdk-comprehend/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/features/step_definitions.rb
+++ b/gems/aws-sdk-comprehend/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@comprehend") do
   @service = Aws::Comprehend::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client_api.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/errors.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/resource.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/types.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/spec/spec_helper.rb
+++ b/gems/aws-sdk-comprehend/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/features/env.rb
+++ b/gems/aws-sdk-configservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/features/step_definitions.rb
+++ b/gems/aws-sdk-configservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@configservice") do
   @service = Aws::ConfigService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/customizations.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/resource.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-configservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/features/env.rb
+++ b/gems/aws-sdk-core/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-core/features/features_helper.rb
+++ b/gems/aws-sdk-core/features/features_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../../lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv4/lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-partitions/lib',  __FILE__))

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-partitions'
 require 'seahorse'
 require 'jmespath'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws
@@ -160,8 +162,8 @@ module Aws
       if config.stub_responses
         apply_stubs(operation_name, stubs.flatten)
       else
-        msg = 'stubbing is not enabled; enable stubbing in the constructor '
-        msg << 'with `:stub_responses => true`'
+        msg = 'stubbing is not enabled; enable stubbing in the constructor '\
+              'with `:stub_responses => true`'
         raise msg
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'deprecations'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class CredentialProviderChain

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   class Credentials
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # A utility module that provides a class method that wraps
@@ -46,10 +48,9 @@ module Aws
     def deprecated(method_name, options = {})
 
       deprecation_msg = options[:message] || begin
-        msg = "DEPRECATION WARNING: called deprecated method `#{method_name}' "
-        msg << "of an #{self}"
-        msg << ", use #{options[:use]} instead" if options[:use]
-        msg
+        instead = options[:use] ? ", use #{options[:use]} instead" : ''
+        "DEPRECATION WARNING: called deprecated method `#{method_name}' "\
+        "of an #{self}#{instead}"
       end
 
       alias_method(:"deprecated_#{method_name}", method_name)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'time'
 require 'net/http'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws
@@ -70,8 +72,8 @@ module Aws
     # Raised when a client is constructed and region is not specified.
     class MissingRegionError < ArgumentError
       def initialize(*args)
-        msg = "missing region; use :region option or "
-        msg << "export region name to ENV['AWS_REGION']"
+        msg = "missing region; use :region option or "\
+              "export region name to ENV['AWS_REGION']"
         super(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ini_parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ini_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class IniParser

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'time'
 require 'net/http'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require_relative 'json/builder'
 require_relative 'json/error_handler'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class ErrorHandler < Xml::ErrorHandler

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class Handler < Seahorse::Client::Handler

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class OjEngine

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class JSONEngine

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'time'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Logging

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'set'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # Decorates a {Seahorse::Client::Response} with paging methods:

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jmespath'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'date'
 require 'time'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class ParamValidator

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/api_key.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/api_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_authorizer_token.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_authorizer_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_credentials_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_credentials_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Plugins

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_user_agent.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_user_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/credentials_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/credentials_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Plugins

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/global_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/global_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/jsonvalue_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/jsonvalue_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @see Log::Formatter

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/api_gateway.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/api_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../query'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/json_rpc.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/json_rpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../query'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/user_agent.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/user_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'query/ec2_param_builder'
 require_relative 'query/handler'
 require_relative 'query/param'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/ec2_param_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/ec2_param_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Query

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Query
     class Param

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param_list.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Resources
     class Collection

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rest/handler'
 require_relative 'rest/request/body'
 require_relative 'rest/request/builder'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Rest

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/body.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/headers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 require 'base64'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/body.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 require 'base64'
 require 'json'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/status_code.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/status_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # @api private
@@ -271,8 +273,8 @@ module Aws
     def validate_profile_exists(profile)
       unless (@parsed_credentials && @parsed_credentials[profile]) ||
           (@parsed_config && @parsed_config[profile])
-        msg = "Profile `#{profile}' not found in #{@credentials_path}"
-        msg << " or #{@config_path}" if @config_path
+        config_error = @config_path ? " or #{@config_path}" : ''
+        msg = "Profile `#{profile}' not found in #{@credentials_path}#{config_error}"
         raise Errors::NoSuchProfileError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'ini_parser'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Structure

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/data_applicator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/data_applicator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class DataApplicator

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/empty_stub.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/empty_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class EmptyStub

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/api_gateway.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/api_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/ec2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Stubbing

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/xml_error.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/xml_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class XmlError

--- a/gems/aws-sdk-core/lib/aws-sdk-core/type_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/type_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class TypeBuilder

--- a/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'waiters/errors'
 require_relative 'waiters/poller'
 require_relative 'waiters/waiter'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
     module Errors

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/waiter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'xml/builder'
 require_relative 'xml/default_list'
 require_relative 'xml/default_map'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_list.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_map.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Xml

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/libxml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/libxml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'libxml'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/nokogiri.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/nokogiri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/oga.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/oga.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'oga'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ox'
 require 'stringio'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 require 'rexml/streamlistener'
 
@@ -15,7 +17,7 @@ module Aws
 
         def parse(xml)
           begin
-            source = REXML::Source.new(xml)
+            source = REXML::Source.new(xml.dup)
             REXML::Parsers::StreamParser.new(source, self).parse
           rescue REXML::ParseException => error
             @stack.error(error.message)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'time'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/parsing_error.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/parsing_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     class Parser

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/stack.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     class Parser

--- a/gems/aws-sdk-core/lib/aws-sdk-sts.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/client.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/client_api.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/resource.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/types.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/seahorse.rb
+++ b/gems/aws-sdk-core/lib/seahorse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'seahorse/util'
 
 # client

--- a/gems/aws-sdk-core/lib/seahorse/client/base.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/block_io.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/block_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class BlockIO

--- a/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/events.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module EventEmitter

--- a/gems/aws-sdk-core/lib/seahorse/client/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Handler

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_builder.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
 

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'set'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
 
@@ -86,8 +88,7 @@ module Seahorse
         if STEPS.key?(step)
           @step = step
         else
-          msg = "invalid :step `%s', must be one of :initialize, :validate, "
-          msg << ":build, :sign or :send"
+          msg = "invalid :step `%s', must be one of :initialize, :validate, :build, :sign or :send"
           raise ArgumentError, msg % step.inspect
         end
       end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/headers.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Http

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'uri'
 
@@ -34,8 +36,8 @@ module Seahorse
           if endpoint.nil? or URI::HTTP === endpoint or URI::HTTPS === endpoint
             @endpoint = endpoint
           else
-            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "
-            msg << "got #{endpoint.inspect}"
+            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "\
+                  "got #{endpoint.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Http

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     # @deprecated Use Aws::Logging instead.

--- a/gems/aws-sdk-core/lib/seahorse/client/managed_file.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/managed_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     # This utility class is used to track files opened by Seahorse.

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'net/https'
 require 'delegate'

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/https'
 require 'openssl'
 
@@ -13,8 +15,8 @@ module Seahorse
         # @api private
         class TruncatedBodyError < IOError
           def initialize(bytes_expected, bytes_received)
-            msg = "http response body truncated, expected #{bytes_expected} "
-            msg << "bytes, received #{bytes_received} bytes"
+            msg = "http response body truncated, expected #{bytes_expected} " \
+                  "bytes, received #{bytes_received} bytes"
             super(msg)
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/networking_error.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/networking_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class NetworkingError < StandardError

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Plugin

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin_list.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'thread'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/endpoint.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/logging.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/net_http.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/net_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'seahorse/client/net_http/handler'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/operation_methods.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/operation_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/raise_response_errors.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/raise_response_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/response_target.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/response_target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Request

--- a/gems/aws-sdk-core/lib/seahorse/client/request_context.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/request_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/model/api.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Api

--- a/gems/aws-sdk-core/lib/seahorse/model/authorizer.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/authorizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Authorizer

--- a/gems/aws-sdk-core/lib/seahorse/model/operation.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Operation

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/util.rb
+++ b/gems/aws-sdk-core/lib/seahorse/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/version.rb
+++ b/gems/aws-sdk-core/lib/seahorse/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   VERSION = '0.1.0'
 end

--- a/gems/aws-sdk-core/spec/api_helper.rb
+++ b/gems/aws-sdk-core/spec/api_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module ApiHelper

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/empty_structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/empty_structure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/json/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/json/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'base64'
 require 'time'

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'pathname'
 

--- a/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/param_converter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/global_configuration_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/global_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/region_endpoint_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/region_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/ec2_param_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/ec2_param_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_list_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/sts/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sts/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/waiters_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/waiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'time'
 

--- a/gems/aws-sdk-core/spec/aws_spec.rb
+++ b/gems/aws-sdk-core/spec/aws_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 require 'pathname'

--- a/gems/aws-sdk-core/spec/fixtures/example.com/plugin.rb
+++ b/gems/aws-sdk-core/spec/fixtures/example.com/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YellowSeahorseFixtures
   class Plugin
   end

--- a/gems/aws-sdk-core/spec/fixtures/plugin.rb
+++ b/gems/aws-sdk-core/spec/fixtures/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SeahorseFixtures
   class Plugin
   end

--- a/gems/aws-sdk-core/spec/seahorse/client/base_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/configuration_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse
@@ -86,8 +88,8 @@ module Seahorse
         describe 'errors' do
 
           it 'raises an error if :step is not valid' do
-            msg = "invalid :step `:bogus', must be one of :initialize, "
-            msg << ":validate, :build, :sign or :send"
+            msg = "invalid :step `:bogus', must be one of :initialize, "\
+                  ":validate, :build, :sign or :send"
             expect {
               handlers.add('handler', step: :bogus)
             }.to raise_error(ArgumentError, msg)

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/http/headers_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/headers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/http/request_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/http/response_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'pathname'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'ostruct'
 require 'stringio'

--- a/gems/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugin_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/content_length_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/content_length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/endpoint_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/logging_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/logging_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/net_http_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/net_http_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/request_context_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/request_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/response_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'pp'
 

--- a/gems/aws-sdk-core/spec/seahorse/model/api_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/authorizer_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/authorizer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/operation_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/shapes_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/shapes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'set'
 

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../../lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv2/lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv4/lib',  __FILE__))

--- a/gems/aws-sdk-core/spec/spec_helper.rb
+++ b/gems/aws-sdk-core/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared_spec_helper'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/gems/aws-sdk-costandusagereportservice/features/env.rb
+++ b/gems/aws-sdk-costandusagereportservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/features/step_definitions.rb
+++ b/gems/aws-sdk-costandusagereportservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@costandusagereportservice") do
   @service = Aws::CostandUsageReportService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client_api.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/errors.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/resource.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/types.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-costandusagereportservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/features/env.rb
+++ b/gems/aws-sdk-costexplorer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/features/step_definitions.rb
+++ b/gems/aws-sdk-costexplorer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@costexplorer") do
   @service = Aws::CostExplorer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client_api.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/errors.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/resource.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/types.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/spec/spec_helper.rb
+++ b/gems/aws-sdk-costexplorer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/features/env.rb
+++ b/gems/aws-sdk-databasemigrationservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/features/step_definitions.rb
+++ b/gems/aws-sdk-databasemigrationservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@databasemigrationservice") do
   @service = Aws::DatabaseMigrationService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client_api.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/customizations.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/errors.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/resource.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/types.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-databasemigrationservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/features/env.rb
+++ b/gems/aws-sdk-datapipeline/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/features/step_definitions.rb
+++ b/gems/aws-sdk-datapipeline/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@datapipeline") do
   @service = Aws::DataPipeline::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client_api.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/customizations.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/errors.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/resource.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/types.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/spec/spec_helper.rb
+++ b/gems/aws-sdk-datapipeline/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/features/env.rb
+++ b/gems/aws-sdk-dax/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/features/step_definitions.rb
+++ b/gems/aws-sdk-dax/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dax") do
   @service = Aws::DAX::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/resource.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/spec/spec_helper.rb
+++ b/gems/aws-sdk-dax/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/features/env.rb
+++ b/gems/aws-sdk-devicefarm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/features/step_definitions.rb
+++ b/gems/aws-sdk-devicefarm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@devicefarm") do
   @service = Aws::DeviceFarm::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client_api.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/customizations.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/errors.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/resource.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/types.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/spec/spec_helper.rb
+++ b/gems/aws-sdk-devicefarm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/features/env.rb
+++ b/gems/aws-sdk-directconnect/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/features/step_definitions.rb
+++ b/gems/aws-sdk-directconnect/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@directconnect") do
   @service = Aws::DirectConnect::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/customizations.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/resource.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/spec/spec_helper.rb
+++ b/gems/aws-sdk-directconnect/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/features/env.rb
+++ b/gems/aws-sdk-directoryservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/features/step_definitions.rb
+++ b/gems/aws-sdk-directoryservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@directoryservice") do
   @service = Aws::DirectoryService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client_api.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/customizations.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/errors.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/resource.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/types.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-directoryservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/features/env.rb
+++ b/gems/aws-sdk-dynamodb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/features/step_definitions.rb
+++ b/gems/aws-sdk-dynamodb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dynamodb") do
   @service = Aws::DynamoDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bigdecimal'
 require 'stringio'
 require 'set'
@@ -42,8 +44,8 @@ module Aws
           when true, false then { bool: obj }
           when nil then { null: true }
           else
-            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "
-            msg << "IO, true, false, or nil, got #{obj.class.name}"
+            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "\
+                  "IO, true, false, or nil, got #{obj.class.name}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-dynamodb/attribute_value'
 

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     class Client

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/errors.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/crc32_validation.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/crc32_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/resource.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/table.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/waiters.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'bigdecimal'
 require 'set'

--- a/gems/aws-sdk-dynamodb/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'zlib'
 

--- a/gems/aws-sdk-dynamodb/spec/spec_helper.rb
+++ b/gems/aws-sdk-dynamodb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/features/env.rb
+++ b/gems/aws-sdk-dynamodbstreams/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/features/step_definitions.rb
+++ b/gems/aws-sdk-dynamodbstreams/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dynamodbstreams") do
   @service = Aws::DynamoDBStreams::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client_api.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/errors.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/resource.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/types.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/spec/spec_helper.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/features/env.rb
+++ b/gems/aws-sdk-ec2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ec2") do
   @service = Aws::EC2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/classic_address.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/classic_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client_api.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-ec2/customizations/resource'
 require 'aws-sdk-ec2/customizations/instance'

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EC2
     class Resource

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/dhcp_options.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/dhcp_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/errors.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/internet_gateway.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/internet_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair_info.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_acl.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface_association.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/placement_group.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/placement_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/copy_encrypted_snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/copy_encrypted_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EC2
     module Plugins
@@ -7,8 +9,8 @@ module Aws
         def after_initialize(client)
           if region = client.config.region
             if matches = region.match(/^(\w+-\w+-\d+)[a-z]$/)
-              msg = ":region option must a region name, not an availability "
-              msg << "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
+              msg = ":region option must a region name, not an availability "\
+                    "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table_association.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/security_group.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/security_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/subnet.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/subnet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/tag.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/volume.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_address.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/spec/client_spec.rb
+++ b/gems/aws-sdk-ec2/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2/spec/instance/decrypt_windows_password_spec.rb
+++ b/gems/aws-sdk-ec2/spec/instance/decrypt_windows_password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2/spec/resource_spec.rb
+++ b/gems/aws-sdk-ec2/spec/resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2/spec/spec_helper.rb
+++ b/gems/aws-sdk-ec2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/features/env.rb
+++ b/gems/aws-sdk-ecr/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/features/step_definitions.rb
+++ b/gems/aws-sdk-ecr/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ecr") do
   @service = Aws::ECR::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client_api.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/customizations.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/errors.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/resource.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/types.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/spec/spec_helper.rb
+++ b/gems/aws-sdk-ecr/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/features/env.rb
+++ b/gems/aws-sdk-ecs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/features/step_definitions.rb
+++ b/gems/aws-sdk-ecs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ecs") do
   @service = Aws::ECS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/customizations.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/resource.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/spec/spec_helper.rb
+++ b/gems/aws-sdk-ecs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/features/env.rb
+++ b/gems/aws-sdk-efs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/features/step_definitions.rb
+++ b/gems/aws-sdk-efs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@efs") do
   @service = Aws::EFS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/client.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/client_api.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/customizations.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/errors.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/resource.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/types.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/spec/spec_helper.rb
+++ b/gems/aws-sdk-efs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/features/env.rb
+++ b/gems/aws-sdk-elasticache/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticache/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticache") do
   @service = Aws::ElastiCache::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/customizations.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/resource.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/waiters.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticache/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/features/env.rb
+++ b/gems/aws-sdk-elasticbeanstalk/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticbeanstalk/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticbeanstalk") do
   @service = Aws::ElasticBeanstalk::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/customizations.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/resource.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticbeanstalk/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/features/env.rb
+++ b/gems/aws-sdk-elasticloadbalancing/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancing/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticloadbalancing") do
   @service = Aws::ElasticLoadBalancing::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/customizations.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/resource.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/waiters.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticloadbalancing/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/features/env.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticloadbalancingv2") do
   @service = Aws::ElasticLoadBalancingV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/customizations.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/resource.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/waiters.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/features/env.rb
+++ b/gems/aws-sdk-elasticsearchservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticsearchservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticsearchservice") do
   @service = Aws::ElasticsearchService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/customizations.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/resource.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticsearchservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/features/env.rb
+++ b/gems/aws-sdk-elastictranscoder/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/features/step_definitions.rb
+++ b/gems/aws-sdk-elastictranscoder/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elastictranscoder") do
   @service = Aws::ElasticTranscoder::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/customizations.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/resource.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/waiters.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/spec/spec_helper.rb
+++ b/gems/aws-sdk-elastictranscoder/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/features/env.rb
+++ b/gems/aws-sdk-emr/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/features/step_definitions.rb
+++ b/gems/aws-sdk-emr/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@emr") do
   @service = Aws::EMR::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/client.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/customizations.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/resource.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/waiters.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/spec/spec_helper.rb
+++ b/gems/aws-sdk-emr/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/features/env.rb
+++ b/gems/aws-sdk-firehose/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/features/step_definitions.rb
+++ b/gems/aws-sdk-firehose/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@firehose") do
   @service = Aws::Firehose::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client_api.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/customizations.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/errors.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/resource.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/types.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/spec/spec_helper.rb
+++ b/gems/aws-sdk-firehose/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/features/env.rb
+++ b/gems/aws-sdk-gamelift/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/features/step_definitions.rb
+++ b/gems/aws-sdk-gamelift/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@gamelift") do
   @service = Aws::GameLift::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client_api.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/customizations.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/errors.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/resource.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/types.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/spec/spec_helper.rb
+++ b/gems/aws-sdk-gamelift/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/features/env.rb
+++ b/gems/aws-sdk-glacier/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/features/step_definitions.rb
+++ b/gems/aws-sdk-glacier/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@glacier") do
   @client = Aws::Glacier::Client.new
 end

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/archive.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/archive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client_api.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/customizations.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/errors.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/job.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/multipart_upload.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/notification.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/account_id.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/account_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Glacier
     module Plugins

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/api_version.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/api_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Glacier
     module Plugins

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/checksums.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/checksums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../tree_hash'
 require 'openssl'
 

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/tree_hash.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/tree_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/types.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/vault.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/vault.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/waiters.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/spec/client_spec.rb
+++ b/gems/aws-sdk-glacier/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-glacier/spec/spec_helper.rb
+++ b/gems/aws-sdk-glacier/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/features/env.rb
+++ b/gems/aws-sdk-glue/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/features/step_definitions.rb
+++ b/gems/aws-sdk-glue/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@glue") do
   @service = Aws::Glue::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/client.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/client_api.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/errors.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/resource.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/types.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/spec/spec_helper.rb
+++ b/gems/aws-sdk-glue/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/features/env.rb
+++ b/gems/aws-sdk-greengrass/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/features/step_definitions.rb
+++ b/gems/aws-sdk-greengrass/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@greengrass") do
   @service = Aws::Greengrass::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client_api.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/errors.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/resource.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/types.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/spec/spec_helper.rb
+++ b/gems/aws-sdk-greengrass/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/features/env.rb
+++ b/gems/aws-sdk-guardduty/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/features/step_definitions.rb
+++ b/gems/aws-sdk-guardduty/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@guardduty") do
   @service = Aws::GuardDuty::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client_api.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/errors.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/resource.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/types.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/spec/spec_helper.rb
+++ b/gems/aws-sdk-guardduty/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/features/env.rb
+++ b/gems/aws-sdk-health/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/features/step_definitions.rb
+++ b/gems/aws-sdk-health/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@health") do
   @service = Aws::Health::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-health/lib/aws-sdk-health.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/client.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/client_api.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/errors.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/resource.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/types.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/spec/spec_helper.rb
+++ b/gems/aws-sdk-health/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/features/env.rb
+++ b/gems/aws-sdk-iam/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/features/step_definitions.rb
+++ b/gems/aws-sdk-iam/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iam") do
   @service = Aws::IAM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key_pair.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key_pair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/account_password_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/account_password_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/account_summary.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/account_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/assume_role_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/assume_role_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/client.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/client_api.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/current_user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/current_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-iam/customizations/resource'

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations/resource.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module IAM
     class Resource

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/group_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/group_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/login_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/login_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/mfa_device.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/mfa_device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/policy_version.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/policy_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/role.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/role_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/role_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/saml_provider.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/saml_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/signing_certificate.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/signing_certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/types.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/virtual_mfa_device.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/virtual_mfa_device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/waiters.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/spec/client_spec.rb
+++ b/gems/aws-sdk-iam/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-iam/spec/resource_spec.rb
+++ b/gems/aws-sdk-iam/spec/resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-iam/spec/spec_helper.rb
+++ b/gems/aws-sdk-iam/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/features/env.rb
+++ b/gems/aws-sdk-importexport/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/features/step_definitions.rb
+++ b/gems/aws-sdk-importexport/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@importexport") do
   @service = Aws::ImportExport::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client_api.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/customizations.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/errors.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/resource.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/types.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/spec/spec_helper.rb
+++ b/gems/aws-sdk-importexport/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/features/env.rb
+++ b/gems/aws-sdk-inspector/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/features/step_definitions.rb
+++ b/gems/aws-sdk-inspector/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@inspector") do
   @service = Aws::Inspector::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client_api.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/customizations.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/errors.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/resource.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/types.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/spec/spec_helper.rb
+++ b/gems/aws-sdk-inspector/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/features/env.rb
+++ b/gems/aws-sdk-iot/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/features/step_definitions.rb
+++ b/gems/aws-sdk-iot/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iot") do
   @service = Aws::IoT::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/client.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/client_api.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/customizations.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/errors.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/resource.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/types.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/spec/spec_helper.rb
+++ b/gems/aws-sdk-iot/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/features/env.rb
+++ b/gems/aws-sdk-iotdataplane/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/features/step_definitions.rb
+++ b/gems/aws-sdk-iotdataplane/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotdataplane") do
   @service = Aws::IoTDataPlane::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client_api.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/customizations.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/errors.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/resource.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/types.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/spec/client_spec.rb
+++ b/gems/aws-sdk-iotdataplane/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-iotdataplane/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotdataplane/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/features/env.rb
+++ b/gems/aws-sdk-iotjobsdataplane/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/features/step_definitions.rb
+++ b/gems/aws-sdk-iotjobsdataplane/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotjobsdataplane") do
   @service = Aws::IoTJobsDataPlane::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client_api.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/errors.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/resource.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/types.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotjobsdataplane/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/features/env.rb
+++ b/gems/aws-sdk-kinesis/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesis/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesis") do
   @service = Aws::Kinesis::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client_api.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/customizations.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/errors.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/resource.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/types.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/waiters.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesis/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/features/env.rb
+++ b/gems/aws-sdk-kinesisanalytics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisanalytics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisanalytics") do
   @service = Aws::KinesisAnalytics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client_api.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/customizations.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/errors.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/resource.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/types.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisanalytics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/features/env.rb
+++ b/gems/aws-sdk-kinesisvideo/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideo/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideo") do
   @service = Aws::KinesisVideo::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client_api.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/errors.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/resource.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/types.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideo/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/features/env.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideoarchivedmedia") do
   @service = Aws::KinesisVideoArchivedMedia::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client_api.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/errors.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/resource.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/types.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/features/env.rb
+++ b/gems/aws-sdk-kinesisvideomedia/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideomedia/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideomedia") do
   @service = Aws::KinesisVideoMedia::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client_api.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/errors.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/resource.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/types.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideomedia/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/features/env.rb
+++ b/gems/aws-sdk-kms/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/features/step_definitions.rb
+++ b/gems/aws-sdk-kms/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kms") do
   @service = Aws::KMS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/client.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/client_api.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/customizations.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/errors.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/resource.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/types.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/spec/spec_helper.rb
+++ b/gems/aws-sdk-kms/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/features/env.rb
+++ b/gems/aws-sdk-lambda/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/features/step_definitions.rb
+++ b/gems/aws-sdk-lambda/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lambda") do
   @service = Aws::Lambda::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client_api.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/customizations.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/errors.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/resource.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/types.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/spec/client_spec.rb
+++ b/gems/aws-sdk-lambda/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-lambda/spec/spec_helper.rb
+++ b/gems/aws-sdk-lambda/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/features/env.rb
+++ b/gems/aws-sdk-lambdapreview/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/features/step_definitions.rb
+++ b/gems/aws-sdk-lambdapreview/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lambdapreview") do
   @service = Aws::LambdaPreview::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client_api.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/customizations.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/errors.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/resource.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/types.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/spec/client_spec.rb
+++ b/gems/aws-sdk-lambdapreview/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-lambdapreview/spec/spec_helper.rb
+++ b/gems/aws-sdk-lambdapreview/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/features/env.rb
+++ b/gems/aws-sdk-lex/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/features/step_definitions.rb
+++ b/gems/aws-sdk-lex/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lex") do
   @service = Aws::Lex::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/client.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/client_api.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/errors.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/resource.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/types.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/spec/spec_helper.rb
+++ b/gems/aws-sdk-lex/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/features/env.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/features/step_definitions.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lexmodelbuildingservice") do
   @service = Aws::LexModelBuildingService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client_api.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/errors.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/resource.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/types.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/features/env.rb
+++ b/gems/aws-sdk-lexruntimeservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/features/step_definitions.rb
+++ b/gems/aws-sdk-lexruntimeservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lexruntimeservice") do
   @service = Aws::LexRuntimeService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client_api.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/errors.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/resource.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/types.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-lexruntimeservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/features/env.rb
+++ b/gems/aws-sdk-lightsail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/features/step_definitions.rb
+++ b/gems/aws-sdk-lightsail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lightsail") do
   @service = Aws::Lightsail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client_api.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/errors.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/resource.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/types.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/spec/spec_helper.rb
+++ b/gems/aws-sdk-lightsail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/features/env.rb
+++ b/gems/aws-sdk-machinelearning/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/features/step_definitions.rb
+++ b/gems/aws-sdk-machinelearning/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@machinelearning") do
   @service = Aws::MachineLearning::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client_api.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/customizations.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/errors.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/plugins/predict_endpoint.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/plugins/predict_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module MachineLearning
     module Plugins

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/resource.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/types.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/waiters.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/spec/client_spec.rb
+++ b/gems/aws-sdk-machinelearning/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-machinelearning/spec/spec_helper.rb
+++ b/gems/aws-sdk-machinelearning/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/features/env.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplacecommerceanalytics") do
   @service = Aws::MarketplaceCommerceAnalytics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client_api.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/customizations.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/errors.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/resource.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/types.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/features/env.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplaceentitlementservice") do
   @service = Aws::MarketplaceEntitlementService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client_api.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/errors.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/resource.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/types.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/features/env.rb
+++ b/gems/aws-sdk-marketplacemetering/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplacemetering/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplacemetering") do
   @service = Aws::MarketplaceMetering::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client_api.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/customizations.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/errors.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/resource.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/types.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplacemetering/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/features/env.rb
+++ b/gems/aws-sdk-mediaconvert/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/features/step_definitions.rb
+++ b/gems/aws-sdk-mediaconvert/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediaconvert") do
   @service = Aws::MediaConvert::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client_api.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/errors.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/resource.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/types.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediaconvert/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/features/env.rb
+++ b/gems/aws-sdk-medialive/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/features/step_definitions.rb
+++ b/gems/aws-sdk-medialive/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@medialive") do
   @service = Aws::MediaLive::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client_api.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/errors.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/resource.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/types.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/spec/spec_helper.rb
+++ b/gems/aws-sdk-medialive/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/features/env.rb
+++ b/gems/aws-sdk-mediapackage/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/features/step_definitions.rb
+++ b/gems/aws-sdk-mediapackage/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediapackage") do
   @service = Aws::MediaPackage::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client_api.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/errors.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/resource.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/types.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediapackage/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/features/env.rb
+++ b/gems/aws-sdk-mediastore/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/features/step_definitions.rb
+++ b/gems/aws-sdk-mediastore/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediastore") do
   @service = Aws::MediaStore::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client_api.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/errors.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/resource.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/types.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediastore/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/features/env.rb
+++ b/gems/aws-sdk-mediastoredata/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/features/step_definitions.rb
+++ b/gems/aws-sdk-mediastoredata/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediastoredata") do
   @service = Aws::MediaStoreData::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client_api.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/errors.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/resource.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/types.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediastoredata/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/features/env.rb
+++ b/gems/aws-sdk-migrationhub/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/features/step_definitions.rb
+++ b/gems/aws-sdk-migrationhub/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@migrationhub") do
   @service = Aws::MigrationHub::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client_api.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/errors.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/resource.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/types.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/spec/spec_helper.rb
+++ b/gems/aws-sdk-migrationhub/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/features/env.rb
+++ b/gems/aws-sdk-mobile/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/features/step_definitions.rb
+++ b/gems/aws-sdk-mobile/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mobile") do
   @service = Aws::Mobile::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client_api.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/errors.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/resource.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/types.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/spec/spec_helper.rb
+++ b/gems/aws-sdk-mobile/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/features/env.rb
+++ b/gems/aws-sdk-mq/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/features/step_definitions.rb
+++ b/gems/aws-sdk-mq/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mq") do
   @service = Aws::MQ::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/client.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/client_api.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/errors.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/resource.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/types.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/spec/spec_helper.rb
+++ b/gems/aws-sdk-mq/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/features/env.rb
+++ b/gems/aws-sdk-mturk/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/features/step_definitions.rb
+++ b/gems/aws-sdk-mturk/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mturk") do
   @service = Aws::MTurk::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client_api.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/errors.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/resource.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/types.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/spec/spec_helper.rb
+++ b/gems/aws-sdk-mturk/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/features/env.rb
+++ b/gems/aws-sdk-opsworks/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/features/step_definitions.rb
+++ b/gems/aws-sdk-opsworks/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@opsworks") do
   @service = Aws::OpsWorks::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client_api.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/customizations.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/errors.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/layer.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/layer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/resource.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack_summary.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/types.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/waiters.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/spec/spec_helper.rb
+++ b/gems/aws-sdk-opsworks/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/features/env.rb
+++ b/gems/aws-sdk-opsworkscm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/features/step_definitions.rb
+++ b/gems/aws-sdk-opsworkscm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@opsworkscm") do
   @service = Aws::OpsWorksCM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client_api.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/errors.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/resource.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/types.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/waiters.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/spec/spec_helper.rb
+++ b/gems/aws-sdk-opsworkscm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/features/env.rb
+++ b/gems/aws-sdk-organizations/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/features/step_definitions.rb
+++ b/gems/aws-sdk-organizations/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@organizations") do
   @service = Aws::Organizations::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client_api.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/errors.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/resource.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/types.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/spec/spec_helper.rb
+++ b/gems/aws-sdk-organizations/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/features/env.rb
+++ b/gems/aws-sdk-pinpoint/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/features/step_definitions.rb
+++ b/gems/aws-sdk-pinpoint/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pinpoint") do
   @service = Aws::Pinpoint::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client_api.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/errors.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/resource.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/types.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/spec/spec_helper.rb
+++ b/gems/aws-sdk-pinpoint/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/features/env.rb
+++ b/gems/aws-sdk-polly/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/features/step_definitions.rb
+++ b/gems/aws-sdk-polly/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@polly") do
   @service = Aws::Polly::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/client.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/client_api.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/customizations.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-polly/presigner'

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/errors.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/presigner.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/presigner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/resource.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/types.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/spec/presigner_spec.rb
+++ b/gems/aws-sdk-polly/spec/presigner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './spec_helper'
 
 module Aws

--- a/gems/aws-sdk-polly/spec/spec_helper.rb
+++ b/gems/aws-sdk-polly/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/features/env.rb
+++ b/gems/aws-sdk-pricing/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/features/step_definitions.rb
+++ b/gems/aws-sdk-pricing/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pricing") do
   @service = Aws::Pricing::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client_api.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/errors.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/resource.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/types.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/spec/spec_helper.rb
+++ b/gems/aws-sdk-pricing/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/features/env.rb
+++ b/gems/aws-sdk-rds/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/features/step_definitions.rb
+++ b/gems/aws-sdk-rds/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@rds") do
   @service = Aws::RDS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/account_quota.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/account_quota.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/certificate.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/client.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-rds/customizations/auth_token_generator'

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations/auth_token_generator.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations/auth_token_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_parameter_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_parameter_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_snapshot.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine_version.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_instance.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_log_file.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_log_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group_family.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group_family.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_security_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_security_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot_attribute.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_subnet_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_subnet_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event_category_map.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event_category_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event_subscription.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event_subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group_option.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group_option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/parameter.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/parameter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/pending_maintenance_action.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/pending_maintenance_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/plugins/cross_region_copying.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/plugins/cross_region_copying.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instance.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instances_offering.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instances_offering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/resource_pending_maintenance_action_list.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/resource_pending_maintenance_action_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/waiters.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
+++ b/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-rds/spec/client_spec.rb
+++ b/gems/aws-sdk-rds/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './spec_helper'
 
 module Aws

--- a/gems/aws-sdk-rds/spec/spec_helper.rb
+++ b/gems/aws-sdk-rds/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/features/env.rb
+++ b/gems/aws-sdk-redshift/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/features/step_definitions.rb
+++ b/gems/aws-sdk-redshift/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@redshift") do
   @service = Aws::Redshift::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/customizations.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/resource.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/waiters.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/spec/spec_helper.rb
+++ b/gems/aws-sdk-redshift/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/features/env.rb
+++ b/gems/aws-sdk-rekognition/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/features/step_definitions.rb
+++ b/gems/aws-sdk-rekognition/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@rekognition") do
   @service = Aws::Rekognition::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/resource.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/spec/spec_helper.rb
+++ b/gems/aws-sdk-rekognition/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/features/env.rb
+++ b/gems/aws-sdk-resourcegroups/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/features/step_definitions.rb
+++ b/gems/aws-sdk-resourcegroups/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@resourcegroups") do
   @service = Aws::ResourceGroups::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client_api.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/errors.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/resource.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/types.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/spec/spec_helper.rb
+++ b/gems/aws-sdk-resourcegroups/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/features/env.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/features/step_definitions.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@resourcegroupstaggingapi") do
   @service = Aws::ResourceGroupsTaggingAPI::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client_api.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/errors.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/resource.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/types.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/spec/spec_helper.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resources/bin/aws-v3.rb
+++ b/gems/aws-sdk-resources/bin/aws-v3.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rubygems'
 require 'optparse'

--- a/gems/aws-sdk-resources/lib/aws-sdk-resources.rb
+++ b/gems/aws-sdk-resources/lib/aws-sdk-resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-core'
 
 # Aws module documentation.

--- a/gems/aws-sdk-route53/features/env.rb
+++ b/gems/aws-sdk-route53/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/features/step_definitions.rb
+++ b/gems/aws-sdk-route53/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@route53") do
   @service = Aws::Route53::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/client.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/client_api.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/customizations.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/errors.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Route53
     module Plugins

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/resource.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/types.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/waiters.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/spec/client_spec.rb
+++ b/gems/aws-sdk-route53/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-route53/spec/spec_helper.rb
+++ b/gems/aws-sdk-route53/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/features/env.rb
+++ b/gems/aws-sdk-route53domains/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/features/step_definitions.rb
+++ b/gems/aws-sdk-route53domains/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@route53domains") do
   @service = Aws::Route53Domains::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client_api.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/customizations.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/errors.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/resource.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/types.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/spec/spec_helper.rb
+++ b/gems/aws-sdk-route53domains/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/features/client/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/client/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 Before("@s3", "@client") do

--- a/gems/aws-sdk-s3/features/env.rb
+++ b/gems/aws-sdk-s3/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/features/resources/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/resources/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'tempfile'
 require 'fileutils'

--- a/gems/aws-sdk-s3/features/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -672,8 +674,7 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_acl.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_cors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle_configuration.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_logging.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_notification.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_policy.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_region_cache.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_region_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_request_payment.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_request_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_tagging.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_tagging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_versioning.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_versioning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_website.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_website.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-s3/bucket_region_cache'
 require 'aws-sdk-s3/encryption'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/multipart_upload.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class MultipartUpload

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class Object

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class ObjectSummary

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/list_object_versions_output.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/list_object_versions_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aws::S3::Types::ListObjectVersionsOutput
 
   # TODO : Remove this customization once the resource code

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-s3/encryption/client'
 require 'aws-sdk-s3/encryption/decrypt_handler'
 require 'aws-sdk-s3/encryption/default_cipher_provider'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
 
@@ -347,8 +349,8 @@ module Aws
           if [:metadata, :instruction_file].include?(location)
             location
           else
-            msg = ":envelope_location must be :metadata or :instruction_file "
-            msg << "got #{location.inspect}"
+            msg = ":envelope_location must be :metadata or :instruction_file \
+                    got #{location.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/decrypt_handler.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/decrypt_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_cipher_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_cipher_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_key_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_key_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_decrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_decrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/key_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/key_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/kms_cipher_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/kms_cipher_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws
@@ -32,14 +34,14 @@ module Aws
             if [32, 24, 16].include?(key.bytesize)
               key
             else
-              msg = "invalid key, symmetric key required to be 16, 24, or "
-              msg << "32 bytes in length, saw length " + key.bytesize.to_s
+              msg = "invalid key, symmetric key required to be 16, 24, or "\
+                    "32 bytes in length, saw length " + key.bytesize.to_s
               raise ArgumentError, msg
             end
           else
-            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "
-            msg << "(for asymmetric encryption) or a String (for symmetric "
-            msg << "encryption)."
+            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key \
+                   (for asymmetric encryption) or a String (for symmetric \
+                   encryption)."
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'thread'
 require 'set'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/legacy_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/legacy_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'time'
 require 'openssl'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'thread'
 require 'set'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_error.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class MultipartUploadError < StandardError

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_part.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_acl.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_copier.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_copier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_multipart_copier.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_multipart_copier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'cgi'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_version.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_dns.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_dns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_name_restrictions.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_name_restrictions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/dualstack.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/dualstack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/location_constraint.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/location_constraint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_host_id.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_host_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/sse_cpk.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/sse_cpk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'openssl'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/url_encoded_keys.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/url_encoded_keys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'cgi'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 
@@ -571,8 +573,8 @@ module Aws
 
       def check_required_values!
         unless @key_set
-          msg = "key required; you must provide a key via :key, "
-          msg << ":key_starts_with, or :allow_any => ['key']"
+          msg = "key required; you must provide a key via :key, "\
+                ":key_starts_with, or :allow_any => ['key']"
           raise msg
         end
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/waiters.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/spec/bucket/delete_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/load_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/load_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/url_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/waiters_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/waiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client/dualstack_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/dualstack_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 require 'tempfile'

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'base64'
 require 'openssl'
@@ -255,7 +257,7 @@ module Aws
 
             it 'supports #get_object with a block' do
               stub_encrypted_get
-              data = ''
+              data = ''.dup
               client.get_object(bucket:'bucket', key:'key') do |chunk|
                 data << chunk
               end

--- a/gems/aws-sdk-s3/spec/encryption/io_encrypter_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/io_encrypter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'openssl'
 

--- a/gems/aws-sdk-s3/spec/file_part_spec.rb
+++ b/gems/aws-sdk-s3/spec/file_part_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/legacy_signer_spec.rb
+++ b/gems/aws-sdk-s3/spec/legacy_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/multipart_upload/complete_spec.rb
+++ b/gems/aws-sdk-s3/spec/multipart_upload/complete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object/move_to_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/move_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'thread'
 

--- a/gems/aws-sdk-s3/spec/object/presigned_post_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/presigned_post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/presigned_url_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/presigned_url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/public_url_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/public_url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object_spec.rb
+++ b/gems/aws-sdk-s3/spec/object_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object_summary_spec.rb
+++ b/gems/aws-sdk-s3/spec/object_summary_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/presigned_post_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigned_post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'base64'
 

--- a/gems/aws-sdk-s3/spec/presigner_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/spec_helper.rb
+++ b/gems/aws-sdk-s3/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/features/env.rb
+++ b/gems/aws-sdk-sagemaker/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/features/step_definitions.rb
+++ b/gems/aws-sdk-sagemaker/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sagemaker") do
   @service = Aws::SageMaker::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client_api.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/errors.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/resource.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/types.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/waiters.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/spec/spec_helper.rb
+++ b/gems/aws-sdk-sagemaker/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/features/env.rb
+++ b/gems/aws-sdk-sagemakerruntime/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/features/step_definitions.rb
+++ b/gems/aws-sdk-sagemakerruntime/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sagemakerruntime") do
   @service = Aws::SageMakerRuntime::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client_api.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/errors.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/resource.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/types.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/spec/spec_helper.rb
+++ b/gems/aws-sdk-sagemakerruntime/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/features/env.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/features/step_definitions.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@serverlessapplicationrepository") do
   @service = Aws::ServerlessApplicationRepository::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client_api.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/errors.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/resource.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/types.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/spec/spec_helper.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/features/env.rb
+++ b/gems/aws-sdk-servicecatalog/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/features/step_definitions.rb
+++ b/gems/aws-sdk-servicecatalog/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@servicecatalog") do
   @service = Aws::ServiceCatalog::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/customizations.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/resource.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/spec/spec_helper.rb
+++ b/gems/aws-sdk-servicecatalog/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/features/env.rb
+++ b/gems/aws-sdk-servicediscovery/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/features/step_definitions.rb
+++ b/gems/aws-sdk-servicediscovery/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@servicediscovery") do
   @service = Aws::ServiceDiscovery::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client_api.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/errors.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/resource.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/types.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/spec/spec_helper.rb
+++ b/gems/aws-sdk-servicediscovery/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/features/env.rb
+++ b/gems/aws-sdk-ses/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/features/step_definitions.rb
+++ b/gems/aws-sdk-ses/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ses") do
   @service = Aws::SES::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/client.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/customizations.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/resource.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/waiters.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/spec/spec_helper.rb
+++ b/gems/aws-sdk-ses/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/features/env.rb
+++ b/gems/aws-sdk-sfn/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/features/step_definitions.rb
+++ b/gems/aws-sdk-sfn/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sfn") do
   @service = Aws::SFN::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn/client.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn/client_api.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn/errors.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn/resource.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/lib/aws-sdk-sfn/types.rb
+++ b/gems/aws-sdk-sfn/lib/aws-sdk-sfn/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sfn/spec/spec_helper.rb
+++ b/gems/aws-sdk-sfn/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/features/env.rb
+++ b/gems/aws-sdk-shield/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/features/step_definitions.rb
+++ b/gems/aws-sdk-shield/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@shield") do
   @service = Aws::Shield::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/client.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/client_api.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/errors.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/resource.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/types.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/spec/spec_helper.rb
+++ b/gems/aws-sdk-shield/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/features/env.rb
+++ b/gems/aws-sdk-simpledb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/features/step_definitions.rb
+++ b/gems/aws-sdk-simpledb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@simpledb") do
   @service = Aws::SimpleDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client_api.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/customizations.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/errors.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/resource.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/types.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/spec/spec_helper.rb
+++ b/gems/aws-sdk-simpledb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/features/env.rb
+++ b/gems/aws-sdk-sms/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/features/step_definitions.rb
+++ b/gems/aws-sdk-sms/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/client.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/customizations.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/resource.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/spec/spec_helper.rb
+++ b/gems/aws-sdk-sms/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/features/env.rb
+++ b/gems/aws-sdk-snowball/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/features/step_definitions.rb
+++ b/gems/aws-sdk-snowball/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@snowball") do
   @service = Aws::Snowball::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client_api.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/customizations.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/errors.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/resource.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/types.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/spec/spec_helper.rb
+++ b/gems/aws-sdk-snowball/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/features/env.rb
+++ b/gems/aws-sdk-sns/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/features/step_definitions.rb
+++ b/gems/aws-sdk-sns/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sns") do
   @service = Aws::SNS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/client.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/client_api.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/customizations.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-sns/message_verifier'

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/errors.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/message_verifier.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/message_verifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'openssl'
 require 'base64'

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_application.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_endpoint.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/resource.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/subscription.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/topic.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/topic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/types.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/spec/message_verifier_spec.rb
+++ b/gems/aws-sdk-sns/spec/message_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-sns/spec/spec_helper.rb
+++ b/gems/aws-sdk-sns/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/features/env.rb
+++ b/gems/aws-sdk-sqs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/features/step_definitions.rb
+++ b/gems/aws-sdk-sqs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sqs") do
   @client = Aws::SQS::Client.new
   @sqs_created_queues = []

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/customizations.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-sqs/queue_poller'

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/message.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws
@@ -117,8 +119,8 @@ module Aws
           end
 
           def mismatch_error_message(section, local_md5, returned_md5, response)
-            m = "MD5 returned by SQS does not match " <<
-            "the calculation on the original request. ("
+            m = "MD5 returned by SQS does not match \
+                 the calculation on the original request. (".dup
 
             if response.respond_to?(:id) && !response.id.nil?
               m << "Message ID: #{response.id}, "

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module SQS
     module Plugins

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/resource.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'uri'
 

--- a/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 
 require_relative '../spec_helper'
@@ -14,19 +16,19 @@ module Aws
         let(:message_attributes) {{
           'ccc' => {
             string_value: 'test',
-            data_type: 'String'
+            data_type: 'String'.dup
           },
           aaa: {
             binary_value: [ 2, 3, 4 ].pack('C*'),
-            data_type: 'Binary'
+            data_type: 'Binary'.dup
           },
           zzz: {
-            data_type: 'Number',
+            data_type: 'Number'.dup,
             string_value: '0230.01'
           },
           'öther_encodings' => {
-            data_type: 'String',
-            string_value: 'Tüst'.encode!('ISO-8859-1')
+            data_type: 'String'.dup,
+            string_value: 'Tüst'.encode('ISO-8859-1')
           }
         }}
 

--- a/gems/aws-sdk-sqs/spec/client_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-sqs/spec/spec_helper.rb
+++ b/gems/aws-sdk-sqs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/features/env.rb
+++ b/gems/aws-sdk-ssm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/features/step_definitions.rb
+++ b/gems/aws-sdk-ssm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ssm") do
   @service = Aws::SSM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/customizations.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/resource.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/spec/spec_helper.rb
+++ b/gems/aws-sdk-ssm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/features/env.rb
+++ b/gems/aws-sdk-states/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/features/step_definitions.rb
+++ b/gems/aws-sdk-states/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@states") do
   @service = Aws::States::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-states/lib/aws-sdk-states.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/client.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/client_api.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/errors.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/resource.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/types.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/spec/spec_helper.rb
+++ b/gems/aws-sdk-states/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/features/env.rb
+++ b/gems/aws-sdk-storagegateway/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/features/step_definitions.rb
+++ b/gems/aws-sdk-storagegateway/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@storagegateway") do
   @service = Aws::StorageGateway::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client_api.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/customizations.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/errors.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/resource.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/types.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/spec/spec_helper.rb
+++ b/gems/aws-sdk-storagegateway/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/features/env.rb
+++ b/gems/aws-sdk-support/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/features/step_definitions.rb
+++ b/gems/aws-sdk-support/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@support") do
   @service = Aws::Support::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-support/lib/aws-sdk-support.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/client.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/client_api.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/errors.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/resource.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/types.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/spec/spec_helper.rb
+++ b/gems/aws-sdk-support/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/features/env.rb
+++ b/gems/aws-sdk-swf/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/features/step_definitions.rb
+++ b/gems/aws-sdk-swf/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@swf") do
   @service = Aws::SWF::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/client.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/client_api.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/errors.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/plugins/read_timeouts.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/plugins/read_timeouts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module SWF
     module Plugins

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/resource.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/types.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/spec/spec_helper.rb
+++ b/gems/aws-sdk-swf/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/features/env.rb
+++ b/gems/aws-sdk-transcribeservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/features/step_definitions.rb
+++ b/gems/aws-sdk-transcribeservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@transcribeservice") do
   @service = Aws::TranscribeService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client_api.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/errors.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/resource.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/types.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-transcribeservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/features/env.rb
+++ b/gems/aws-sdk-translate/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/features/step_definitions.rb
+++ b/gems/aws-sdk-translate/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@translate") do
   @service = Aws::Translate::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/client.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/client_api.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/errors.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/resource.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/types.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/spec/spec_helper.rb
+++ b/gems/aws-sdk-translate/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/features/env.rb
+++ b/gems/aws-sdk-waf/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/features/step_definitions.rb
+++ b/gems/aws-sdk-waf/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@waf") do
   @service = Aws::WAF::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/client.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/resource.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/spec/spec_helper.rb
+++ b/gems/aws-sdk-waf/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/features/env.rb
+++ b/gems/aws-sdk-wafregional/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/features/step_definitions.rb
+++ b/gems/aws-sdk-wafregional/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@wafregional") do
   @service = Aws::WAFRegional::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/resource.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/spec/spec_helper.rb
+++ b/gems/aws-sdk-wafregional/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/features/env.rb
+++ b/gems/aws-sdk-workdocs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/features/step_definitions.rb
+++ b/gems/aws-sdk-workdocs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workdocs") do
   @service = Aws::WorkDocs::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/resource.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/spec/spec_helper.rb
+++ b/gems/aws-sdk-workdocs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/features/env.rb
+++ b/gems/aws-sdk-workmail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/features/step_definitions.rb
+++ b/gems/aws-sdk-workmail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workmail") do
   @service = Aws::WorkMail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client_api.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/errors.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/resource.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/types.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/spec/spec_helper.rb
+++ b/gems/aws-sdk-workmail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/features/env.rb
+++ b/gems/aws-sdk-workspaces/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/features/step_definitions.rb
+++ b/gems/aws-sdk-workspaces/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workspaces") do
   @service = Aws::WorkSpaces::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client_api.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/errors.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/resource.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/types.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/spec/spec_helper.rb
+++ b/gems/aws-sdk-workspaces/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/features/env.rb
+++ b/gems/aws-sdk-xray/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/features/step_definitions.rb
+++ b/gems/aws-sdk-xray/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@xray") do
   @service = Aws::XRay::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/client.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/client_api.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/errors.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/resource.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/types.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/spec/spec_helper.rb
+++ b/gems/aws-sdk-xray/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk/lib/aws-sdk.rb
+++ b/gems/aws-sdk/lib/aws-sdk.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-resources'

--- a/gems/aws-sigv2/lib/aws-sigv2.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sigv2/credentials'
 require_relative 'aws-sigv2/signer'
 

--- a/gems/aws-sigv2/lib/aws-sigv2/credentials.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv2
     class Credentials

--- a/gems/aws-sigv2/lib/aws-sigv2/signer.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 require 'uri'

--- a/gems/aws-sigv4/lib/aws-sigv4.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sigv4/credentials'
 require_relative 'aws-sigv4/errors'
 require_relative 'aws-sigv4/signature'

--- a/gems/aws-sigv4/lib/aws-sigv4/credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     # Users that wish to configure static credentials can use the

--- a/gems/aws-sigv4/lib/aws-sigv4/errors.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     module Errors

--- a/gems/aws-sigv4/lib/aws-sigv4/request.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sigv4/lib/aws-sigv4/signature.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     class Signature

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'tempfile'
 require 'time'

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 require 'tempfile'

--- a/gems/aws-sigv4/spec/spec_helper.rb
+++ b/gems/aws-sigv4/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 $:.unshift(File.expand_path('../../lib', __FILE__))
 

--- a/gems/aws-sigv4/spec/suite_spec.rb
+++ b/gems/aws-sigv4/spec/suite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 desc 'Generates the code for every service'

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 task 'changelog:add' do
   Dir.glob('gems/*').each do |gem_dir|
     path = "#{gem_dir}/CHANGELOG.md"

--- a/tasks/gems.rake
+++ b/tasks/gems.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 desc 'Builds service gems'

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/core/rake_task'
 
 ##

--- a/tasks/update-aws-sdk-dependencies.rake
+++ b/tasks/update-aws-sdk-dependencies.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates list of service gems dependend on by the aws-sdk gem
 task 'update-aws-sdk-dependencies' do
 

--- a/tasks/update-partition-service-list.rake
+++ b/tasks/update-partition-service-list.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates the services in the aws-partitions gem
 task 'update-partition-service-list' do
   lines = []

--- a/tasks/update-readme.rake
+++ b/tasks/update-readme.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates the table of supported services in the repo README
 task 'update-readme' do
 

--- a/tasks/update-sensitive-params.rake
+++ b/tasks/update-sensitive-params.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rebuilds the list of parameters that should be filtered when logging
 task 'update-sensitive-params' do
   sensitive = []


### PR DESCRIPTION
This will prevent unnecessary allocations of strings. There were a few
files that I had to remove it from because they depend on being able to
mutate strings. Those files were:

gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
