### PR TITLE
require `cluster` for ECS DescribeTasks

### DIFF
--- a/apis/ecs/2014-11-13/api-2.json
+++ b/apis/ecs/2014-11-13/api-2.json
@@ -972,7 +972,7 @@
     },
     "DescribeTasksRequest":{
       "type":"structure",
-      "required":["tasks"],
+      "required":["cluster", "tasks"],
       "members":{
         "cluster":{"shape":"String"},
         "tasks":{"shape":"StringList"}

--- a/apis/ecs/2014-11-13/examples-1.json
+++ b/apis/ecs/2014-11-13/examples-1.json
@@ -484,6 +484,7 @@
     "DescribeTasks": [
       {
         "input": {
+          "cluster": "arn:aws:ecs:<region>:<aws_account_id>:cluster/default",
           "tasks": [
             "c5cba4eb-5dad-405e-96db-71ef8eefe6a8"
           ]


### PR DESCRIPTION
`Aws::ECS::Client#describe_tasks` will permit an API request to be sent
without the `cluster` request parameter, but such a request will always
be met with a response containing a populated `failures` array. The
reason given for each failure is `MISSING`.

```
> ecs_client.describe_tasks(tasks: %w[a8d82dbd-4796-451b-bc8d-21ef77285d9f])
  failures = [
    [0] #<#<Class:0x00007f85114428a0>:Aws::ECS::Types::Failure:0x7f8511f3d408
      arn = "arn:aws:ecs:us-east-1:963710170562:task/a8d82dbd-4796-451b-bc8d-21ef77285d9f",
      reason = "MISSING"
    >
  ],
  tasks = []
```

When the `cluster` request parameter is included and set equal to a
valid value (the arn for a cluster that the submitted task arns are
associated with), the response comes back as desired without any
failures.

It seems that the documentation should be updated to reflect that
`cluster` is in fact a request request parameter.

Thank you for your contribution!

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md
