### PR TITLE
Make aws-sdk-v1 resilient to security groups long ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Makes aws-sdk-v1 resilient to security groups long ids. Following the move to longer ids, `AutoScaling::LaunchConfiguration` fails a regex testing the length of `SecurityGroup` ids.
+
 1.67.0 (2017-04-03)
 ------------------
 

--- a/lib/aws/auto_scaling/launch_configuration.rb
+++ b/lib/aws/auto_scaling/launch_configuration.rb
@@ -150,7 +150,7 @@ module AWS
       protected
 
       def get_security_groups(names_or_ids)
-        if names_or_ids.all?{|str| str.match(/^sg-[0-9a-f]{8}$/) }
+        if names_or_ids.all?{|str| str.match(/^sg-[0-9a-f]{8,}$/) }
           names_or_ids.collect do |security_group_id|
             EC2::SecurityGroup.new(security_group_id, :config => config)
           end

--- a/spec/aws/auto_scaling/launch_configuration_spec.rb
+++ b/spec/aws/auto_scaling/launch_configuration_spec.rb
@@ -98,10 +98,10 @@ module AWS
 
         it 'returns security groups with id patterns' do
           groups
-          groups << 'sg-12345678'
+          groups << 'sg-12345678910121416'
           groups << 'sg-22345678'
           launch_config.security_groups.should == [
-            EC2::SecurityGroup.new('sg-12345678', :config => config),
+            EC2::SecurityGroup.new('sg-12345678910121416', :config => config),
             EC2::SecurityGroup.new('sg-22345678', :config => config),
           ]
         end


### PR DESCRIPTION
Even though deprecated, aws-sdk-v1 is still useful.
The move to long ids breaks `AutoScaling::LaunchConfiguration` because it checks the length of security groups id.

Editing the test demonstrates the problem:

```
Failures:

  1) AWS::AutoScaling::LaunchConfiguration#security_groups returns security groups with id patterns
     Failure/Error: ]
       expected: [<AWS::EC2::SecurityGroup id:sg-12345678910121416>, <AWS::EC2::SecurityGroup id:sg-22345678>]
            got: [] (using ==)
       Diff:
       @@ -1,3 +1,2 @@
       -[<AWS::EC2::SecurityGroup id:sg-12345678910121416>,
       - <AWS::EC2::SecurityGroup id:sg-22345678>]
       +[]
     # ./spec/aws/auto_scaling/launch_configuration_spec.rb:106:in `block (3 levels) in <class:AutoScaling>'
```

This commit fixes the issue.
