### PR TITLE
Update signed AWS request's credentials to remove deprecation warning

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased Changes
 ------------------
 
+1.0.3 (2019-04-07)
+------------------
+
+* Issue - Fix deprecation warning when signing an AWS request.
+
 1.0.3 (2018-06-28)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -572,7 +572,7 @@ module Aws
       end
 
       def credentials_set?(credentials)
-        credentials.access_key_id && credentials.secret_access_key
+        credentials.credentials.access_key_id && credentials.credentials.secret_access_key
       end
 
       class << self


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This pull request updates the `credentials_set?` method, from Deprecation 2.1.0, inside `aws-sdk-ruby/gems/aws-sigv4/lib/aws-sigv4/signer.rb` by using `#credentials` from `aws-sdk-ruby/gems/aws-sdk-core/lib/aws-sdk-core/credentials.rb` instead of the `access_key_id` and `secret_access_key` methods inside `aws-sdk-ruby/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb` that result in errors from a race condition. 
