### PR TITLE
Fix client docs to generate correct method name for wait_until

### DIFF
--- a/build_tools/aws-sdk-code-generator/templates/client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_class.mustache
@@ -106,7 +106,7 @@ module {{module_name}}
     # In between attempts, the waiter will sleep.
     #
     #     # polls in a loop, sleeping between attempts
-    #     client.waiter_until(waiter_name, params)
+    #     client.wait_until(waiter_name, params)
     #
     # ## Configuration
     #


### PR DESCRIPTION
The method name is wait_until, not waiter_until.

```ruby
[3] Pry(UNK)> ec2.waiter_until
NoMethodError: undefined method `waiter_until' for #<Aws::EC2::Client>
Did you mean?  wait_until
from (pry):3:in `__binding__'
[4] Pry(UNK)> iam.waiter_until
NoMethodError: undefined method `waiter_until' for #<Aws::IAM::Client>
Did you mean?  wait_until
from (pry):4:in `__binding__'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
