### PR TITLE
Use single quoted string if no interpolation is done.

### DIFF
--- a/gems/aws-eventstream/CHANGELOG.md
+++ b/gems/aws-eventstream/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Use single quotes for string where interpolation is not done.
+
 1.0.2 (2019-03-11)
 ------------------
 

--- a/gems/aws-eventstream/lib/aws-eventstream/decoder.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/decoder.rb
@@ -159,7 +159,7 @@ module Aws
         end
 
         buffer.rewind
-        total_len, headers_len, _ = buffer.read.unpack("N*")
+        total_len, headers_len, _ = buffer.read.unpack('N*')
         [total_len, headers_len, buffer]
       end
 
@@ -234,15 +234,15 @@ module Aws
       # overhead decode helpers
 
       def unpack_uint32(buffer)
-        buffer.read(4).unpack("N")[0]
+        buffer.read(4).unpack('N')[0]
       end
 
       def unpack_uint16(buffer)
-        buffer.read(2).unpack("S>")[0]
+        buffer.read(2).unpack('S>')[0]
       end
 
       def unpack_uint8(buffer)
-        buffer.readbyte.unpack("C")[0]
+        buffer.readbyte.unpack('C')[0]
       end
     end
 

--- a/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
@@ -139,18 +139,18 @@ module Aws
       # overhead encode helpers
 
       def pack_uint8(val)
-        [val].pack("C")
+        [val].pack('C')
       end
 
       def pack_uint16(val)
-        [val].pack("S>")
+        [val].pack('S>')
       end
 
       def pack_uint32(val)
         if val.respond_to?(:each)
-          val.pack("N*")
+          val.pack('N*')
         else
-          [val].pack("N")
+          [val].pack('N')
         end
       end
 

--- a/gems/aws-eventstream/lib/aws-eventstream/errors.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/errors.rb
@@ -14,19 +14,19 @@ module Aws
       # Raise when insufficient bytes of a message is received
       class IncompleteMessageError < RuntimeError
         def initialize(*args)
-          super("Not enough bytes for event message")
+          super('Not enough bytes for event message')
         end
       end
 
       class PreludeChecksumError < RuntimeError
         def initialize(*args)
-          super("Prelude checksum mismatch")
+          super('Prelude checksum mismatch')
         end
       end
 
       class MessageChecksumError < RuntimeError
         def initialize(*args)
-          super("Message checksum mismatch")
+          super('Message checksum mismatch')
         end
       end
 

--- a/gems/aws-eventstream/lib/aws-eventstream/header_value.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/header_value.rb
@@ -20,8 +20,8 @@ module Aws
 
       def format_value(value)
         case @type
-        when "timestamp" then format_timestamp(value)
-        when "uuid" then format_uuid(value)
+        when 'timestamp' then format_timestamp(value)
+        when 'uuid' then format_uuid(value)
         else
           value
         end
@@ -32,7 +32,7 @@ module Aws
         # For user-friendly uuid representation,
         # format binary bytes into uuid string format
         uuid_pattern = [ [ 3, 2, 1, 0 ], [ 5, 4 ], [ 7, 6 ], [ 8, 9 ], 10..15 ]
-        uuid_pattern.map {|p| p.map {|n| "%02x" % bytes.to_a[n] }.join }.join("-")
+        uuid_pattern.map {|p| p.map {|n| "%02x" % bytes.to_a[n] }.join }.join('-')
       end
 
       def format_timestamp(value)

