### PR TITLE
Use target client in Object#copy_to when possible

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Change `Aws::S3::Object#copy_to` to use the target's client so the request is sent to the correct region endpoint.
+
 1.30.1 (2019-01-11)
 ------------------
 

--- a/gems/aws-sdk-s3/spec/object/copy_to_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/copy_to_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../spec_helper'
+
+module Aws
+  module S3
+    describe Object do
+      describe '#copy_to' do
+        let(:source_client) { Client.new(stub_responses: true) }
+        let(:destination_client) { Client.new(stub_responses: true) }
+        let(:source) do
+          Aws::S3::Object.new(
+            'source-bucket', 'source-key',
+            client: source_client
+          )
+        end
+        let(:destination) do
+          Aws::S3::Object.new(
+            'destination-bucket', 'destination-key',
+            client: destination_client
+          )
+        end
+        let(:copy_source) do
+          [
+            source.bucket_name,
+            Seahorse::Util.uri_path_escape(source.key)
+          ].join('/')
+        end
+
+        it 'copies one object to a location referenced by another object' do
+          expect(destination_client).to receive(:copy_object).with(
+            copy_source: copy_source,
+            bucket: destination.bucket_name,
+            key: destination.key
+          )
+          source.copy_to(destination)
+        end
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -50,12 +50,15 @@ module Aws
         end
 
         it 'accepts an S3::Object source' do
-          expect(client).to receive(:copy_object).with({
+          target = S3::Object.new(
+            'target-bucket', 'target-key',
+            stub_responses: true
+          )
+          expect(target.client).to receive(:copy_object).with({
             bucket: 'target-bucket',
             key: 'target-key',
             copy_source: 'bucket/unescaped/key%20path',
           })
-          target = S3::Object.new('target-bucket', 'target-key', stub_responses:true)
           object.copy_to(target)
         end
 


### PR DESCRIPTION
When calling `source.copy_to(target)` when source and target are both `Aws::S3::Object`s we need to use the `Client` instance of the target instead of the source to make the request land on the correct endpoint (and thus region).
