### PR TITLE
fix for missing client constructor documentation

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
@@ -12,6 +12,7 @@ module AwsSdkCodeGenerator
           ruby_type: option.doc_type,
           default_value: option.doc_default,
           docstring: option.docstring,
+          indent: "  "
         ).to_s
       end
       @documentation = Docstring.join_docstrings(@documentation, block_comment: false)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
@@ -14,13 +14,14 @@ module AwsSdkCodeGenerator
       @docstring = options.fetch(:docstring).to_s
       @default_value = options[:default_value]
       @option_hash_name = options.fetch(:option_hash_name, 'options')
+      @indent = options.fetch(:indent, "")
     end
 
     def build
       if @docstring.empty?
         first_line.rstrip
       else
-        first_line + Docstring.block_comment(@docstring, gap: '   ')
+        first_line + Docstring.block_comment(@docstring, gap: "   #{@indent}")
       end
     end
     alias to_str build
@@ -29,7 +30,7 @@ module AwsSdkCodeGenerator
     private
 
     def first_line
-      "# @option #{@option_hash_name} [#{@required}#{@ruby_type}] :#{@name}#{default_value}\n"
+      "# #{@indent}@option #{@option_hash_name} [#{@required}#{@ruby_type}] :#{@name}#{default_value}\n"
     end
 
     def default_value

--- a/build_tools/aws-sdk-code-generator/templates/client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_class.mustache
@@ -21,6 +21,8 @@ module {{module_name}}
     {{/plugin_class_names}}
 
     {{#client_constructor}}
+    # @overload initialize(options)
+    #   @param [Hash] options
     {{>documentation}}
     {{/client_constructor}}
     def initialize(*args)


### PR DESCRIPTION
Fix for issue: https://github.com/aws/aws-sdk-ruby/issues/1649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
