### PR TITLE
Fix http-2 Dependency for Old Ruby Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   include:
     - rvm: 2.5
       env: OLD_OJ=1
-    - rvm: 2.5
+    - rvm: 2.3
       env: OLD_OX=1
     - rvm: 2.5
       env: NO_H2=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - rvm: jruby-9.1.16.0
       env: KITCHEN_SINK=1
   include:
-    - rvm: 2.5
+    - rvm: 2.3
       env: OLD_OJ=1
     - rvm: 2.3
       env: OLD_OX=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - jruby-9.1.16.0
 
 sudo: false
@@ -28,10 +29,12 @@ matrix:
     - rvm: jruby-9.1.16.0
       env: KITCHEN_SINK=1
   include:
-    - rvm: 2.3
+    - rvm: 2.5
       env: OLD_OJ=1
-    - rvm: 2.3
+    - rvm: 2.5
       env: OLD_OX=1
+    - rvm: 2.5
+      env: NO_H2=1
 
 notifications:
   webhooks:

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
     end
   end
 
-  if RUBY_VERSION >= '2.1'
+  if RUBY_VERSION >= '2.1' || ENV['NO_H2']
     # http 2 requires ruby version >= 2.1
     # over alpn with tls
     # requires ruby version >= 2.3 and openssl >=1.0.2

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
     end
   end
 
-  if RUBY_VERSION >= '2.1' || ENV['NO_H2']
+  if RUBY_VERSION >= '2.1' && !ENV['NO_H2']
     # http 2 requires ruby version >= 2.1
     # over alpn with tls
     # requires ruby version >= 2.3 and openssl >=1.0.2

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/async_client_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/async_client_spec.rb
@@ -7,7 +7,7 @@ describe 'Client Interface:' do
       SpecHelper.generate_service(['Async'], multiple_files: false)  
     end
 
