### PR TITLE
RUBY_VERSION <= ‘1.9.3’ < ‘2.0’

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
@@ -12,7 +12,7 @@ module Seahorse
           if RUBY_VERSION >= '2.0' && RUBY_VERSION < '2.5'
             Net::HTTP.send(:include, Ruby_2)
             Net::HTTP::IDEMPOTENT_METHODS_.clear
-          elsif RUBY_VERSION >= '1.9.3'
+          elsif RUBY_VERSION >= '1.9.3' && RUBY_VERSION < '2.0'
             Net::HTTP.send(:include, Ruby_1_9_3)
           end
           Net::HTTP.send(:alias_method, :old_transport_request, :transport_request)


### PR DESCRIPTION
RUBY_VERSION <= ‘1.9.3’ < ‘2.0’
Must specify ruby version range for Ruby_1_9_3 patch, otherwise it will be applied to 2.5.0 or greater. Which I believe is unintended. A Ruby 2.5 environment should not include the Ruby_1_9_3 module patch.