### PR TITLE
Changes to CSM Plugin

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update to code paths and plugins for future SDK instrumentation and telemetry.
+
 3.44.1 (2018-12-17)
 ------------------
 

--- a/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
@@ -24,6 +24,26 @@ module Aws
         a
       end
 
+      let(:truncate_attempt) do
+        a = RequestMetrics::ApiCallAttempt.new(
+          "StubService",
+          "StubOperation",
+          "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234_truncated_67890123456789012345678901234567890123456789_client",
+          1,
+          1526502725425,
+          "stub-service.us-stubbed-1.example.org",
+          "us-stubbed-1",
+          "my-user-agent",
+          "AKID-STUB",
+          "TOKEN-STUB"
+        )
+        a.request_latency = 95
+        a.http_status_code = 200
+        a.x_amz_request_id = "226FC0DC6464C2AE"
+        a.x_amz_id_2 = "fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc="
+        a
+      end
+
       let(:example_request_metric) do
         rm = RequestMetrics.new(
           service: "StubService",
@@ -35,7 +55,27 @@ module Aws
         rm.add_call_attempt(example_attempt)
         rm.api_call.complete(
           latency: 123,
-          attempt_count: 1
+          attempt_count: 1,
+          user_agent: "my_ua",
+          final_http_status_code: 200
+        )
+        rm
+      end
+
+      let(:example_truncated_request_metric) do
+        rm = RequestMetrics.new(
+          service: "StubService",
+          operation: "StubOperation",
+          client_id: "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234_truncated_67890123456789012345678901234567890123456789_client",
+          timestamp: 1526502682104,
+          region: "us-stubbed-1"
+        )
+        rm.add_call_attempt(truncate_attempt)
+        rm.api_call.complete(
+          latency: 123,
+          attempt_count: 1,
+          user_agent: "my_ua",
+          final_http_status_code: 200
         )
         rm
       end
@@ -75,7 +115,13 @@ module Aws
         rm.add_call_attempt(example_failed_attempt)
         rm.api_call.complete(
           latency: 123,
-          attempt_count: 1
+          attempt_count: 1,
+          user_agent: "my_ua",
+          final_http_status_code: 400,
+          final_aws_exception: example_failed_attempt.aws_exception,
+          final_aws_exception_message: example_failed_attempt.aws_exception_msg,
+          final_sdk_exception: example_failed_attempt.sdk_exception,
+          final_sdk_exception_message: example_failed_attempt.sdk_exception_msg,
         )
         rm
       end
@@ -91,7 +137,7 @@ module Aws
         allow(UDPSocket).to receive(:new) { stub_socket }
         expect(stub_socket).to receive(:connect).twice
         expect(stub_socket).to receive(:send).with(
-          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1","MaxRetriesExceeded":0}',
+          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1","MaxRetriesExceeded":0,"UserAgent":"my_ua","FinalHttpStatusCode":200}',
           0
         )
         expect(stub_socket).to receive(:send).with(
@@ -107,7 +153,7 @@ module Aws
         allow(UDPSocket).to receive(:new) { stub_socket }
         expect(stub_socket).to receive(:connect).twice
         expect(stub_socket).to receive(:send).with(
-          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"FooClient","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1","MaxRetriesExceeded":0}',
+          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"FooClient","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1","MaxRetriesExceeded":0,"UserAgent":"my_ua","FinalHttpStatusCode":400,"FinalSdkException":"Aws::Errors::ParserError","FinalSdkExceptionMessage":"Response parsing error.","FinalAwsException":"ServiceError","FinalAwsExceptionMessage":"A service problem happened."}',
           0
         )
         expect(stub_socket).to receive(:send).with(
@@ -115,6 +161,22 @@ module Aws
           0
         )
         publisher.publish(example_failed_metric)
+      end
+
+      it 'truncates long fields' do
+        publisher = Aws::ClientSideMonitoring::Publisher.new(agent_port: 1234)
+        stub_socket = double
+        allow(UDPSocket).to receive(:new) { stub_socket }
+        expect(stub_socket).to receive(:connect).twice
+        expect(stub_socket).to receive(:send).with(
+          '{"Type":"ApiCall","Service":"StubService","Api":"StubOperation","ClientId":"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234_truncated","Timestamp":1526502682104,"Version":1,"AttemptCount":1,"Latency":123,"Region":"us-stubbed-1","MaxRetriesExceeded":0,"UserAgent":"my_ua","FinalHttpStatusCode":200}',
+          0
+        )
+        expect(stub_socket).to receive(:send).with(
+          '{"Type":"ApiCallAttempt","Service":"StubService","Api":"StubOperation","ClientId":"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234_truncated","Timestamp":1526502725425,"Version":1,"Fqdn":"stub-service.us-stubbed-1.example.org","Region":"us-stubbed-1","UserAgent":"my-user-agent","AccessKey":"AKID-STUB","SessionToken":"TOKEN-STUB","HttpStatusCode":200,"XAmzRequestId":"226FC0DC6464C2AE","XAmzId2":"fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=","AttemptLatency":95}',
+          0
+        )
+        publisher.publish(example_truncated_request_metric)
       end
 
     end

