### PR TITLE
add acm CertificateValidated waiter

### DIFF
--- a/apis/acm/2015-12-08/waiters-2.json
+++ b/apis/acm/2015-12-08/waiters-2.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "waiters": {
-    "CertificateIssued": {
+    "CertificateValidated": {
       "delay": 60,
       "maxAttempts": 40,
       "operation": "DescribeCertificate",

--- a/apis/acm/2015-12-08/waiters-2.json
+++ b/apis/acm/2015-12-08/waiters-2.json
@@ -1,0 +1,35 @@
+{
+  "version": 2,
+  "waiters": {
+    "CertificateIssued": {
+      "delay": 60,
+      "maxAttempts": 40,
+      "operation": "DescribeCertificate",
+      "acceptors": [
+        {
+          "matcher": "pathAll",
+          "expected": "SUCCESS",
+          "argument": "Certificate.DomainValidationOptions[].ValidationStatus",
+          "state": "success"
+        },
+        {
+          "matcher": "pathAny",
+          "expected": "PENDING_VALIDATION",
+          "argument": "Certificate.DomainValidationOptions[].ValidationStatus",
+          "state": "retry"
+        },
+        {
+          "matcher": "pathAny",
+          "expected": "FAILED",
+          "argument": "Certificate.Status",
+          "state": "failure"
+        },
+        {
+          "matcher": "error",
+          "expected": "ResourceNotFoundException",
+          "state": "failure"
+        }
+      ]
+    }
+  }
+}

--- a/gems/aws-sdk-acm/CHANGELOG.md
+++ b/gems/aws-sdk-acm/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Add DescribeCertificate waiter.
+* Feature - Add CertificateValidated waiter.
 
 1.7.0 (2018-05-02)
 ------------------

--- a/gems/aws-sdk-acm/CHANGELOG.md
+++ b/gems/aws-sdk-acm/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add DescribeCertificate waiter.
+
 1.7.0 (2018-05-02)
 ------------------
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This adds a `DescribeCertificate` waiter to `aws-sdk-acm`. I was working on a deploy pipeline that uses the SDK, and needed to wait for certificate validation before the pipeline continues.

First time contributing to the generated code in `apis/`. I read through the Contributing doc but please let me know if there's anything I need to add!

The one thing I know may need to be revised is the error matcher - not sure if I've specified the "expected" value correctly. Thanks!