### PR TITLE
[CI] Address bundle 2.0 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 
+before_install:
+  - gem install bundler -v ‘< 2’
+
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 before_install:
-  - gem install bundler -v ‘< 2’
+  - gem install bundler -v '< 2'
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://docs.travis-ci.com/user/languages/ruby/#bundler-20
bundle 2.0 drops support for ruby version under 2.2