### PR TITLE
Adding Region to CSM ApiCall Events

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Adds to code paths and plugins for future SDK instrumentation and telemetry.
+
 3.29.0 (2018-09-28)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Adds to code paths and plugins for future SDK instrumentation and telemetry.
+* Feature - Adds to code paths and plugins for future SDK instrumentation and telemetry.
 
 3.29.0 (2018-09-28)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/request_metrics.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/request_metrics.rb
@@ -9,8 +9,9 @@ module Aws
         @api = opts[:operation]
         @client_id = opts[:client_id]
         @timestamp = opts[:timestamp] # In epoch milliseconds
+        @region = opts[:region]
         @version = 1
-        @api_call = ApiCall.new(@service, @api, @client_id, @version, @timestamp)
+        @api_call = ApiCall.new(@service, @api, @client_id, @version, @timestamp, @region)
         @api_call_attempts = []
       end
 
@@ -41,14 +42,15 @@ module Aws
 
       class ApiCall
         attr_reader :service, :api, :client_id, :timestamp, :version,
-          :attempt_count, :latency
+          :attempt_count, :latency, :region
 
-        def initialize(service, api, client_id, version, timestamp)
+        def initialize(service, api, client_id, version, timestamp, region)
           @service = service
           @api = api
           @client_id = client_id
           @version = version
           @timestamp = timestamp
+          @region = region
         end
 
         def complete(opts = {})
@@ -65,7 +67,8 @@ module Aws
             "Timestamp" => @timestamp,
             "Version" => @version,
             "AttemptCount" => @attempt_count,
-            "Latency" => @latency
+            "Latency" => @latency,
+            "Region" => @region
           }.to_json
         end
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_plugin.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_plugin.rb
@@ -99,6 +99,7 @@ all generated client side metrics. Defaults to an empty string.
             service: service_id,
             operation: context.operation.name,
             client_id: context.config.client_side_monitoring_client_id,
+            region: context.config.region,
             timestamp: DateTime.now.strftime('%Q').to_i,
           )
           context.metadata[:client_metrics] = request_metrics

--- a/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
@@ -30,6 +30,7 @@ module Aws
           operation: "StubOperation",
           client_id: "",
           timestamp: 1526502682104,
+          region: "us-stubbed-1"
         )
         rm.add_call_attempt(example_attempt)
         rm.api_call.complete(
@@ -69,6 +70,7 @@ module Aws
           operation: "StubOperation",
           client_id: "FooClient",
           timestamp: 1526502682104,
+          region: "us-stubbed-1"
         )
         rm.add_call_attempt(example_failed_attempt)
         rm.api_call.complete(
@@ -89,7 +91,7 @@ module Aws
         allow(UDPSocket).to receive(:new) { stub_socket }
         expect(stub_socket).to receive(:connect).twice
         expect(stub_socket).to receive(:send).with(
-          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123}',
+          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1"}',
           0
         )
         expect(stub_socket).to receive(:send).with(
@@ -105,7 +107,7 @@ module Aws
         allow(UDPSocket).to receive(:new) { stub_socket }
         expect(stub_socket).to receive(:connect).twice
         expect(stub_socket).to receive(:send).with(
-          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"FooClient","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123}',
+          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"FooClient","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1"}',
           0
         )
         expect(stub_socket).to receive(:send).with(

--- a/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
@@ -162,6 +162,7 @@ module Aws
           expect(api_call.attempt_count).to eq(1)
           expect(api_call.latency).to be_a_kind_of(Fixnum)
           expect(api_call.client_id).to eq("")
+          expect(api_call.region).to eq("us-stubbed-1")
         end
       end
 


### PR DESCRIPTION
Parallels the region value added to API call attempts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
