### PR TITLE
The Cognito Identity Provider InitiateAuth action does not require a signed request

### DIFF
--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
@@ -2739,6 +2739,7 @@ module Aws::CognitoIdentityProvider
         o.name = "InitiateAuth"
         o.http_method = "POST"
         o.http_request_uri = "/"
+        o['authtype'] = "none"
         o.input = Shapes::ShapeRef.new(shape: InitiateAuthRequest)
         o.output = Shapes::ShapeRef.new(shape: InitiateAuthResponse)
         o.errors << Shapes::ShapeRef.new(shape: ResourceNotFoundException)

--- a/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
@@ -10,6 +10,16 @@ module Aws
         expect(resp.context.http_request.headers['Authorization']).to be(nil)
       end
 
+      it "does not sign calls to initiate_auth" do
+        client = Client.new(stub_responses: true)
+        resp = client.initiate_auth(
+          client_id:'id',
+          auth_flow: 'USER_PASSWORD_AUTH',
+          auth_parameters: {}
+        )
+        expect(resp.context.http_request.headers['Authorization']).to be(nil)
+      end
+
     end
   end
 end


### PR DESCRIPTION
This is the API called by the JavaScript, iOS, and Android clients where the IAM keys may not be available for security reasons.

Verified with `httpie`:

```
http --debug POST https://cognito-idp.us-east-1.amazonaws.com/ X-Amz-Target:AWSCognitoIdentityProviderService.InitiateAuth ClientId=clientId AuthFlow=USER_PASSWORD_AUTH AuthParameters:='{"USERNAME":"username","PASSWORD":"password"}' Content-Type:application/x-amz-json-1.1
```

I suspect that `RespondToAuthChallenge` should also be `o['authtype'] = "none"`, but it is not needed by my particular use case (I am implementing a user-level client in Ruby; that is, the user is using the Ruby client the same way it would be using the JavaScript client).

In the interim, this behaviour can be monkey-patched with

```ruby
Aws::CognitoIdentityProvider::ClientApi::API.operation(:initiate_auth)['authtype'] = 'none'
```

as long as it is applied before `Aws::CognitoIdentifier::Client.new`.