### PR TITLE
Spelling error fix for for exception

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
@@ -39,7 +39,7 @@ module Aws
         if @size
           @batches[0][index]
         else
-          raise "unabled to index into a lazy loaded collection"
+          raise "unable to index into a lazy loaded collection"
         end
       end
       deprecated :[]


### PR DESCRIPTION
Changed "unabled" to "unable". The "d" might have been added erroneously.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
