### PR TITLE
moving towards a more 'frozen strings literal friendly' ruby

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 # kramdown
 require 'kramdown'
@@ -141,7 +143,7 @@ module AwsSdkCodeGenerator
     end
 
     def apig_prefix(name)
-      "__" << name
+      "__#{name}"
     end
 
     def shape(ref)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator
@@ -14,7 +16,7 @@ module AwsSdkCodeGenerator
     end
 
     def build
-      code = ''
+      code = ''.dup
       loops = self.send(:loops)
       count = loops.size
       loops.each.with_index do |loop_expression, n|
@@ -95,7 +97,7 @@ module AwsSdkCodeGenerator
     end
 
     def find_prefix(paths)
-      prefix = ''
+      prefix = ''.dup
       loop.with_index do |_, n|
         return prefix if paths.empty?
         letter = paths[0][n]

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}
@@ -252,8 +254,8 @@ module {{module_name}}
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -9,7 +9,7 @@ end
 def whitelist
   {
     "core" => {
-      "errors.rb" => 141,
+      "errors.rb" => 143,
       "signature_v4.rb" => 35,
       "stub_responses.rb" => 19
     },
@@ -28,7 +28,7 @@ describe "ensure no hard-coded region" do
     Dir.glob("#{dir}**/*").sort.each do |path|
       next if File.directory? path
 
-      file = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read } 
+      file = File.open(path, 'r', encoding: 'UTF-8') { |f| f.read }
       lines = file.lines.to_a
 
       it "#{path} has no hard-coded region" do
@@ -37,7 +37,7 @@ describe "ensure no hard-coded region" do
           next if val.strip[0] == "#"
           # skip known whitelists
           next if whitelist[key] && whitelist[key][File.basename(path)] == idx
-          expect(val).not_to match(/(us|eu|ap|sa|ca)-\w+-\d+/)        
+          expect(val).not_to match(/(us|eu|ap|sa|ca)-\w+-\d+/)
         end
       end
 

--- a/doc-src/templates/default/fulldoc/html/setup.rb
+++ b/doc-src/templates/default/fulldoc/html/setup.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 def javascripts_full_list
   super + ['js/nolink.js']
 end
 
 def class_list(root = Registry.root, tree = TreeContext.new)
-  out = ''
+  out = ''.dup
   # non-service classes
   out << "<li class='#{tree.classes.join(' ')} nolink'>"
   out << "<div class='item' style='padding-left:#{tree.indent}'>"

--- a/gems/aws-eventstream/lib/aws-eventstream/bytes_buffer.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/bytes_buffer.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Aws
-  module EventStream 
+  module EventStream
 
     # @api private
     class BytesBuffer
@@ -35,7 +37,7 @@ module Aws
       end
 
       def write(bytes)
-        @data <<= bytes
+        @data += bytes
         bytes.bytesize
       end
       alias_method :<<, :write

--- a/gems/aws-partitions/lib/aws-partitions/partition.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class Partition
@@ -22,8 +24,8 @@ module Aws
         if @regions.key?(region_name)
           @regions[region_name]
         else
