### PR TITLE
Added support for authenticated encryption

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Adds support for authenticated encryption.
+
 1.30.0 (2018-12-04)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -295,6 +295,7 @@ module Aws
             options.delete(:encryption_key)
             options.delete(:envelope_location)
             options.delete(:instruction_file_suffix)
+            options.delete(:authenticated_encryption)
             S3::Client.new(options)
           end
         end
@@ -313,10 +314,14 @@ module Aws
             KmsCipherProvider.new(
               kms_key_id: options[:kms_key_id],
               kms_client: kms_client(options),
+              authenticated_encryption: options[:authenticated_encryption]
             )
           else
             # kept here for backwards compatability, {#key_provider} is deprecated
             @key_provider = extract_key_provider(options)
+            if options[:authenticated_encryption]
+              raise NotImplementedError, ':authenticated_encryption not supported for default cipher yet'
+            end
             DefaultCipherProvider.new(key_provider: @key_provider)
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
@@ -36,6 +36,7 @@ module Aws
           context.params[:body] = IOEncrypter.new(cipher, io)
           context.params[:metadata] ||= {}
           context.params[:metadata]['x-amz-unencrypted-content-length'] = io.size
+          context.params[:metadata]['x-amz-tag-len'] = cipher.auth_tag.bytesize * 8 if Utils.cipher_authenticated?(cipher)
           if md5 = context.params.delete(:content_md5)
             context.params[:metadata]['x-amz-unencrypted-content-md5'] = md5
           end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
@@ -72,6 +72,9 @@ module Aws
             key.bytesize * 8
           end
 
+          def cipher_authenticated?(cipher)
+            cipher.respond_to?(:authenticated?) && cipher.authenticated?
+          end
         end
       end
     end


### PR DESCRIPTION
Hi, this adds support for authenticated encryption (AES-GCM). Currently, the gem can decrypt AES-GCM. This allows it to encrypt as well.

```ruby
Aws::S3::Encryption::Client.new(
  kms_key_id: "alias/my-key",
  authenticated_encryption: true
)
```

The Java SDK uses [CryptoMode](https://aws.amazon.com/blogs/developer/amazon-s3-client-side-authenticated-encryption/) for this. In the future, a `:strict` option can be added to only allow for authenticated decryption.

![screen shot 2018-12-09 at 1 38 46 pm](https://user-images.githubusercontent.com/220358/49703465-48e11700-fbba-11e8-8958-c6953b950bf4.png)
