### PR TITLE
Add waiter for SecurityGroup exists

### DIFF
--- a/apis/ec2/2016-11-15/waiters-2.json
+++ b/apis/ec2/2016-11-15/waiters-2.json
@@ -366,6 +366,24 @@
         }
       ]
     },
+    "SecurityGroupExists": {
+      "operation": "DescribeSecurityGroups",
+      "delay": 5,
+      "maxAttempts": 6,
+      "acceptors": [
+        {
+          "expected": true,
+          "matcher": "path",
+          "state": "success",
+          "argument": "length(security_groups[].group_id) > `0`"
+        },
+        {
+          "expected": "InvalidGroupNotFound",
+          "matcher": "error",
+          "state": "retry"
+        }
+      ]
+    },
     "SnapshotCompleted": {
       "delay": 15,
       "operation": "DescribeSnapshots",

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
@@ -25707,6 +25707,7 @@ module Aws::EC2
     # | nat_gateway_available           | {#describe_nat_gateways}            | 15       | 40            |
     # | network_interface_available     | {#describe_network_interfaces}      | 20       | 10            |
     # | password_data_available         | {#get_password_data}                | 15       | 40            |
+    # | security_group_exists           | {#describe_security_groups}         | 15       | 40            |
     # | snapshot_completed              | {#describe_snapshots}               | 15       | 40            |
     # | spot_instance_request_fulfilled | {#describe_spot_instance_requests}  | 15       | 40            |
     # | subnet_available                | {#describe_subnets}                 | 15       | 40            |
@@ -25788,6 +25789,7 @@ module Aws::EC2
         nat_gateway_available: Waiters::NatGatewayAvailable,
         network_interface_available: Waiters::NetworkInterfaceAvailable,
         password_data_available: Waiters::PasswordDataAvailable,
+        security_group_exists: Waiters::SecurityGroupExists,
         snapshot_completed: Waiters::SnapshotCompleted,
         spot_instance_request_fulfilled: Waiters::SpotInstanceRequestFulfilled,
         subnet_available: Waiters::SubnetAvailable,

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
@@ -25707,7 +25707,7 @@ module Aws::EC2
     # | nat_gateway_available           | {#describe_nat_gateways}            | 15       | 40            |
     # | network_interface_available     | {#describe_network_interfaces}      | 20       | 10            |
     # | password_data_available         | {#get_password_data}                | 15       | 40            |
-    # | security_group_exists           | {#describe_security_groups}         | 5        | 6            |
+    # | security_group_exists           | {#describe_security_groups}         | 5        | 6             |
     # | snapshot_completed              | {#describe_snapshots}               | 15       | 40            |
     # | spot_instance_request_fulfilled | {#describe_spot_instance_requests}  | 15       | 40            |
     # | subnet_available                | {#describe_subnets}                 | 15       | 40            |

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
@@ -25707,7 +25707,7 @@ module Aws::EC2
     # | nat_gateway_available           | {#describe_nat_gateways}            | 15       | 40            |
     # | network_interface_available     | {#describe_network_interfaces}      | 20       | 10            |
     # | password_data_available         | {#get_password_data}                | 15       | 40            |
-    # | security_group_exists           | {#describe_security_groups}         | 15       | 40            |
+    # | security_group_exists           | {#describe_security_groups}         | 5        | 6            |
     # | snapshot_completed              | {#describe_snapshots}               | 15       | 40            |
     # | spot_instance_request_fulfilled | {#describe_spot_instance_requests}  | 15       | 40            |
     # | subnet_available                | {#describe_subnets}                 | 15       | 40            |

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
@@ -675,6 +675,49 @@ module Aws::EC2
 
     end
 
+    class SecurityGroupExists
+
+      # @param [Hash] options
+      # @option options [required, Client] :client
+      # @option options [Integer] :max_attempts (6)
+      # @option options [Integer] :delay (5)
+      # @option options [Proc] :before_attempt
+      # @option options [Proc] :before_wait
+      def initialize(options)
+        @client = options.fetch(:client)
+        @waiter = Aws::Waiters::Waiter.new({
+          max_attempts: 6,
+          delay: 5,
+          poller: Aws::Waiters::Poller.new(
+            operation_name: :describe_security_groups,
+            acceptors: [
+              {
+                "expected" => true,
+                "matcher" => "path",
+                "state" => "success",
+                "argument" => "length(security_groups[].group_id) > `0`"
+              },
+              {
+                "expected" => "InvalidGroupNotFound",
+                "matcher" => "error",
+                "state" => "retry"
+              }
+            ]
+          )
+        }.merge(options))
+      end
+
+      # @option (see Client#describe_security_groups)
+      # @return (see Client#describe_security_groups)
+      def wait(params = {})
+        @waiter.wait(client: @client, params: params)
+      end
+
+      # @api private
+      attr_reader :waiter
+
+    end
+
     class NatGatewayAvailable
 
       # @param [Hash] options

--- a/gems/aws-sdk-ec2/spec/client_spec.rb
+++ b/gems/aws-sdk-ec2/spec/client_spec.rb
@@ -98,6 +98,30 @@ module Aws
           end
 
         end
+
+        describe ':security_group_exists' do
+
+          it 'returns fails when an error is returned' do
+            client = Client.new(stub_responses: true)
+            client.stub_responses(:describe_security_groups, 'InvalidGroupNotFound')
+            expect {
+              client.wait_until(:security_group_exists, group_ids:['sg-1234578']) do |w|
+                w.max_attempts = 1
+              end
+            }.to raise_error(Aws::Waiters::Errors::TooManyAttemptsError)
+          end
+
+          it 'returns the security_group object when the group exists' do
+            client = Client.new(stub_responses: true)
+            client.stub_responses(:describe_security_groups, security_groups: [{group_id: 'sg-1234578'}])
+            actual = client.wait_until(:security_group_exists, group_ids:['sg-1234578']) do |w|
+              w.max_attempts = 1
+            end
+            expect(actual.security_groups[0].group_id).to eq('sg-1234578')
+          end
+
+        end
+
       end
     end
   end


### PR DESCRIPTION
Add waiter for SecurityGroup exists.  The `wait_until` method on the SecurityGroup class has been deprecated and does not have a corresponding replacement per `# @deprecated Use [Aws::EC2::Client] #wait_until instead`

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