--- a/gems/aws-eventstream/lib/aws-eventstream/types.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/types.rb
@@ -6,32 +6,32 @@ module Aws
 
       def self.types
         [
-          "bool_true",
-          "bool_false",
-          "byte",
-          "short",
-          "integer",
-          "long",
-          "bytes",
-          "string",
-          "timestamp",
-          "uuid"
+          'bool_true',
+          'bool_false',
+          'byte',
+          'short',
+          'integer',
+          'long',
+          'bytes',
+          'string',
+          'timestamp',
+          'uuid'
         ]
       end
 
       # pack/unpack pattern, byte size, type idx
       def self.pattern
         {
-          "bool_true" => [true, 0, 0],
-          "bool_false" => [false, 0, 1],
-          "byte" => ["c", 1, 2],
-          "short" => ["s>", 2, 3],
-          "integer" => ["l>", 4, 4],
-          "long" => ["q>", 8, 5],
-          "bytes" => [nil, nil, 6],
-          "string" => [nil, nil, 7],
-          "timestamp" => ["q>", 8, 8],
-          "uuid" => [nil, 16, 9]
+          'bool_true' => [true, 0, 0],
+          'bool_false' => [false, 0, 1],
+          'byte' => ["c", 1, 2],
+          'short' => ["s>", 2, 3],
+          'integer' => ["l>", 4, 4],
+          'long' => ["q>", 8, 5],
+          'bytes' => [nil, nil, 6],
+          'string' => [nil, nil, 7],
+          'timestamp' => ["q>", 8, 8],
+          'uuid' => [nil, 16, 9]
         }
       end
 

--- a/gems/aws-eventstream/spec/bytes_buffer_spec.rb
+++ b/gems/aws-eventstream/spec/bytes_buffer_spec.rb
@@ -16,7 +16,7 @@ module Aws
           buffer.read(5)
         }.to raise_error(
           Aws::EventStream::Errors::ReadBytesExceedLengthError,
-          "Attempting reading bytes to offset 4 exceeds buffer length of 3"
+          'Attempting reading bytes to offset 4 exceeds buffer length of 3'
         )
       end
 

--- a/gems/aws-eventstream/spec/encoder_spec.rb
+++ b/gems/aws-eventstream/spec/encoder_spec.rb
@@ -7,7 +7,7 @@ module Aws
     
     describe Encoder do
 
-      describe "#encode" do
+      describe '#encode' do
         
         Dir.glob(File.expand_path('../fixtures/decoded/positive/*', __FILE__)).each do |path|
 

--- a/gems/aws-eventstream/spec/header_value_spec.rb
+++ b/gems/aws-eventstream/spec/header_value_spec.rb
@@ -13,7 +13,7 @@ module Aws
       it 'formats uuid when format is enabled' do
         uuid_bytes = "\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0E\x0F\x10" 
         hv = HeaderValue.new(value: uuid_bytes, type: 'uuid', format: true)
-        expect(hv.value).to eql("04030201-0605-0807-090a-0b0c0d0e0f10")
+        expect(hv.value).to eql('04030201-0605-0807-090a-0b0c0d0e0f10')
       end
 
       it 'formats timestamp when format is enable' do

--- a/gems/aws-eventstream/spec/spec_helper.rb
+++ b/gems/aws-eventstream/spec/spec_helper.rb
@@ -28,8 +28,8 @@ module SpecHelper
     def convert_msg(path)
       hash = JSON.load(File.read(path))
       Aws::EventStream::Message.new(
-        headers: build_headers(hash["headers"]),
-        payload: StringIO.new(Base64.decode64(hash["payload"]))
+        headers: build_headers(hash['headers']),
+        payload: StringIO.new(Base64.decode64(hash['payload']))
       )
     end
 
@@ -42,13 +42,13 @@ module SpecHelper
 
     def build_headers(headers)
       headers.inject({}) do |hash, ctx|
-        value = ctx["value"]
-        if ctx["value"].is_a? String
-          value = Base64.decode64(ctx["value"])
+        value = ctx['value']
+        if ctx['value'].is_a? String
+          value = Base64.decode64(ctx['value'])
         end
-        hash[ctx["name"]] = Aws::EventStream::HeaderValue.new(
+        hash[ctx['name']] = Aws::EventStream::HeaderValue.new(
           value: value,
-          type: Aws::EventStream::Types.types[ctx["type"]]
+          type: Aws::EventStream::Types.types[ctx['type']]
         )
         hash
       end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

As per [Rubocop guidelines](https://github.com/rubocop-hq/ruby-style-guide#strings) using single quoted string if no interpolation is done.