### PR TITLE
Avoid redirects for FIPS endpoint even if 307 with location provided

### DIFF
--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -15,7 +15,7 @@ def whitelist
     },
     "s3" => {
       "location_constraint.rb" => 12,
-      "s3_signer.rb" => 195
+      "s3_signer.rb" => 198
     }
   }
 end

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -15,7 +15,7 @@ def whitelist
     },
     "s3" => {
       "location_constraint.rb" => 12,
-      "s3_signer.rb" => 198
+      "s3_signer.rb" => 199
     }
   }
 end

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Avoids region redirects for FIPS endpoints
+
 1.16.0 (2018-06-28)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
@@ -18,7 +18,9 @@ by Amazon S3.
             response = @handler.call(context)
             if context.http_response.status_code == 307
               endpoint = context.http_response.headers['location']
-              context.http_request.endpoint = endpoint
+              unless context.http_request.endpoint.host.include?('fips')
+                context.http_request.endpoint = endpoint
+              end
               context.http_response.body.truncate(0)
               @handler.call(context)
             else

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -121,10 +121,10 @@ module Aws
           end
 
           def get_region_and_retry(context)
-            actual_region = context.http_response.headers['x-amz-bucket-region']
-            actual_region ||= region_from_body(context.http_response.body_contents)
-            # disable retry for fips endpoints
+            # disable region detect and retry for fips endpoints
             unless context.http_request.endpoint.host.include?('fips')
+              actual_region = context.http_response.headers['x-amz-bucket-region']
+              actual_region ||= region_from_body(context.http_response.body_contents)
               update_bucket_cache(context, actual_region)
               log_warning(context, actual_region)
               resign_with_new_region(context, actual_region)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -124,7 +124,7 @@ module Aws
             actual_region = context.http_response.headers['x-amz-bucket-region']
             actual_region ||= region_from_body(context.http_response.body_contents)
             # disable retry for fips endpoints
-            unless fips_endpoint?(context, actual_region)
+            unless context.http_request.endpoint.host.include?('fips')
               update_bucket_cache(context, actual_region)
               log_warning(context, actual_region)
               resign_with_new_region(context, actual_region)
@@ -134,10 +134,6 @@ module Aws
 
           def update_bucket_cache(context, actual_region)
             S3::BUCKET_REGIONS[context.params[:bucket]] = actual_region
-          end
-
-          def fips_endpoint?(context, actual_region)
-            context.http_request.endpoint.host.include?('fips') || actual_region.include?('fips')
           end
 
           def wrong_sigv4_region?(resp)

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -43,6 +43,9 @@ module Aws
           stub_request(:put, 'https://bucket.s3.us-west-2.amazonaws.com/key').
             to_return(status: [400, 'Bad Request'], body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'</Message><Region>eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId><HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oekWlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>")
 
+          stub_request(:put, 'https://bucket.s3-fips.us-west-2.amazonaws.com/keya').
+            to_return(status: [400, 'Bad Request'], body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region 'us-west-2' is wrong; expecting 'eu-central-1'</Message><Region>eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId><HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oekWlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>")
+
           stub_request(:put, 'https://bucket.s3.eu-central-1.amazonaws.com/key').
             to_return(status: [200, 'Ok'])
 
@@ -71,6 +74,16 @@ module Aws
           }.to raise_error(Aws::S3::Errors::Http307Error)
 
         end
+
+        it 'never fix endpoint for fips regions' do
+          client = S3::Client.new(client_opts.merge(
+            region: 'us-west-2', endpoint: 'https://s3-fips.us-west-2.amazonaws.com')
+          )
+          expect {
+            client.put_object(bucket:'bucket', key:'keya', body:'body')
+          }.to raise_error(Aws::S3::Errors::AuthorizationHeaderMalformed)
+        end
+
       end
     end
   end

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -46,6 +46,11 @@ module Aws
           stub_request(:put, 'https://bucket.s3.eu-central-1.amazonaws.com/key').
             to_return(status: [200, 'Ok'])
 
+          stub_request(:put, 'https://bucket.s3-fips.us-west-2.amazonaws.com/key').
+            to_return(status: [307, 'Temporary Redirect'], headers: {
+              'Location' => 'https://bucket.s3.eu-central-1.amazonaws.com/key'
+            })
+
         end
 
         it 'detects the moved permanently and redirects' do
@@ -57,6 +62,15 @@ module Aws
           expect(host).to eq('bucket.s3.eu-central-1.amazonaws.com')
         end
 
+        it 'never redirect fips endpoints' do
+          client = S3::Client.new(client_opts.merge(
+            region: 'us-west-2', endpoint: 'https://s3-fips.us-west-2.amazonaws.com')
+          )
+          expect {
+            client.put_object(bucket:'bucket', key:'key', body:'body')
+          }.to raise_error(Aws::S3::Errors::Http307Error)
+
+        end
       end
     end
   end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Cannot reproduce this every time with real request made to S3, but this PR should cover it if ever happens. Many times, S3 FIPS endpoint would throw hard fail error instead of 307 code.