### PR TITLE
Fix to support URI encoded characters in http_proxy

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix to support URI encoded characters in http_proxy
+
 3.21.2 (2018-05-22)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'net/http'
 require 'net/https'
 require 'delegate'
@@ -252,6 +253,17 @@ module Seahorse
 
         private
 
+        # Extract the parts of the http_proxy URI
+        # @return [Array(String)]
+        def http_proxy_parts
+          return [
+            http_proxy.host,
+            http_proxy.port,
+            (http_proxy.user && CGI::unescape(http_proxy.user)),
+            (http_proxy.password && CGI::unescape(http_proxy.password))
+          ]
+        end
+
         # Starts and returns a new HTTP(S) session.
         # @param [String] endpoint
         # @return [Net::HTTPSession]
@@ -262,10 +274,7 @@ module Seahorse
           args = []
           args << endpoint.host
           args << endpoint.port
-          args << http_proxy.host
-          args << http_proxy.port
-          args << http_proxy.user
-          args << http_proxy.password
+          args += http_proxy_parts
 
           http = ExtendedSession.new(Net::HTTP.new(*args.compact))
           http.set_debug_output(logger) if http_wire_trace?

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
@@ -4,6 +4,25 @@ module Seahorse
   module Client
     module NetHttp
       describe ConnectionPool do
+        describe "#http_proxy_parts (private)" do
+          it "with a regular URI" do
+            http_proxy = URI.parse('http://proxy.com:8080')
+            pool = described_class.new(:http_proxy => http_proxy)
+            expect(pool.send(:http_proxy_parts)).to eq ["proxy.com", 8080, nil, nil]
+          end
+
+          it "with a URI with username and password" do
+            http_proxy = URI.parse('http://username:password@proxy.com:8080')
+            pool = described_class.new(:http_proxy => http_proxy)
+            expect(pool.send(:http_proxy_parts)).to eq ["proxy.com", 8080, "username", "password"]
+          end
+
+          it "with a URI with username and password with special characters" do
+            http_proxy = URI.parse('http://%3A%40%2Fusername:password%3A%40%2F@proxy.com:8080')
+            pool = described_class.new(:http_proxy => http_proxy)
+            expect(pool.send(:http_proxy_parts)).to eq ["proxy.com", 8080, ":@/username", "password:@/"]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
See #458, where this was fixed previously but was somehow lost.

As this class has no specs previously, I broke the part I changed out into a separate private method and just tested that.  I was unsure how to test it end-to-end, otherwise.