### PR TITLE
Exclude eventstream operations in V3 [Delay Support, Temporary]

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -30,7 +30,10 @@ module AwsSdkCodeGenerator
           if @service.protocol == 'api-gateway'
             shape_name = lstrip_prefix(upcase_first(shape_name))
           end
-          if struct_type?(shape)
+          # exclude eventstream and event shapes
+          if shape['eventstream'] || shape['event']
+            list
+          elsif struct_type?(shape)
             list << StructClass.new(
               class_name: shape_name,
               members: struct_members(shape),


### PR DESCRIPTION
eventstream concept is public, and this PR is for delay eventstream operations support for V3 SDK.
This avoids generation for eventstream operations and related shapes.