### PR TITLE
Fix documentation error

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -52,7 +52,7 @@ module Aws
     end
 
     # @return [Integer] The number of times to retry failed attempts to
-    #   fetch credentials from the instance metadata service. Defaults to 0.
+    #   fetch credentials from the instance metadata service. Defaults to 5.
     attr_reader :retries
 
     private


### PR DESCRIPTION
Retries defaults to 5 if not specified in initialiser (not 0).
