### PR TITLE
Fix JRuby Issues with IO.copy_stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - jruby-9.1.5.0
+  - jruby-9.1.16.0
 
 sudo: false
 
@@ -22,7 +22,7 @@ bundler_args: --without docs release repl
 
 matrix:
   exclude:
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.1.16.0
       env: KITCHEN_SINK=1
   include:
     - rvm: 2.3

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -219,6 +219,9 @@ module Aws
       #     # Passed chunks automatically split into multiupart multipart upload parts
       #     # and the parts are uploaded in parallel. This allows for streaming uploads
       #     # that never touch the disk.
+      #
+      #  Note that this is known to have issues in JRuby until jruby-9.1.15.0, so avoid using this with older versions of JRuby.
+      #
       # @example Streaming chunks of data
       #     obj.upload_file do |write_stream|
       #       10.times { write_stream << 'hello' }

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -2,6 +2,7 @@ require 'thread'
 require 'set'
 require 'tempfile'
 require 'stringio'
+
 module Aws
   module S3
     # @api private
@@ -105,7 +106,13 @@ module Aws
         return if read_pipe.closed?
         temp_io = @tempfile ? Tempfile.new(TEMPFILE_PREIX) : StringIO.new
         temp_io.binmode
-        bytes_copied = IO.copy_stream(read_pipe, temp_io, @part_size)
+        buffer = read_pipe.read(@part_size)
+        if buffer
+          temp_io.write(buffer)
+          bytes_copied = buffer.bytesize
+        else
+          bytes_copied = 0
+        end
         temp_io.rewind
         if bytes_copied == 0
           if Tempfile === temp_io

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -106,13 +106,7 @@ module Aws
         return if read_pipe.closed?
         temp_io = @tempfile ? Tempfile.new(TEMPFILE_PREIX) : StringIO.new
         temp_io.binmode
-        buffer = read_pipe.read(@part_size)
-        if buffer
-          temp_io.write(buffer)
-          bytes_copied = buffer.bytesize
-        else
-          bytes_copied = 0
-        end
+        bytes_copied = IO.copy_stream(read_pipe, temp_io, @part_size)
         temp_io.rewind
         if bytes_copied == 0
           if Tempfile === temp_io


### PR DESCRIPTION
In short, JRuby had some major issues around IO.copy_stream until about
`9.1.15.0`, with even more fixes coming in `9.1.16.0`. This proposed
patch works around that issue and integration tests are passing in
JRuby.

Fixes #1711

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
