### PR TITLE
[Partial PR 1946] separate aws-eventstream diff

### DIFF
--- a/gems/aws-eventstream/CHANGELOG.md
+++ b/gems/aws-eventstream/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - public #encode_headers method
+
 1.0.1 (2018-06-15)
 ------------------
 

--- a/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
@@ -39,6 +39,12 @@ module Aws
       # and 4 bytes total message crc checksum
       OVERHEAD_LENGTH = 16
 
+      # Maximum header length allowed (after encode) 128kb
+      MAX_HEADERS_LENGTH = 131072
+
+      # Maximum payload length allowed (after encode) 16mb
+      MAX_PAYLOAD_LENGTH = 16777216
+
       # Encodes Aws::EventStream::Message to output IO when
       #   provided, else return the encoded binary string
       #
@@ -62,13 +68,20 @@ module Aws
         end
       end
 
-      private
-
+      # Encodes an Aws::EventStream::Message
+      #   into Aws::EventStream::BytesBuffer
+      #
+      # @param [Aws::EventStream::Message] msg
+      #
+      # @return [Aws::EventStream::BytesBuffer]
       def encode_message(message)
         # create context buffer with encode headers
         ctx_buffer = encode_headers(message)
         headers_len = ctx_buffer.bytesize
         # encode payload
+        if message.payload.length > MAX_PAYLOAD_LENGTH
+          raise Aws::EventStream::Errors::EventPayloadLengthExceedError.new
+        end
         ctx_buffer << message.payload.read
         total_len = ctx_buffer.bytesize + OVERHEAD_LENGTH
 
@@ -85,6 +98,12 @@ module Aws
         buffer
       end
 
+      # Encodes headers part of an Aws::EventStream::Message
+      #   into Aws::EventStream::BytesBuffer
+      #
+      # @param [Aws::EventStream::Message] msg
+      #
+      # @return [Aws::EventStream::BytesBuffer]
       def encode_headers(msg)
         buffer = BytesBuffer.new('')
         msg.headers.each do |k, v|
@@ -101,8 +120,13 @@ module Aws
           pattern ? buffer << [v.value].pack(pattern) :
             buffer << v.value
         end
+        if buffer.bytesize > MAX_HEADERS_LENGTH
+          raise Aws::EventStream::Errors::EventHeadersLengthExceedError.new
+        end
         buffer
       end
+
+      private
 
       def prelude(total_len, headers_len)
         BytesBuffer.new(pack_uint32([

--- a/gems/aws-eventstream/lib/aws-eventstream/errors.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/errors.rb
@@ -30,6 +30,18 @@ module Aws
         end
       end
 
+      class EventPayloadLengthExceedError < RuntimeError
+        def initialize(*args)
+          super("Payload length of a message should be under 16mb.")
+        end
+      end
+
+      class EventHeadersLengthExceedError < RuntimeError
+        def initialize(*args)
+          super("Encoded headers length of a message should be under 128kb.")
+        end
+      end
+
     end
   end
 end

--- a/gems/aws-eventstream/spec/encoder_spec.rb
+++ b/gems/aws-eventstream/spec/encoder_spec.rb
@@ -26,6 +26,37 @@ module Aws
         end
 
       end
+
+      describe "#encode error" do
+
+        it 'raises an error when payload exceeds' do
+          payload = double('payload', :length => 16777217)
+          message = Aws::EventStream::Message.new(
+            headers: {},
+            payload: payload
+          )
+          expect {
+            Encoder.new.encode(message)
+          }.to raise_error(Aws::EventStream::Errors::EventPayloadLengthExceedError)
+        end
+
+        it 'raises an error when encoded headers exceeds' do
+          headers = {}
+          headers['foo'] = Aws::EventStream::HeaderValue.new(
+            value: "*" * 131073, type: 'string'
+          )
+          message = Aws::EventStream::Message.new(
+            headers: headers,
+            payload: StringIO.new
+          )
+          expect {
+            Encoder.new.encode(message)
+          }.to raise_error(Aws::EventStream::Errors::EventHeadersLengthExceedError)
+
+        end
+
+      end
     end
+
   end
 end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR helps to release `aws-eventstream` changes first, as `aws-sigv4` requires a version bump on it.
same diff separates from #1946 
