### PR TITLE
[Fix] S3 Accelerate endpoint doesn't work with expect header

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - S3 accelerate endpoint doesn't work with 'expect' header
+
 1.9.0 (2018-04-04)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -60,6 +60,8 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
             endpoint.port = 443
             endpoint.host = "#{bucket_name}.s3-accelerate.amazonaws.com"
             context.http_request.endpoint = endpoint.to_s
+            # s3 accelerate endpoint doesn't work with 'expect' header
+            context.http_request.headers.delete('expect')
           end
 
           def use_combined_accelerate_dualstack_endpoint(context)
@@ -70,6 +72,8 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
             endpoint.port = 443
             endpoint.host = "#{bucket_name}.s3-accelerate.dualstack.amazonaws.com"
             context.http_request.endpoint = endpoint.to_s
+            # s3 accelerate endpoint doesn't work with 'expect' header
+            context.http_request.headers.delete('expect')
           end
 
           def validate_bucket_name!(bucket_name)

--- a/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
@@ -65,6 +65,10 @@ module Aws
           expect(resp.context.http_request.endpoint.to_s).to eq('https://bucket-name.s3.amazonaws.com/')
         end
 
+        it 'does not contain `expect` header in request' do
+          resp = accelerated_client.put_object(bucket:'bucket-name', key:'key', body: 'foo')
+          expect(resp.context.http_request.headers['expect']).to be_nil
+        end
       end
 
       describe ':use_accelerate_endpoint with :use_dualstack_endpoint' do
@@ -88,6 +92,11 @@ module Aws
         it 'does not apply to #delete_bucket' do
           resp = accel_dualstack_client.delete_bucket(bucket:'bucket-name')
           expect(resp.context.http_request.endpoint.to_s).to eq('https://bucket-name.s3.dualstack.us-east-1.amazonaws.com/')
+        end
+
+        it 'does not contain `expect` header in request' do
+          resp = accel_dualstack_client.put_object(bucket:'bucket-name', key:'key', body: 'foo')
+          expect(resp.context.http_request.headers['expect']).to be_nil
         end
         
       end


### PR DESCRIPTION
As title
CF strips those headers :( 
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html