### PR TITLE
[BuildTools] ignore deprecatedMessage trait

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -38,6 +38,7 @@ module AwsSdkCodeGenerator
         'fault' => false,
         'error' => false,
         'deprecated' => false,
+        'deprecatedMessage' => false,
         'type' => false,
         'documentation' => false,
         'members' => false,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Currently not supported, but shouldn't block build