### PR TITLE
Logged API Requests interface

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add Logged API Requests interface to stubbed clients
+
 3.22.1 (2018-06-28)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -27,9 +27,8 @@ module Aws
       requests = @api_requests
       self.handle do |context|
         requests << {
-          metadata: context.metadata,
-          request: context.http_request,
-          response: context.http_response,
+          operation_name: context.operation_name,
+          params: context.params,
           context: context
         }
         @handler.call(context)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -6,6 +6,9 @@ module Aws
   # return when a client is using stubbed responses. Pass
   # `:stub_responses => true` to a client constructor to enable this
   # behavior.
+  #
+  # Also allows you to see the requests made by the client by reading the
+  # api_requests instance variable
   module ClientStubs
 
     # @api private
@@ -17,6 +20,16 @@ module Aws
           apply_stubs(operation_name, Array === stubs ? stubs : [stubs])
         end
       end
+
+      # When a client is stubbed allow the user to access the requests made
+      @api_requests = []
+
+      requests = @api_requests
+      self.handle do |context|
+        requests << context
+        @handler.call(context)
+      end
+      self.class.attr_reader :api_requests
     end
 
     # Configures what data / errors should be returned from the named operation

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -29,7 +29,6 @@ module Aws
         requests << context
         @handler.call(context)
       end
-      self.class.attr_reader :api_requests
     end
 
     # Configures what data / errors should be returned from the named operation
@@ -175,6 +174,16 @@ module Aws
       else
         msg = 'stubbing is not enabled; enable stubbing in the constructor '
         msg << 'with `:stub_responses => true`'
+        raise msg
+      end
+    end
+
+    def api_requests
+      if config.stub_responses
+        @api_requests
+      else
+        msg = 'you must enable stubbing in order to client requests;'
+        msg << ' enable stubbing in the constructor with `:stub_responses => true`'
         raise msg
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -184,7 +184,8 @@ module Aws
 
     # Allows you to access all of the requests that the stubbed client has made
     #
-    # @return [Array] Returns an array of the api requests made
+    # @return [Array] Returns an array of the api requests made, each request object contains the
+    #                 :operation_name, :params, and :context of the request. 
     # @raise [NotImplementedError] Raises `NotImplementedError` when the client is not stubbed
     def api_requests
       if config.stub_responses

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -26,7 +26,12 @@ module Aws
 
       requests = @api_requests
       self.handle do |context|
-        requests << context
+        requests << {
+          metadata: context.metadata,
+          request: context.http_request,
+          response: context.http_response,
+          context: context
+        }
         @handler.call(context)
       end
     end
@@ -178,13 +183,17 @@ module Aws
       end
     end
 
+    # Allows you to access all of the requests that the stubbed client has made
+    #
+    # @return [Array] Returns an array of the api requests made
+    # @raise [NotImplementedError] Raises `NotImplementedError` when the client is not stubbed
     def api_requests
       if config.stub_responses
         @api_requests
       else
-        msg = 'you must enable stubbing in order to client requests;'
-        msg << ' enable stubbing in the constructor with `:stub_responses => true`'
-        raise msg
+        msg = 'This method is only implemented for stubbed clients, and is '
+        msg << 'available when you enable stubbing in the constructor with `stub_responses: true`'
+        raise NotImplementedError.new(msg)
       end
     end
 

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -161,10 +161,9 @@ Known AWS regions include (not specific to this service):
           expect(client.api_requests.length).to eq(1)
           
           log_obj = client.api_requests[0]
-          expect(log_obj[:metadata]).to eq({:gem_name=>"aws-sdk-sampleapi2", :gem_version=>"1.0.0", :response_target=>nil, :original_params=>{:bucket=>"aws-sdk"}, :request_id=>"stubbed-request-id"})
-          expect(log_obj[:request].http_method).to eq("PUT")
-          expect(log_obj[:response].body_contents).to eq("<CreateBucketResult xmlns=\"\">\n</CreateBucketResult>\n")
-          expect(log_obj[:response].status_code).to eq(200)
+          expect(log_obj[:operation_name]).to eq(:create_bucket)
+          expect(log_obj[:params]).to eq({:bucket=>"aws-sdk"})
+          expect(log_obj[:context].metadata).to eq({:gem_name=>"aws-sdk-sampleapi2", :gem_version=>"1.0.0", :response_target=>nil, :original_params=>{:bucket=>"aws-sdk"}, :request_id=>"stubbed-request-id"})
         end
 
         it 'raises an error when accessing api requests of a non stubbed client' do 

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -163,7 +163,13 @@ Known AWS regions include (not specific to this service):
           log_obj = client.api_requests[0]
           expect(log_obj[:operation_name]).to eq(:create_bucket)
           expect(log_obj[:params]).to eq({:bucket=>"aws-sdk"})
-          expect(log_obj[:context].metadata).to eq({:gem_name=>"aws-sdk-sampleapi2", :gem_version=>"1.0.0", :response_target=>nil, :original_params=>{:bucket=>"aws-sdk"}, :request_id=>"stubbed-request-id"})
+          expect(log_obj[:context].metadata).to eq({
+                                                    :gem_name=>"aws-sdk-sampleapi2",
+                                                    :gem_version=>"1.0.0",
+                                                    :response_target=>nil, 
+                                                    :original_params=>{:bucket=>"aws-sdk"},
+                                                    :request_id=>"stubbed-request-id"
+                                                  })
         end
 
         it 'raises an error when accessing api requests of a non stubbed client' do 

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -150,6 +150,22 @@ Known AWS regions include (not specific to this service):
         expect(client.example_operation.string).to eq('value')
       end
 
+      it 'allows api requests to be logged when stubbed' do 
+        client = client_class.new(stub_responses: {
+          example_operation: { string: 'value' }
+        })
+        expect(client.api_requests.length).to eq(0)
+        client.example_operation
+        expect(client.api_requests.length).to eq(1)
+      end
+
+      it 'raises an error when accessing api requests of a non stubbed client' do 
+        client = client_class.new(options.merge(stub_responses: false))
+        expect {
+          client.api_requests
+        }.to raise_error(NotImplementedError)
+      end
+
     end
   end
 end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- [x] Adds an accessible `api_requests` to all clients. When a client is stubbed it will write all requests it makes to `api_requests` which can be accessed from the stubbed client.

Thank you for your contribution!
