### PR TITLE
Reduce memory usage of Aws::S3::Object#upload_stream

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Reduce memory usage of `Aws::S3::Object#upload_stream` when `StringIO` is used
+
 1.36.0 (2019-03-27)
 ------------------
 

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Reduce memory usage of `Aws::S3::Object#upload_stream` when `StringIO` is used
+* Issue - Reduce memory usage of `Aws::S3::Object#upload_stream` when `StringIO` is used
 
 1.36.0 (2019-03-27)
 ------------------

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -141,6 +141,8 @@ module Aws
                   if Tempfile === body
                     body.close
                     body.unlink
+                  elsif StringIO === body
+                    body.string.clear
                   end
                 end
               end


### PR DESCRIPTION
Once we've taken content from the pipe and uploaded it, we can safely deallocate it. This change greatly reduces memory usage of Aws::S3::Object#upload_stream; when I profiled with a 15MB file, the memory usage went from **17MB** to just **2MB**.