### PR TITLE
Fix for EmptyStructure Issue

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/api.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/api.json
@@ -1,0 +1,22 @@
+{
+  "metadata": {
+    "endpointPrefix": "svcname",
+    "serviceId": "sample_query_svc",
+    "protocol": "query"
+  },
+  "operations": {
+    "EmptyResponse": {
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": { "shape": "EmptyResponseRequest" }
+    }
+  },
+  "shapes": {
+    "EmptyResponseRequest": {
+      "type": "structure",
+      "members": {}
+    }
+  }
+}

--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/paginators.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/paginators.json
@@ -1,0 +1,3 @@
+{
+  "pagination": {}
+}

--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/waiters.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/sample_query/waiters.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "waiters": {}
+}

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/query_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/query_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+
+describe 'Client Interface:' do
+  describe 'Support Query APIs' do
+    before(:all) do
+      SpecHelper.generate_service(['SampleQuery'], multiple_files: false)
+    end
+
+    let(:client) {
+      SampleQuery::Client.new(
+        region: "us-west-2",
+        stub_responses: true
+      )
+    }
+
+    it 'properly parses an empty response' do
+      client.stub_responses(:empty_response,
+        {
+          status_code: 200,
+          headers: {},
+          body: "<DeleteStackResponse xmlns=\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">\n  <ResponseMetadata>\n    <RequestId>foo-bar-baz</RequestId>\n  </ResponseMetadata>\n</DeleteStackResponse>\n"
+        }
+      )
+      resp = client.empty_response
+      expect(resp.data.class).to eq(Aws::EmptyStructure)
+      expect(resp.to_h).to eq({})
+    end
+  end
+end

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Feature - Improve Query protocol handling of empty responses, to ensure response is an instance of `Aws::EmptyStructure` rather than the class `Aws::EmptyStructure` itself.
 * Issue - Plugin updates to support client-side monitoring.
 
 3.44.2 (2019-01-04)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
@@ -27,7 +27,12 @@ module Aws
         build_request(context)
         @handler.call(context).on_success do |response|
           response.error = nil
-          response.data = parse_xml(context) || EmptyStructure.new
+          parsed = parse_xml(context)
+          if parsed.nil? || parsed == EmptyStructure
+            response.data = EmptyStructure.new
+          else
+            response.data = parsed
+          end
         end
       end
 


### PR DESCRIPTION
Some XML will parse as the class `Aws::EmptyResponse`, which blocks the ability for the return value to be a new instance of `Aws::EmptyResponse`. This change fixes that.

Fixes #1955

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