-          msg = "invalid region name #{region_name.inspect}; valid region "
-          msg << "names include %s" % [@regions.keys.join(', ')]
+          msg = "invalid region name #{region_name.inspect}; valid region " \
+                "names include %s" % [@regions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end
@@ -40,8 +42,8 @@ module Aws
         if @services.key?(service_name)
           @services[service_name]
         else
-          msg = "invalid service name #{service_name.inspect}; valid service "
-          msg << "names include %s" % [@services.keys.join(', ')]
+          msg = "invalid service name #{service_name.inspect}; valid service " \
+                "names include %s" % [@services.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition_list.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class PartitionList
@@ -19,8 +21,8 @@ module Aws
         if @partitions.key?(partition_name)
           @partitions[partition_name]
         else
-          msg = "invalid partition name #{partition_name.inspect}; valid "
-          msg << "partition names include %s" % [@partitions.keys.join(', ')]
+          msg = "invalid partition name #{partition_name.inspect}; valid " \
+                "partition names include %s" % [@partitions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -1167,8 +1169,8 @@ module Aws::AutoScaling
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -954,8 +956,8 @@ module Aws::CloudFormation
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -476,8 +478,8 @@ module Aws::CloudWatch
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-partitions'
 require 'seahorse'
 require 'jmespath'
@@ -150,8 +152,8 @@ module Aws
 
     # @api private
     def eager_autoload!(*args)
-      msg = 'Aws.eager_autoload is no longer needed, usage of '
-      msg << 'autoload has been replaced with require statements'
+      msg = 'Aws.eager_autoload is no longer needed, usage of ' \
+            'autoload has been replaced with require statements'
       warn(msg)
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws
@@ -176,8 +178,8 @@ module Aws
       if config.stub_responses
         apply_stubs(operation_name, stubs.flatten)
       else
-        msg = 'stubbing is not enabled; enable stubbing in the constructor '
-        msg << 'with `:stub_responses => true`'
+        msg = 'stubbing is not enabled; enable stubbing in the constructor ' \
+              'with `:stub_responses => true`'
         raise msg
       end
     end
@@ -185,14 +187,14 @@ module Aws
     # Allows you to access all of the requests that the stubbed client has made
     #
     # @return [Array] Returns an array of the api requests made, each request object contains the
-    #                 :operation_name, :params, and :context of the request. 
+    #                 :operation_name, :params, and :context of the request.
     # @raise [NotImplementedError] Raises `NotImplementedError` when the client is not stubbed
     def api_requests
       if config.stub_responses
         @api_requests
       else
-        msg = 'This method is only implemented for stubbed clients, and is '
-        msg << 'available when you enable stubbing in the constructor with `stub_responses: true`'
+        msg = 'This method is only implemented for stubbed clients, and is ' \
+              'available when you enable stubbing in the constructor with `stub_responses: true`'
         raise NotImplementedError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
@@ -1,5 +1,6 @@
-module Aws
+# frozen_string_literal: true
 
+module Aws
   # A utility module that provides a class method that wraps
   # a method such that it generates a deprecation warning when called.
   # Given the following class:
@@ -34,7 +35,6 @@ module Aws
   #
   # @api private
   module Deprecations
-
     # @param [Symbol] method_name The name of the deprecated method.
     #
     # @option options [String] :message The warning message to issue
@@ -44,9 +44,8 @@ module Aws
     #   method that should be used.
     #
     def deprecated(method_name, options = {})
-
       deprecation_msg = options[:message] || begin
-        msg = "DEPRECATION WARNING: called deprecated method `#{method_name}' "
+        msg = "DEPRECATION WARNING: called deprecated method `#{method_name}' ".dup
         msg << "of an #{self}"
         msg << ", use #{options[:use]} instead" if options[:use]
         msg
@@ -56,7 +55,7 @@ module Aws
 
       warned = false # we only want to issue this warning once
 
-      define_method(method_name) do |*args,&block|
+      define_method(method_name) do |*args, &block|
         unless warned
           warned = true
           warn(deprecation_msg + "\n" + caller.join("\n"))
@@ -64,6 +63,5 @@ module Aws
         send("deprecated_#{method_name}", *args, &block)
       end
     end
-
   end
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws
@@ -109,8 +111,8 @@ module Aws
     # Raised when a client is constructed and region is not specified.
     class MissingRegionError < ArgumentError
       def initialize(*args)
-        msg = "missing region; use :region option or "
-        msg << "export region name to ENV['AWS_REGION']"
+        msg = "missing region; use :region option or " \
+              "export region name to ENV['AWS_REGION']"
         super(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # @api private
@@ -283,7 +285,7 @@ module Aws
       unless (@parsed_credentials && @parsed_credentials[profile]) ||
           (@parsed_config && @parsed_config[profile])
         msg = "Profile `#{profile}' not found in #{@credentials_path}"
-        msg << " or #{@config_path}" if @config_path
+        msg += "or #{@config_path}" if @config_path
         raise Errors::NoSuchProfileError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-eventstream'
 
 module Aws
@@ -94,7 +96,7 @@ module Aws
               # Pending
               raise 'Stubbing :exception event is not supported'
             end
-            stream << Aws::EventStream::Encoder.new.encode(
+            stream += Aws::EventStream::Encoder.new.encode(
               Aws::EventStream::Message.new(opts))
             stream
           end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 require 'rexml/streamlistener'
 
@@ -15,7 +17,7 @@ module Aws
 
         def parse(xml)
           begin
-            source = REXML::Source.new(xml)
+            source = REXML::Source.new(xml.dup)
             REXML::Parsers::StreamParser.new(source, self).parse
           rescue REXML::ParseException => error
             @stack.error(error.message)

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
 
@@ -86,8 +88,8 @@ module Seahorse
         if STEPS.key?(step)
           @step = step
         else
-          msg = "invalid :step `%s', must be one of :initialize, :validate, "
-          msg << ":build, :sign or :send"
+          msg = "invalid :step `%s', must be one of :initialize, :validate, " \
+                ":build, :sign or :send"
           raise ArgumentError, msg % step.inspect
         end
       end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'uri'
 
@@ -34,8 +36,8 @@ module Seahorse
           if endpoint.nil? or URI::HTTP === endpoint or URI::HTTPS === endpoint
             @endpoint = endpoint
           else
-            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "
-            msg << "got #{endpoint.inspect}"
+            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, " \
+                  "got #{endpoint.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/https'
 require 'openssl'
 
@@ -13,8 +15,8 @@ module Seahorse
         # @api private
         class TruncatedBodyError < IOError
           def initialize(bytes_expected, bytes_received)
-            msg = "http response body truncated, expected #{bytes_expected} "
-            msg << "bytes, received #{bytes_received} bytes"
+            msg = "http response body truncated, expected #{bytes_expected} " \
+                  "bytes, received #{bytes_received} bytes"
             super(msg)
           end
         end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 
@@ -8,7 +10,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = ''.dup
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 
@@ -5,7 +7,7 @@ module Aws
   module Xml
     describe DocBuilder do
 
-      let(:result) { '' }
+      let(:result) { ''.dup }
 
       let(:options) { { target: result, indent: '' } }
 

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse
@@ -87,7 +89,7 @@ module Seahorse
 
           it 'raises an error if :step is not valid' do
             msg = "invalid :step `:bogus', must be one of :initialize, "
-            msg << ":validate, :build, :sign or :send"
+            msg += ":validate, :build, :sign or :send"
             expect {
               handlers.add('handler', step: :bogus)
             }.to raise_error(ArgumentError, msg)

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'logger'
 
@@ -9,7 +11,7 @@ module Seahorse
         class LogNullDevice
           attr_reader :messages
           def write(msg)
-            @messages ||= ''
+            @messages ||= ''.dup
             @messages << msg
           end
           def close; end

--- a/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'tempfile'
 require 'pathname'
@@ -122,7 +124,7 @@ module Seahorse
         describe 'IO object target' do
 
           it 'writes to the given object' do
-            buffer = StringIO.new('')
+            buffer = StringIO.new(''.dup)
             request.send_request(target: buffer)
             expect(buffer.string).to eq("part1part2part3")
           end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bigdecimal'
 require 'stringio'
 require 'set'
@@ -42,8 +44,8 @@ module Aws
           when true, false then { bool: obj }
           when nil then { null: true }
           else
-            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "
-            msg << "IO, true, false, or nil, got #{obj.class.name}"
+            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, " \
+                  "IO, true, false, or nil, got #{obj.class.name}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -528,8 +530,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -1454,8 +1456,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EC2
     module Plugins
@@ -7,8 +9,8 @@ module Aws
         def after_initialize(client)
           if region = client.config.region
             if matches = region.match(/^(\w+-\w+-\d+)[a-z]$/)
-              msg = ":region option must a region name, not an availability "
-              msg << "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
+              msg = ":region option must a region name, not an availability " \
+                    "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -554,8 +556,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -1830,8 +1832,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -329,8 +331,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -331,8 +333,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -864,8 +866,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -672,8 +674,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
 
@@ -347,8 +349,8 @@ module Aws
           if [:metadata, :instruction_file].include?(location)
             location
           else
-            msg = ":envelope_location must be :metadata or :instruction_file "
-            msg << "got #{location.inspect}"
+            msg = ":envelope_location must be :metadata or :instruction_file " \
+                  "got #{location.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws
@@ -32,12 +34,12 @@ module Aws
             if [32, 24, 16].include?(key.bytesize)
               key
             else
-              msg = "invalid key, symmetric key required to be 16, 24, or "
-              msg << "32 bytes in length, saw length " + key.bytesize.to_s
+              msg = "invalid key, symmetric key required to be 16, 24, or " \
+                    "32 bytes in length, saw length " + key.bytesize.to_s
               raise ArgumentError, msg
             end
           else
-            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "
+            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key ".dup
             msg << "(for asymmetric encryption) or a String (for symmetric "
             msg << "encryption)."
             raise ArgumentError, msg

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -1059,8 +1061,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -911,8 +913,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; " \
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins
@@ -78,13 +80,13 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
 
           def validate_bucket_name!(bucket_name)
             unless BucketDns.dns_compatible?(bucket_name, _ssl = true)
-              msg = "unable to use `accelerate: true` on buckets with "
-              msg << "non-DNS compatible names"
+              msg = "unable to use `accelerate: true` on buckets with " \
+                    "non-DNS compatible names"
               raise ArgumentError, msg
             end
             if bucket_name.include?('.')
-              msg = "unable to use `accelerate: true` on buckets with dots"
-              msg << "in their name: #{bucket_name.inspect}"
+              msg = "unable to use `accelerate: true` on buckets with dots" \
+                    "in their name: #{bucket_name.inspect}"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 
@@ -45,7 +47,7 @@ module Aws
           end
 
           def update_in_chunks(digest, io)
-            while chunk = io.read(CHUNK_SIZE, buffer ||= "")
+            while chunk = io.read(CHUNK_SIZE, buffer ||= "".dup)
               digest.update(chunk)
             end
             io.rewind

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 
@@ -571,8 +573,8 @@ module Aws
 
       def check_required_values!
         unless @key_set
-          msg = "key required; you must provide a key via :key, "
-          msg << ":key_starts_with, or :allow_any => ['key']"
+          msg = "key required; you must provide a key via :key, " \
+                ":key_starts_with, or :allow_any => ['key']"
           raise msg
         end
       end

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'base64'
 require 'openssl'
@@ -255,7 +257,7 @@ module Aws
 
             it 'supports #get_object with a block' do
               stub_encrypted_get
-              data = ''
+              data = ''.dup
               client.get_object(bucket:'bucket', key:'key') do |chunk|
                 data << chunk
               end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws
@@ -117,14 +119,14 @@ module Aws
           end
 
           def mismatch_error_message(section, local_md5, returned_md5, response)
-            m = "MD5 returned by SQS does not match " <<
+            m = "MD5 returned by SQS does not match " \
             "the calculation on the original request. ("
 
             if response.respond_to?(:id) && !response.id.nil?
-              m << "Message ID: #{response.id}, "
+              m += "Message ID: #{response.id}, "
             end
 
-            m << "MD5 calculated by the #{section}: " <<
+            m += "MD5 calculated by the #{section}: " \
             "'#{local_md5}', MD5 checksum returned: '#{returned_md5}')"
           end
         end

--- a/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 
@@ -26,7 +27,7 @@ module Aws
           },
           'öther_encodings' => {
             data_type: 'String',
-            string_value: 'Tüst'.encode!('ISO-8859-1')
+            string_value: 'Tüst'.dup.encode!('ISO-8859-1')
           }
         }}
 
@@ -89,7 +90,7 @@ module Aws
 
             before(:each) do
               message_attributes.keys.each do |attribute_name|
-                message_attributes[attribute_name][:data_type] << '.test'
+                message_attributes[attribute_name][:data_type] += '.test'
               end
             end
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'tempfile'
 require 'time'
@@ -473,7 +475,7 @@ module Aws
           OpenSSL::Digest::SHA256.file(value).hexdigest
         elsif value.respond_to?(:read)
           sha256 = OpenSSL::Digest::SHA256.new
-          while chunk = value.read(1024 * 1024, buffer ||= "") # 1MB
+          while chunk = value.read(1024 * 1024, buffer ||= "".dup) # 1MB
             sha256.update(chunk)
           end
           value.rewind

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/core/rake_task'
 
 ##
@@ -12,7 +14,7 @@ task 'test:spec:each' do
       failures << spec_file if !ok
     end
   end
-  msg = "One or more spec files had failures:\n\n"
+  msg = "One or more spec files had failures:\n\n".dup
   failures.each do |path|
     msg << "bundle exec rspec #{path}\n"
   end


### PR DESCRIPTION
trying to eliminate all places that modify string literals.

we still can't run the build using `RUBYOPT="--enable-frozen-string-literal" rake`, because of [kramdown](https://github.com/gettalong/kramdown) (cc @gettalong), but that's something I'm going to address tomorrow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.