### PR TITLE
Replaced BigDecimal.new() with BigDecimal()

### DIFF
--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -76,12 +76,12 @@ module Aws
             end
           when :l then value.map { |v| format(v) }
           when :s then value
-          when :n then BigDecimal.new(value)
+          when :n then BigDecimal(value)
           when :b then StringIO.new(value)
           when :null then nil
           when :bool then value
           when :ss then Set.new(value)
-          when :ns then Set.new(value.map { |n| BigDecimal.new(n) })
+          when :ns then Set.new(value.map { |n| BigDecimal(n) })
           when :bs then Set.new(value.map { |b| StringIO.new(b) })
           when :es then Set.new
           else

--- a/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
@@ -79,7 +79,7 @@ module Aws
 
           # Ruby 2.4 changed the casing of BigDecimal's to_s value.
           # We need to check in a case insensitive manner
-          big_decimal_value = value.marshal(BigDecimal.new("0.1E125"))
+          big_decimal_value = value.marshal(BigDecimal("0.1E125"))
           expect(big_decimal_value.keys).to eq([:n])
           expect(big_decimal_value[:n]).to match(/0.1E125/i)
         end
@@ -201,7 +201,7 @@ module Aws
 
         it 'converts :ns to a set of big decimals (to preserve precision)' do
           expect(value.unmarshal(ns: %w(123 456))).to eq(
-            Set.new([BigDecimal.new('123'), BigDecimal.new('456')]))
+            Set.new([BigDecimal('123'), BigDecimal('456')]))
         end
 
         it 'converts :bs to a set of binary values' do
@@ -217,9 +217,9 @@ module Aws
 
         it 'converts :n to big decimals' do
           # supports integers, floats, and big decimals
-          expect(value.unmarshal(n: '123')).to eq(BigDecimal.new('123'))
-          expect(value.unmarshal(n: '12.34')).to eq(BigDecimal.new('12.34'))
-          expect(value.unmarshal(n: '0.1E125')).to eq(BigDecimal.new('0.1E125'))
+          expect(value.unmarshal(n: '123')).to eq(BigDecimal('123'))
+          expect(value.unmarshal(n: '12.34')).to eq(BigDecimal('12.34'))
+          expect(value.unmarshal(n: '0.1E125')).to eq(BigDecimal('0.1E125'))
         end
 
         it 'converts :s to a string' do
@@ -297,9 +297,9 @@ module Aws
               },
             ],
             'scores' => [
-              BigDecimal.new('4.5'),
-              BigDecimal.new('5'),
-              BigDecimal.new('3.9'),
+              BigDecimal('4.5'),
+              BigDecimal('5'),
+              BigDecimal('3.9'),
               nil,
               'perfect'
             ]


### PR DESCRIPTION
fixes #1936 

Use `Kernel.BigDecimal` method instead of `BigDecimal.new`