-    if RUBY_VERSION >= '2.1'
+    if RUBY_VERSION >= '2.1' && !ENV['NO_H2']
 
       let(:output_stream) {
         [
@@ -134,8 +134,7 @@ describe 'Client Interface:' do
     else
 
       it 'raises error when initializing AsyncClient' do
-        expected_msg = "API operations over HTTP2 protocol"\
-          " is not supported for Ruby Version < 2.1"
+        expected_msg = "Must include http/2 gem to use AsyncClient instances."
         expect {
           Async::AsyncClient.new
         }.to raise_error(RuntimeError, expected_msg)

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -24,9 +24,8 @@ module {{module_name}}
     {{>documentation}}
     {{/client_constructor}}
     def initialize(*args)
-      unless RUBY_VERSION >= '2.1'
-        raise "API operations over HTTP2 protocol is not supported"\
-          " for Ruby Version < 2.1"
+      unless Kernel.const_defined?("HTTP2::Client")
+        raise "Must include http/2 gem to use AsyncClient instances."
       end
       super
     end

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -1,6 +1,13 @@
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}
+if RUBY_VERSION <= '2.1'
+  begin
+    require 'http/2'
+  rescue LoadError
+    STDERR.puts "Unable to load the http/2 gem."
+  end
+end
 {{#plugin_requires}}
 require '{{.}}'
 {{/plugin_requires}}

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -24,7 +24,7 @@ module {{module_name}}
     {{>documentation}}
     {{/client_constructor}}
     def initialize(*args)
-      unless Kernel.const_defined?("HTTP2::Client")
+      unless Kernel.const_defined?("HTTP2")
         raise "Must include http/2 gem to use AsyncClient instances."
       end
       super

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -1,7 +1,7 @@
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}
-if RUBY_VERSION <= '2.1'
+if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
   rescue LoadError

--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -8,7 +8,7 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.47.0"
+    MINIMUM_CORE_VERSION = "3.47.1"
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 
     # @option options [String] :manifest_path (MANIFEST_PATH)

--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -8,7 +8,7 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.47.1"
+    MINIMUM_CORE_VERSION = "3.48.0"
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 
     # @option options [String] :manifest_path (MANIFEST_PATH)

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix http-2 Dependency for Old Ruby Versions (Github Issue #1994)
+
 3.47.0 (2019-03-14)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix http-2 Dependency for Old Ruby Versions (Github Issue #1994)
+* Feature - Fix http-2 Dependency for Old Ruby Versions (Github Issue #1994)
 
 3.47.0 (2019-03-14)
 ------------------

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-partitions', '~> 1.0')
   spec.add_dependency('aws-sigv4', '~> 1.1') # necessary for making Aws::STS API calls
   spec.add_dependency('aws-eventstream', '~> 1.0', '>= 1.0.2') # necessary for binary eventstream
-  spec.add_dependency('http-2', '~> 0.10') # necessary for making h2 calls
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-core',

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -1,5 +1,9 @@
-if RUBY_VERSION >= '2.1'
-  require 'http/2'
+if RUBY_VERSION <= '2.1'
+  begin
+    require 'http/2'
+  rescue LoadError
+    STDERR.puts "Unable to load the http/2 gem."
+  end
 end
 require 'openssl'
 require 'socket'

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION <= '2.1'
+if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
   rescue LoadError

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
@@ -1,5 +1,9 @@
-if RUBY_VERSION >= '2.1'
-  require 'http/2'
+if RUBY_VERSION <= '2.1'
+  begin
+    require 'http/2'
+  rescue LoadError
+    STDERR.puts "Unable to load the http/2 gem."
+  end
 end
 require 'securerandom'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION <= '2.1'
+if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
   rescue LoadError

--- a/gems/aws-sdk-core/spec/seahorse/client/async_base_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/async_base_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 module Seahorse
   module Client
     describe AsyncBase do
-      if RUBY_VERSION >= '2.1'
+      if RUBY_VERSION >= '2.1' && !ENV['NO_H2']
 
         describe 'api operations' do
 

--- a/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
@@ -4,7 +4,7 @@ module Seahorse
   module Client
     module H2
       describe Connection do
-        if RUBY_VERSION >= '2.1'
+        if RUBY_VERSION >= '2.1' && !ENV['NO_H2']
           let(:conn) { Connection.new }
 
           describe '#new_stream' do
@@ -15,6 +15,10 @@ module Seahorse
 
           end
 
+        else
+          it 'it should raise an error when you attempt to create a connection' do
+            Connection.new
+          end
         end
 
       end

--- a/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
@@ -14,11 +14,6 @@ module Seahorse
             end
 
           end
-
-        else
-          it 'it should raise an error when you attempt to create a connection' do
-            Connection.new
-          end
         end
 
       end

--- a/gems/aws-sdk-kinesis/CHANGELOG.md
+++ b/gems/aws-sdk-kinesis/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Update AsyncClient implementation. Note that the `http-2` gem now must be included separately in your Gemfile or gemspec in order to use the asyncronous client.
+
 1.10.0 (2019-03-14)
 ------------------
 

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesis/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.47.0')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.47.1')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesis/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.47.1')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -5,6 +5,13 @@
 #
 # WARNING ABOUT GENERATED CODE
 
+if RUBY_VERSION >= '2.1'
+  begin
+    require 'http/2'
+  rescue LoadError
+    STDERR.puts "Unable to load the http/2 gem."
+  end
+end
 require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'
 require 'aws-sdk-core/plugins/logging.rb'
@@ -172,7 +179,7 @@ module Aws::Kinesis
     #     sending the request.
     #
     def initialize(*args)
-      unless Kernel.const_defined?("HTTP2::Client")
+      unless Kernel.const_defined?("HTTP2")
         raise "Must include http/2 gem to use AsyncClient instances."
       end
       super

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -172,9 +172,8 @@ module Aws::Kinesis
     #     sending the request.
     #
     def initialize(*args)
-      unless RUBY_VERSION >= '2.1'
-        raise "API operations over HTTP2 protocol is not supported"\
-          " for Ruby Version < 2.1"
+      unless Kernel.const_defined?("HTTP2::Client")
+        raise "Must include http/2 gem to use AsyncClient instances."
       end
       super
     end


### PR DESCRIPTION
While older Ruby versions are end of life, we still attempt to provide backwards compatibility, for example if users are using 3rd party long term support versions of older Rubies. The `http-2` gem has a hard lock on Ruby versions, requiring `2.1` or newer. This branch is looking for a way to:

1. Unblock users with older Rubies so they can install the latest version of aws-sdk-core and receive service updates.
2. Provide a reasonable path for using HTTP/2 features for those with compatible Rubies (> 2.1).
3. Not break any users who are just upgrading their gems regularly without using the new features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
