### PR TITLE
Allow nil for url argument of Aws::CloudFront::CookieSigner#singed_cookie

### DIFF
--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix url argument of #signed_cookie.
+
 1.22.0 (2019-07-25)
 ------------------
 

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
@@ -25,15 +25,18 @@ module Aws
       # @option params [Time, DateTime, Date, String, Integer<timestamp>] :expires
       # @option params [String<JSON>] :policy
       def signed_cookie(url, params = {})
-        scheme, uri = scheme_and_uri(url)
-        signed_content = signature(
-          resource: resource(scheme, uri),
-          expires: time(params[:expires]),
-          policy: params[:policy]
-        )
+        content = {}.tap do |c|
+          if params[:policy]
+            c[:policy] = params[:policy]
+          elsif url && params[:expires]
+            scheme, uri = scheme_and_uri(url)
+            c[:resource] = resource(scheme, uri)
+            c[:expires] = time(params[:expires])
+          end
+        end
 
         cookie_parameters = {}
-        signed_content.each { |k, v|
+        signature(content).each { |k, v|
           cookie_parameters["CloudFront-#{k}"] = v.to_s.gsub("\n", '')
         }
         cookie_parameters

--- a/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
@@ -29,10 +29,7 @@ module Aws
                 }
               ]
           }
-          cookie = signer.signed_cookie(
-            "http://abc.cloudfront.net/images/image.jpg",
-            policy: policy.to_json
-          )
+          cookie = signer.signed_cookie(nil, policy: policy.to_json)
           expect(cookie['CloudFront-Policy']).to eq('eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__')
           expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')
           expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')

--- a/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
@@ -29,6 +29,24 @@ module Aws
                 }
               ]
           }
+          cookie = signer.signed_cookie(
+            "http://abc.cloudfront.net/images/image.jpg",
+            policy: policy.to_json
+          )
+          expect(cookie['CloudFront-Policy']).to eq('eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__')
+          expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')
+          expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')
+        end
+        it 'can generate signed urls with custom policy without passing a url' do
+          policy =  {
+            'Statement' => [
+              'Resource' => 'images/image.jpg',
+                'Condition' => {
+                'IpAddress' => {'AWS:SourceIp' => '10.52.176.0/24'},
+                'DateLessThan' => {'AWS:EpochTime' => expires}
+                }
+              ]
+          }
           cookie = signer.signed_cookie(nil, policy: policy.to_json)
           expect(cookie['CloudFront-Policy']).to eq('eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2ltYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTOlNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__')
           expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')

--- a/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
@@ -19,6 +19,7 @@ module Aws
             signer.signed_cookie("what_ever_ilegal/url")
           }.to raise_error(ArgumentError)
         end
+
         it 'can generate signed urls with custom policy' do
           policy =  {
             'Statement' => [
@@ -37,6 +38,7 @@ module Aws
           expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')
           expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')
         end
+
         it 'can generate signed urls with custom policy without passing a url' do
           policy =  {
             'Statement' => [
@@ -52,6 +54,7 @@ module Aws
           expect(cookie['CloudFront-Signature']).to eq('n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL83aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106HT4-Hp1c~nyOmXs4R5mU_')
           expect(cookie['CloudFront-Key-Pair-Id']).to eq('CF_KEYPAIR_ID')
         end
+
         it 'can generate signed cookies with canned policy' do
           cookie = signer.signed_cookie(
             "https://abc.cloudfront.net/images/image.jpg?color=red",


### PR DESCRIPTION
Thanks for the project!

Currently `Aws::CloudFront::CookieSigner#signed_cookie` requires url argument, but it seems unnecessary to pass url when passing policy. `Aws::CloudFront::Signer#signature` also expects either `policy` or `resource` (and `expires`).

https://github.com/aws/aws-sdk-ruby/blob/a6626a1e2f86c5f7c9cb19650b8df46a7305a6fb/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb#L79-L90

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html