### PR TITLE
Revert "Fix typo (http_reed_timeout) (#1482)" which is intended typo

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -26,11 +26,11 @@ Version 2 differs from version 1 in a number of important ways.
 
   ```ruby
   # version 1
-  AWS::S3::Client.new(http_read_timeout: 10)
+  AWS::S3::Client.new(http_reed_timeout: 10)
   # oops, typo'd option is ignored
 
   # version 2
-  Aws::S3::Client.new(http_read_timeout: 10)
+  Aws::S3::Client.new(http_reed_timeout: 10)
   # => raises ArgumentError
   ```
 


### PR DESCRIPTION
I think this section is an example for typo in a parameter and we should not fix this typo since it is intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
