### PR TITLE
instance_profile_credentials.rb: add User-Agent to the metadata crede…

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Aws::InstanceProfileCredentials - Add sending a User-Agent other than the default User-Agent in Ruby.  Make the User-Agent `aws-sdk-ruby3/<version>` to allow protection against Server Side Request Forgery (SSRF) credential theft vectors by use of a metadata proxy 
+* Feature - Aws::InstanceProfileCredentials - Add sending a User-Agent other than the default User-Agent in Ruby.  Adding the User-Agent `aws-sdk-ruby3/<version>` to allow protection against Server Side Request Forgery (SSRF) credential theft vectors by use of a metadata proxy.  
 
 3.19.0 (2018-04-04)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::InstanceProfileCredentials - Add sending a User-Agent other than the default User-Agent in Ruby.  Make the User-Agent `aws-sdk-ruby3/<version>` to allow protection against Server Side Request Forgery (SSRF) credential theft vectors by use of a metadata proxy 
+
 3.19.0 (2018-04-04)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -115,7 +115,7 @@ module Aws
     end
 
     def http_get(connection, path)
-      response = connection.request(Net::HTTP::Get.new(path))
+      response = connection.request(Net::HTTP::Get.new(path, {"User-Agent" => "aws-sdk-ruby3/#{CORE_GEM_VERSION}"}))
       if response.code.to_i == 200
         response.body
       else


### PR DESCRIPTION
Adds the sending of a User-Agent other than the default User-Agent used, 'Ruby'.  Similar to golang SDK
that starts with aws-sdk-go/1.8.19.

This will enable protection of AWS credentials from Server Side Request Forgery (SSRF) vectors by using a metadata proxy and rejecting User-Agents that do not meet a regex.