### PR TITLE
Support object versioning for #download_file

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Supports `:version_id` for resource `#download_file` helper
+
 1.15.0 (2018-06-26)
 ------------------
 

--- a/gems/aws-sdk-s3/features/resources/download_file.feature
+++ b/gems/aws-sdk-s3/features/resources/download_file.feature
@@ -83,3 +83,15 @@ Feature: Managed file download
     Then 12 get_object requests should have been made
     And those downloaded files should match the uploaded file
     And these test file has been cleaned up
+
+  @auto @version-id @large-file
+  Scenario: Download an object with its version id
+    Given I enabled bucket versioning
+    And I have a 16M file
+    And I upload the file
+    And I have a 1M file
+    And I upload the file with same key
+    When I download the file with previous version id
+    Then 4 get_object requests should have been made
+    And the download file should match the previous version object
+    And this test file has been cleaned up

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -333,6 +333,10 @@ module Aws
       # @option options [String] thread_count Customize threads used in multipart
       #   download, if not provided, 10 is default value
       #
+      # @option options [String] version_id The object version id used to retrieve
+      #   the object, to know more about object versioning, see:
+      #   https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectVersioning.html
+      #
       # @return [Boolean] Returns `true` when the file is downloaded
       #   without any errors.
       def download_file(destination, options = {})


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Addressing feature request #1770 

I didn't take in all available parameters available for `head_object` and `get_object` because:

1. there is a diff in the parameters these 2 operations accepts
2. some of the parameters doesn't make a lot of sense when introduced in downloader
3. introducing all current supports parameters would require more sophisticated testing for those scenarios.
4. the current PR interface for the downloader would allow easy add for extra parameters in the future. 