### PR TITLE
Exclude eventstream operations from V2

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/api/customizations.rb
@@ -27,7 +27,7 @@ module Aws
           metadata = api['metadata'] || {}
           prefix = metadata['endpointPrefix']
           # event stream is not supported at V2
-          api = exclude_eventstream(api)
+          api = exclude_eventstream(api) if api['operations']
           @apis[prefix].call(api) if @apis[prefix]
         end
 


### PR DESCRIPTION
eventstream concept is public, and this PR is for excluding eventstream operations for V2 SDK