--- a/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
@@ -157,12 +157,15 @@ module Aws
           api_call = stub_publisher.metrics[0].api_call
           expect(api_call.service).to eq("S3")
           expect(api_call.api).to eq("ListBuckets")
-          expect(api_call.timestamp).to be_a_kind_of(Fixnum)
-          expect(api_call.version).to be_a_kind_of(Fixnum)
+          expect(api_call.timestamp).to be_a_kind_of(Integer)
+          expect(api_call.version).to be_a_kind_of(Integer)
           expect(api_call.attempt_count).to eq(1)
-          expect(api_call.latency).to be_a_kind_of(Fixnum)
+          expect(api_call.latency).to be_a_kind_of(Integer)
           expect(api_call.client_id).to eq("")
           expect(api_call.region).to eq("us-stubbed-1")
+          expect(api_call.user_agent).to match(/^aws-sdk-ruby3/)
+          expect(api_call.user_agent).to match(/aws-sdk-sampleapi.\/1.0.0/)
+          expect(api_call.final_http_status_code).to eq(200)
         end
       end
 
@@ -177,15 +180,15 @@ module Aws
           attempt = api_call_attempts[0]
           expect(attempt.service).to eq("S3")
           expect(attempt.api).to eq("ListBuckets")
-          expect(attempt.timestamp).to be_a_kind_of(Fixnum)
-          expect(attempt.version).to be_a_kind_of(Fixnum)
+          expect(attempt.timestamp).to be_a_kind_of(Integer)
+          expect(attempt.version).to be_a_kind_of(Integer)
           expect(attempt.fqdn).to eq("s3.us-stubbed-1.amazonaws.com")
           expect(attempt.region).to eq("us-stubbed-1")
           expect(attempt.user_agent).to match(/^aws-sdk-ruby3/)
           expect(attempt.user_agent).to match(/aws-sdk-sampleapi.\/1.0.0/)
           expect(attempt.access_key).to eq("stubbed-akid")
           expect(attempt.http_status_code).to eq(200)
-          expect(attempt.request_latency).to be_a_kind_of(Fixnum)
+          expect(attempt.request_latency).to be_a_kind_of(Integer)
           expect(attempt.client_id).to eq("")
         end
 
@@ -211,6 +214,12 @@ module Aws
           request_metrics = stub_publisher.metrics[0]
           api_call_attempts = request_metrics.api_call_attempts
           expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
+          expect(request_metrics.api_call.final_aws_exception).to eq(
+            "NoSuchKey"
+          )
+          expect(request_metrics.api_call.final_aws_exception_message).to eq(
+            "The resource you requested does not exist"
+          )
           expect(api_call_attempts.size).to eq(1)
           attempt = api_call_attempts[0]
           expect(attempt.aws_exception).to eq("NoSuchKey")
@@ -289,6 +298,12 @@ module Aws
             expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
+            expect(request_metrics.api_call.final_sdk_exception).to eq(
+              "ArgumentError"
+            )
+            expect(request_metrics.api_call.final_sdk_exception_message).to eq(
+              "Injected exception."
+            )
             expect(attempt.sdk_exception).to eq("ArgumentError")
             expect(attempt.sdk_exception_msg).to eq("Injected exception.")
           end
@@ -333,6 +348,12 @@ module Aws
             expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
+            expect(request_metrics.api_call.final_sdk_exception).to eq(
+              "ArgumentError"
+            )
+            expect(request_metrics.api_call.final_sdk_exception_message).to eq(
+              "Bad response."
+            )
             expect(attempt.sdk_exception).to eq("ArgumentError")
             expect(attempt.sdk_exception_msg).to eq("Bad response.")
           end
@@ -362,6 +383,18 @@ module Aws
             expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
+            expect(request_metrics.api_call.final_aws_exception).to eq(
+              "NoSuchKey"
+            )
+            expect(request_metrics.api_call.final_aws_exception_message).to eq(
+              "The resource you requested does not exist"
+            )
+            expect(request_metrics.api_call.final_sdk_exception).to eq(
+              "ArgumentError"
+            )
+            expect(request_metrics.api_call.final_sdk_exception_message).to eq(
+              "Bad response."
+            )
             expect(attempt.aws_exception).to eq("NoSuchKey")
             expect(attempt.aws_exception_msg).to eq(
               "The resource you requested does not exist"


### PR DESCRIPTION
Tracks the following fields in an ApiCall metric:
- UserAgent
- FinalHttpStatusCode
- FinalAwsException (where applicable)
- FinalAwsExceptionMessage (where applicable)
- FinalSdkException (where applicable)
- FinalSdkExceptionMessage (where applicable)

Also, truncates fields that have size limits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
