### PR TITLE
Fix GCM Decryption Issue

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
@@ -21,9 +21,12 @@ module Aws
         end
 
         def write(chunk)
+          @last_chunk = chunk
           chunk = truncate_chunk(chunk)
-          @bytes_written += chunk.bytesize
-          @decrypter.write(chunk)
+          if chunk.bytesize > 0
+            @bytes_written += chunk.bytesize
+            @decrypter.write(chunk)
+          end
         end
 
         def finalize
@@ -39,8 +42,12 @@ module Aws
         def truncate_chunk(chunk)
           if chunk.bytesize + @bytes_written <= @max_bytes
             chunk
-          else
+          elsif @bytes_written < @max_bytes
             chunk[0..(@max_bytes - @bytes_written - 1)]
+          else
+            # If the tag was sent over after the full body has been read,
+            # we don't want to accidentally append it.
+            ""
           end
         end
 


### PR DESCRIPTION
Specifically, body tags that are split across multiple data packets
could cause an issue with how the string slicing logic was written to
append junk bytes to the end of the body. This fix catches such a
scenario and ensures those bytes are dropped before finalizing the
streaming decryption.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
