### PR TITLE
Rescue `EncodingError` from `oj`

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Rescue `EncodingError` raised by `oj` on JSON documents with new line.
+
 3.20.2 (2018-04-26)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
@@ -23,7 +23,7 @@ module Aws
 
       def load(json)
         ENGINE.load(json, *ENGINE_LOAD_OPTIONS)
-      rescue ENGINE_ERROR => e
+      rescue *ENGINE_ERROR => e
         raise ParseError.new(e)
       end
 
@@ -45,15 +45,15 @@ module Aws
       end
 
       def json_engine
-        [JSON, [], [], JSON::ParserError]
+        [JSON, [], [], [JSON::ParserError]]
       end
 
       def oj_parse_error
         if Oj.const_defined?('ParseError')
-          Oj::ParseError
+          [Oj::ParseError]
         else
-          SyntaxError
-        end
+          [SyntaxError]
+        end << EncodingError
       end
 
     end

--- a/gems/aws-sdk-core/spec/aws/json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../spec_helper'
+
+module Aws
+  describe Json do
+    describe '.load' do
+      subject(:load) { described_class.load(json) }
+
+      context 'with valid JSON' do
+        let(:json) { "{}" }
+
+        it { expect { load }.not_to raise_error(Aws::Json::ParseError) }
+      end
+
+      context 'with invalid JSON' do
+        let(:json) do
+          '<html><body><b>Http/1.1 Service Unavailable</b></body> </html>
+            '
+        end
+
+        it { expect { load }.to raise_error(Aws::Json::ParseError) }
+
+        if !ENV["PURE_RUBY"]
+          it { expect { load }.not_to raise_error(EncodingError) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby: 2.5.1

After upgrading to `aws-sdk-core` to `3.20.2` we have started receiving the following error in some of our DynamoDB queries:

```
EncodingError: Empty input at line 1, column 1 [parse.c:928] in '<html><body><b>Http/1.1 Service Unavailable</b></body> </html>
'
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json.rb" line 25 in load
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json.rb" line 25 in load
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json/error_handler.rb" line 17 in extract_error
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/xml/error_handler.rb" line 22 in error
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json/error_handler.rb" line 9 in block in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/response.rb" line 45 in block in on
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/http/response.rb" line 139 in block in on_success
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/http/response.rb" line 166 in block in listener
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/http/response.rb" line 130 in on_done
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/http/response.rb" line 137 in on_success
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/response.rb" line 44 in on
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json/error_handler.rb" line 8 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/signature_v4.rb" line 66 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/helpful_socket_errors.rb" line 10 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/retry_errors.rb" line 92 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/json/handler.rb" line 11 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/user_agent.rb" line 13 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/plugins/endpoint.rb" line 45 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/param_validator.rb" line 24 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/plugins/raise_response_errors.rb" line 14 in call
"/usr/local/bundle/gems/aws-sdk-dynamodb-1.6.0/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb" line 117 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/jsonvalue_converter.rb" line 20 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/idempotency_token.rb" line 17 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/param_converter.rb" line 24 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/aws-sdk-core/plugins/response_paging.rb" line 10 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/plugins/response_target.rb" line 23 in call
"/usr/local/bundle/gems/aws-sdk-core-3.20.2/lib/seahorse/client/request.rb" line 70 in send_request
"/usr/local/bundle/gems/aws-sdk-dynamodb-1.6.0/lib/aws-sdk-dynamodb/client.rb" line 735 in batch_write_item
```

Upon investigation we have noticed, that the following string (new line is important) is causing `oj` gem to raise `EncodingError` instead of `Oj::ParseError`.

```
'<html><body><b>Http/1.1 Service Unavailable</b></body> </html>
'
```

The patch provided adds `EncodingError` to the list of expected error for rewrapping to `Aws::Json::ParseError`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
