### PR TITLE
Calling Aws::Route53::Client#change_resource_record_sets passing an instance of ChangeResourceRecordSetsRequest throws an error

### DIFF
--- a/gems/aws-sdk-route53/CHANGELOG.md
+++ b/gems/aws-sdk-route53/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased Changes
 ------------------
 
+1.11.0 (2018-06-26)
+------------------
+
+* Issue - Update `IdFix` plugin to work with Hash and Struct requests.
+
 1.10.0 (2018-06-26)
 ------------------
 

--- a/gems/aws-sdk-route53/CHANGELOG.md
+++ b/gems/aws-sdk-route53/CHANGELOG.md
@@ -1,9 +1,6 @@
 Unreleased Changes
 ------------------
 
-1.11.0 (2018-06-26)
-------------------
-
 * Issue - Update `IdFix` plugin to work with Hash and Struct requests.
 
 1.10.0 (2018-06-26)

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
@@ -29,7 +29,7 @@ module Aws
             # Many operations accept of :id or :hosted_zone_id as a root-level
             # param, pruning prefixes from those.
             [:id, :hosted_zone_id, :delegation_set_id].each do |key|
-              params[key] = remove_prefix(params[key]) if params[key]
+              params[key] = remove_prefix(params[key]) if params.to_hash.key?(key)
             end
 
             # The `#change_resource_record_sets operation` has a deeply nested

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
@@ -29,7 +29,7 @@ module Aws
             # Many operations accept of :id or :hosted_zone_id as a root-level
             # param, pruning prefixes from those.
             [:id, :hosted_zone_id, :delegation_set_id].each do |key|
-              params[key] = remove_prefix(params[key]) if params.to_hash.key?(key)
+              params[key] = remove_prefix(params[key]) if params.to_h.key?(key)
             end
 
             # The `#change_resource_record_sets operation` has a deeply nested

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
@@ -29,7 +29,7 @@ module Aws
             # Many operations accept of :id or :hosted_zone_id as a root-level
             # param, pruning prefixes from those.
             [:id, :hosted_zone_id, :delegation_set_id].each do |key|
-              params[key] = remove_prefix(params[key]) if params.to_h.key?(key)
+              params[key] = remove_prefix(params[key]) if params.to_hash.key?(key)
             end
 
             # The `#change_resource_record_sets operation` has a deeply nested

--- a/gems/aws-sdk-route53/spec/client_spec.rb
+++ b/gems/aws-sdk-route53/spec/client_spec.rb
@@ -81,6 +81,42 @@ module Aws
           )
         end
 
+        it 'removes prefixes from the nested targets when params is typeof ChangeResourceRecordSetsRequest' do
+          client.handle(step: :send) do |context|
+            context.http_response.status_code = 200
+            Seahorse::Client::Response.new(context: context)
+          end
+
+          params = Aws::Route53::Types::ChangeResourceRecordSetsRequest.new(
+            hosted_zone_id: '/hostedzone/zoneid',
+            change_batch: {
+              changes: [
+                {
+                  action: 'action',
+                  resource_record_set: {
+                    name: 'name',
+                    type: 'type',
+                    alias_target: {
+                      dns_name: 'dns-name',
+                      evaluate_target_health: false,
+                      hosted_zone_id: '/hostedzone/target'
+                    }
+                  }
+                }
+              ]
+            }
+          )
+
+
+          resp = client.change_resource_record_sets(params)
+          expect(resp.context.http_request.endpoint.path).to match(
+            %r{^/\d{4}-\d{2}-\d{2}/hostedzone/zoneid/rrset/$}
+          )
+          expect(resp.context.http_request.body_contents).to match(
+            '<HostedZoneId>target</HostedZoneId>'
+          )
+        end
+
       end
 
       describe '#get_traffic_policy' do

--- a/gems/aws-sdk-route53/spec/client_spec.rb
+++ b/gems/aws-sdk-route53/spec/client_spec.rb
@@ -107,7 +107,6 @@ module Aws
             }
           )
 
-
           resp = client.change_resource_record_sets(params)
           expect(resp.context.http_request.endpoint.path).to match(
             %r{^/\d{4}-\d{2}-\d{2}/hostedzone/zoneid/rrset/$}
@@ -116,7 +115,6 @@ module Aws
             '<HostedZoneId>target</HostedZoneId>'
           )
         end
-
       end
 
       describe '#get_traffic_policy' do


### PR DESCRIPTION
Bug fix for issue https://github.com/aws/aws-sdk-ruby/issues/1813

When calling Aws::Route53::Client#change_resource_record_sets passing an instance of Aws::Route53::Types::ChangeResourceRecordSetsRequest instead of a Hash, the following error is being thrown: no member 'id' in struct.

This fix makes sure to convert the Struct to hash by using the #to_hash method before trying to find the the given key exists in it. If a Hash is passed, the #.to_hash method will return self. This is to ensure compatibility between ruby versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
