### PR TITLE
Replace Fixnum with Integer in HashFormatter code generator

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
@@ -35,7 +35,7 @@ module AwsSdkCodeGenerator
       when Array then array(obj, i:i)
       when String then @quote_strings ? obj.inspect : obj
       when Symbol then obj.inspect
-      when Fixnum, true, false then obj.inspect
+      when Integer, true, false then obj.inspect
       else raise ArgumentError, "unsupported value `#{obj.class}'"
       end
     end


### PR DESCRIPTION
The `Fixnum` class has been deprecated in newer Ruby versions, the `Integer` superclass should now be used. This gets rid of the related deprecation warnings when running tests.