### PR TITLE
Correct gemspec metadata

### DIFF
--- a/build_tools/aws-sdk-code-generator/aws-sdk-code-generator.gemspec
+++ b/build_tools/aws-sdk-code-generator/aws-sdk-code-generator.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Code Generator'
   spec.description   = 'Generates the service code for the AWS SDK for Ruby'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
@@ -24,7 +24,7 @@ module AwsSdkCodeGenerator
       end
 
       def homepage
-        @custom ? 'http://gem-homepage.com' : 'http://github.com/aws/aws-sdk-ruby'
+        @custom ? 'http://gem-homepage.com' : 'https://github.com/aws/aws-sdk-ruby'
       end
 
       def email

--- a/gems/aws-eventstream/aws-eventstream.gemspec
+++ b/gems/aws-eventstream/aws-eventstream.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS Event Stream Library'
   spec.description   = 'Amazon Web Services event stream library. Decodes and encodes binary stream under `vnd.amazon.event-stream` content-type'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
 

--- a/gems/aws-partitions/aws-partitions.gemspec
+++ b/gems/aws-partitions/aws-partitions.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Provides information about AWS partitions, regions, and services.'
   spec.description   = 'Provides interfaces to enumerate AWS partitions, regions, and services.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = ['partitions.json'] + Dir['lib/**/*.rb']
 

--- a/gems/aws-sdk-acm/aws-sdk-acm.gemspec
+++ b/gems/aws-sdk-acm/aws-sdk-acm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - ACM'
   spec.description   = 'Official AWS Ruby gem for AWS Certificate Manager (ACM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
+++ b/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - ACM-PCA'
   spec.description   = 'Official AWS Ruby gem for AWS Certificate Manager Private Certificate Authority (ACM-PCA). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
+++ b/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Alexa For Business'
   spec.description   = 'Official AWS Ruby gem for Alexa For Business. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
+++ b/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amplify'
   spec.description   = 'Official AWS Ruby gem for AWS Amplify (Amplify). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
+++ b/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon API Gateway'
   spec.description   = 'Official AWS Ruby gem for Amazon API Gateway. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
+++ b/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AmazonApiGatewayManagementApi'
   spec.description   = 'Official AWS Ruby gem for AmazonApiGatewayManagementApi. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
+++ b/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AmazonApiGatewayV2'
   spec.description   = 'Official AWS Ruby gem for AmazonApiGatewayV2. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
+++ b/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Application Auto Scaling'
   spec.description   = 'Official AWS Ruby gem for Application Auto Scaling. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
+++ b/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Application Discovery Service'
   spec.description   = 'Official AWS Ruby gem for AWS Application Discovery Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
+++ b/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS App Mesh'
   spec.description   = 'Official AWS Ruby gem for AWS App Mesh. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
+++ b/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon AppStream'
   spec.description   = 'Official AWS Ruby gem for Amazon AppStream. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
+++ b/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWSAppSync'
   spec.description   = 'Official AWS Ruby gem for AWS AppSync (AWSAppSync). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-athena/aws-sdk-athena.gemspec
+++ b/gems/aws-sdk-athena/aws-sdk-athena.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Athena'
   spec.description   = 'Official AWS Ruby gem for Amazon Athena. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
+++ b/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Auto Scaling'
   spec.description   = 'Official AWS Ruby gem for Auto Scaling. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
+++ b/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Auto Scaling Plans'
   spec.description   = 'Official AWS Ruby gem for AWS Auto Scaling Plans. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-backup/aws-sdk-backup.gemspec
+++ b/gems/aws-sdk-backup/aws-sdk-backup.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Backup'
   spec.description   = 'Official AWS Ruby gem for AWS Backup. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-batch/aws-sdk-batch.gemspec
+++ b/gems/aws-sdk-batch/aws-sdk-batch.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Batch'
   spec.description   = 'Official AWS Ruby gem for AWS Batch. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
+++ b/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWSBudgets'
   spec.description   = 'Official AWS Ruby gem for AWS Budgets (AWSBudgets). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-chime/aws-sdk-chime.gemspec
+++ b/gems/aws-sdk-chime/aws-sdk-chime.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Chime'
   spec.description   = 'Official AWS Ruby gem for Amazon Chime. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
+++ b/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Cloud9'
   spec.description   = 'Official AWS Ruby gem for AWS Cloud9. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
+++ b/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon CloudDirectory'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudDirectory. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
+++ b/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS CloudFormation'
   spec.description   = 'Official AWS Ruby gem for AWS CloudFormation. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
+++ b/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CloudFront'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudFront (CloudFront). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
+++ b/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CloudHSM'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudHSM (CloudHSM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
+++ b/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CloudHSM V2'
   spec.description   = 'Official AWS Ruby gem for AWS CloudHSM V2 (CloudHSM V2). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
+++ b/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon CloudSearch'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudSearch. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
+++ b/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon CloudSearch Domain'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudSearch Domain. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
+++ b/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CloudTrail'
   spec.description   = 'Official AWS Ruby gem for AWS CloudTrail (CloudTrail). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
+++ b/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CloudWatch'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudWatch (CloudWatch). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
+++ b/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon CloudWatch Events'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudWatch Events. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
+++ b/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon CloudWatch Logs'
   spec.description   = 'Official AWS Ruby gem for Amazon CloudWatch Logs. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
+++ b/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS CodeBuild'
   spec.description   = 'Official AWS Ruby gem for AWS CodeBuild. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
+++ b/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CodeCommit'
   spec.description   = 'Official AWS Ruby gem for AWS CodeCommit (CodeCommit). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
+++ b/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CodeDeploy'
   spec.description   = 'Official AWS Ruby gem for AWS CodeDeploy (CodeDeploy). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
+++ b/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CodePipeline'
   spec.description   = 'Official AWS Ruby gem for AWS CodePipeline (CodePipeline). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
+++ b/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - CodeStar'
   spec.description   = 'Official AWS Ruby gem for AWS CodeStar (CodeStar). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
+++ b/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Cognito Identity'
   spec.description   = 'Official AWS Ruby gem for Amazon Cognito Identity. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
+++ b/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Cognito Identity Provider'
   spec.description   = 'Official AWS Ruby gem for Amazon Cognito Identity Provider. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
+++ b/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Cognito Sync'
   spec.description   = 'Official AWS Ruby gem for Amazon Cognito Sync. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
+++ b/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Comprehend'
   spec.description   = 'Official AWS Ruby gem for Amazon Comprehend. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
+++ b/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - ComprehendMedical'
   spec.description   = 'Official AWS Ruby gem for AWS Comprehend Medical (ComprehendMedical). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
+++ b/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Config Service'
   spec.description   = 'Official AWS Ruby gem for AWS Config (Config Service). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-connect/aws-sdk-connect.gemspec
+++ b/gems/aws-sdk-connect/aws-sdk-connect.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Connect'
   spec.description   = 'Official AWS Ruby gem for Amazon Connect Service (Amazon Connect). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Core'
   spec.description   = 'Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.require_paths = ['lib']
   spec.files         = ['ca-bundle.crt', 'VERSION']

--- a/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
+++ b/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Cost and Usage Report Service'
   spec.description   = 'Official AWS Ruby gem for AWS Cost and Usage Report Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
+++ b/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Cost Explorer'
   spec.description   = 'Official AWS Ruby gem for AWS Cost Explorer Service (AWS Cost Explorer). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
+++ b/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Database Migration Service'
   spec.description   = 'Official AWS Ruby gem for AWS Database Migration Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
+++ b/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Data Pipeline'
   spec.description   = 'Official AWS Ruby gem for AWS Data Pipeline. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
+++ b/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - DataSync'
   spec.description   = 'Official AWS Ruby gem for AWS DataSync (DataSync). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-dax/aws-sdk-dax.gemspec
+++ b/gems/aws-sdk-dax/aws-sdk-dax.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon DAX'
   spec.description   = 'Official AWS Ruby gem for Amazon DynamoDB Accelerator (DAX) (Amazon DAX). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
+++ b/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Device Farm'
   spec.description   = 'Official AWS Ruby gem for AWS Device Farm. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
+++ b/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Direct Connect'
   spec.description   = 'Official AWS Ruby gem for AWS Direct Connect. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
+++ b/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Directory Service'
   spec.description   = 'Official AWS Ruby gem for AWS Directory Service (Directory Service). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
+++ b/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon DLM'
   spec.description   = 'Official AWS Ruby gem for Amazon Data Lifecycle Manager (Amazon DLM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
+++ b/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon DocDB'
   spec.description   = 'Official AWS Ruby gem for Amazon DocumentDB with MongoDB compatibility (Amazon DocDB). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
+++ b/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - DynamoDB'
   spec.description   = 'Official AWS Ruby gem for Amazon DynamoDB (DynamoDB). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
+++ b/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon DynamoDB Streams'
   spec.description   = 'Official AWS Ruby gem for Amazon DynamoDB Streams. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
+++ b/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon EC2'
   spec.description   = 'Official AWS Ruby gem for Amazon Elastic Compute Cloud (Amazon EC2). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
+++ b/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon ECR'
   spec.description   = 'Official AWS Ruby gem for Amazon EC2 Container Registry (Amazon ECR). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
+++ b/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon ECS'
   spec.description   = 'Official AWS Ruby gem for Amazon EC2 Container Service (Amazon ECS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-efs/aws-sdk-efs.gemspec
+++ b/gems/aws-sdk-efs/aws-sdk-efs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - EFS'
   spec.description   = 'Official AWS Ruby gem for Amazon Elastic File System (EFS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-eks/aws-sdk-eks.gemspec
+++ b/gems/aws-sdk-eks/aws-sdk-eks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon EKS'
   spec.description   = 'Official AWS Ruby gem for Amazon Elastic Container Service for Kubernetes (Amazon EKS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
+++ b/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon ElastiCache'
   spec.description   = 'Official AWS Ruby gem for Amazon ElastiCache. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
+++ b/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Elastic Beanstalk'
   spec.description   = 'Official AWS Ruby gem for AWS Elastic Beanstalk (Elastic Beanstalk). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
+++ b/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Elastic Load Balancing'
   spec.description   = 'Official AWS Ruby gem for Elastic Load Balancing. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
+++ b/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Elastic Load Balancing v2'
   spec.description   = 'Official AWS Ruby gem for Elastic Load Balancing (Elastic Load Balancing v2). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
+++ b/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Elasticsearch Service'
   spec.description   = 'Official AWS Ruby gem for Amazon Elasticsearch Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
+++ b/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Elastic Transcoder'
   spec.description   = 'Official AWS Ruby gem for Amazon Elastic Transcoder. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-emr/aws-sdk-emr.gemspec
+++ b/gems/aws-sdk-emr/aws-sdk-emr.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon EMR'
   spec.description   = 'Official AWS Ruby gem for Amazon Elastic MapReduce (Amazon EMR). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
+++ b/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Firehose'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Firehose (Firehose). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-fms/aws-sdk-fms.gemspec
+++ b/gems/aws-sdk-fms/aws-sdk-fms.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - FMS'
   spec.description   = 'Official AWS Ruby gem for Firewall Management Service (FMS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
+++ b/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon FSx'
   spec.description   = 'Official AWS Ruby gem for Amazon FSx. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
+++ b/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon GameLift'
   spec.description   = 'Official AWS Ruby gem for Amazon GameLift. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
+++ b/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Glacier'
   spec.description   = 'Official AWS Ruby gem for Amazon Glacier. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
+++ b/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Global Accelerator'
   spec.description   = 'Official AWS Ruby gem for AWS Global Accelerator. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-glue/aws-sdk-glue.gemspec
+++ b/gems/aws-sdk-glue/aws-sdk-glue.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Glue'
   spec.description   = 'Official AWS Ruby gem for AWS Glue. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
+++ b/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Greengrass'
   spec.description   = 'Official AWS Ruby gem for AWS Greengrass. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
+++ b/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon GuardDuty'
   spec.description   = 'Official AWS Ruby gem for Amazon GuardDuty. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-health/aws-sdk-health.gemspec
+++ b/gems/aws-sdk-health/aws-sdk-health.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWSHealth'
   spec.description   = 'Official AWS Ruby gem for AWS Health APIs and Notifications (AWSHealth). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iam/aws-sdk-iam.gemspec
+++ b/gems/aws-sdk-iam/aws-sdk-iam.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - IAM'
   spec.description   = 'Official AWS Ruby gem for AWS Identity and Access Management (IAM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
+++ b/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Import/Export'
   spec.description   = 'Official AWS Ruby gem for AWS Import/Export. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
+++ b/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Inspector'
   spec.description   = 'Official AWS Ruby gem for Amazon Inspector. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iot/aws-sdk-iot.gemspec
+++ b/gems/aws-sdk-iot/aws-sdk-iot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT'
   spec.description   = 'Official AWS Ruby gem for AWS IoT. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
+++ b/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT 1-Click Devices Service'
   spec.description   = 'Official AWS Ruby gem for AWS IoT 1-Click Devices Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
+++ b/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT 1-Click Projects'
   spec.description   = 'Official AWS Ruby gem for AWS IoT 1-Click Projects Service (AWS IoT 1-Click Projects). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
+++ b/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT Analytics'
   spec.description   = 'Official AWS Ruby gem for AWS IoT Analytics. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
+++ b/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT Data Plane'
   spec.description   = 'Official AWS Ruby gem for AWS IoT Data Plane. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
+++ b/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS IoT Jobs Data Plane'
   spec.description   = 'Official AWS Ruby gem for AWS IoT Jobs Data Plane. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
+++ b/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kafka'
   spec.description   = 'Official AWS Ruby gem for Managed Streaming for Kafka (Kafka). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis (Kinesis). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
+++ b/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis Analytics'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Analytics (Kinesis Analytics). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
+++ b/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis Analytics V2'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Analytics (Kinesis Analytics V2). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
+++ b/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis Video'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Video Streams (Kinesis Video). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis Video Archived Media'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Video Streams Archived Media (Kinesis Video Archived Media). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
+++ b/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Kinesis Video Media'
   spec.description   = 'Official AWS Ruby gem for Amazon Kinesis Video Streams Media (Kinesis Video Media). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-kms/aws-sdk-kms.gemspec
+++ b/gems/aws-sdk-kms/aws-sdk-kms.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - KMS'
   spec.description   = 'Official AWS Ruby gem for AWS Key Management Service (KMS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
+++ b/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Lambda'
   spec.description   = 'Official AWS Ruby gem for AWS Lambda. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
+++ b/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Lambda'
   spec.description   = 'Official AWS Ruby gem for AWS Lambda. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lex/aws-sdk-lex.gemspec
+++ b/gems/aws-sdk-lex/aws-sdk-lex.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Lex Runtime Service'
   spec.description   = 'Official AWS Ruby gem for Amazon Lex Runtime Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
+++ b/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Lex Model Building Service'
   spec.description   = 'Official AWS Ruby gem for Amazon Lex Model Building Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lexruntimeservice/aws-sdk-lexruntimeservice.gemspec
+++ b/gems/aws-sdk-lexruntimeservice/aws-sdk-lexruntimeservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Lex Runtime Service'
   spec.description   = 'This gem is deprecated, please use `aws-sdk-lex` instead. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
+++ b/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS License Manager'
   spec.description   = 'Official AWS Ruby gem for AWS License Manager. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
+++ b/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Lightsail'
   spec.description   = 'Official AWS Ruby gem for Amazon Lightsail. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
+++ b/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Machine Learning'
   spec.description   = 'Official AWS Ruby gem for Amazon Machine Learning. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-macie/aws-sdk-macie.gemspec
+++ b/gems/aws-sdk-macie/aws-sdk-macie.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Macie'
   spec.description   = 'Official AWS Ruby gem for Amazon Macie. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
+++ b/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Marketplace Commerce Analytics'
   spec.description   = 'Official AWS Ruby gem for AWS Marketplace Commerce Analytics. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
+++ b/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Marketplace Entitlement Service'
   spec.description   = 'Official AWS Ruby gem for AWS Marketplace Entitlement Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
+++ b/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWSMarketplace Metering'
   spec.description   = 'Official AWS Ruby gem for AWSMarketplace Metering. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
+++ b/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS MediaConnect'
   spec.description   = 'Official AWS Ruby gem for AWS MediaConnect. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
+++ b/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaConvert'
   spec.description   = 'Official AWS Ruby gem for AWS Elemental MediaConvert (MediaConvert). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
+++ b/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaLive'
   spec.description   = 'Official AWS Ruby gem for AWS Elemental MediaLive (MediaLive). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
+++ b/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaPackage'
   spec.description   = 'Official AWS Ruby gem for AWS Elemental MediaPackage (MediaPackage). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
+++ b/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaStore'
   spec.description   = 'Official AWS Ruby gem for AWS Elemental MediaStore (MediaStore). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
+++ b/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaStore Data'
   spec.description   = 'Official AWS Ruby gem for AWS Elemental MediaStore Data Plane (MediaStore Data). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
+++ b/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - MediaTailor'
   spec.description   = 'Official AWS Ruby gem for AWS MediaTailor (MediaTailor). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
+++ b/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Migration Hub'
   spec.description   = 'Official AWS Ruby gem for AWS Migration Hub. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
+++ b/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Mobile'
   spec.description   = 'Official AWS Ruby gem for AWS Mobile. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mq/aws-sdk-mq.gemspec
+++ b/gems/aws-sdk-mq/aws-sdk-mq.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AmazonMQ'
   spec.description   = 'Official AWS Ruby gem for AmazonMQ. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
+++ b/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon MTurk'
   spec.description   = 'Official AWS Ruby gem for Amazon Mechanical Turk (Amazon MTurk). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
+++ b/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Neptune'
   spec.description   = 'Official AWS Ruby gem for Amazon Neptune. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
+++ b/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS OpsWorks'
   spec.description   = 'Official AWS Ruby gem for AWS OpsWorks. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
+++ b/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - OpsWorksCM'
   spec.description   = 'Official AWS Ruby gem for AWS OpsWorks for Chef Automate (OpsWorksCM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
+++ b/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Organizations'
   spec.description   = 'Official AWS Ruby gem for AWS Organizations (Organizations). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-pi/aws-sdk-pi.gemspec
+++ b/gems/aws-sdk-pi/aws-sdk-pi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS PI'
   spec.description   = 'Official AWS Ruby gem for AWS Performance Insights (AWS PI). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
+++ b/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Pinpoint'
   spec.description   = 'Official AWS Ruby gem for Amazon Pinpoint. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
+++ b/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Pinpoint Email'
   spec.description   = 'Official AWS Ruby gem for Amazon Pinpoint Email Service (Pinpoint Email). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
+++ b/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Pinpoint SMS Voice'
   spec.description   = 'Official AWS Ruby gem for Amazon Pinpoint SMS and Voice Service (Pinpoint SMS Voice). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-polly/aws-sdk-polly.gemspec
+++ b/gems/aws-sdk-polly/aws-sdk-polly.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Polly'
   spec.description   = 'Official AWS Ruby gem for Amazon Polly. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
+++ b/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Pricing'
   spec.description   = 'Official AWS Ruby gem for AWS Price List Service (AWS Pricing). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
+++ b/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon QuickSight'
   spec.description   = 'Official AWS Ruby gem for Amazon QuickSight. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ram/aws-sdk-ram.gemspec
+++ b/gems/aws-sdk-ram/aws-sdk-ram.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - RAM'
   spec.description   = 'Official AWS Ruby gem for AWS Resource Access Manager (RAM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-rds/aws-sdk-rds.gemspec
+++ b/gems/aws-sdk-rds/aws-sdk-rds.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon RDS'
   spec.description   = 'Official AWS Ruby gem for Amazon Relational Database Service (Amazon RDS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
+++ b/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS RDS DataService'
   spec.description   = 'Official AWS Ruby gem for AWS RDS DataService. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
+++ b/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Redshift'
   spec.description   = 'Official AWS Ruby gem for Amazon Redshift. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
+++ b/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Rekognition'
   spec.description   = 'Official AWS Ruby gem for Amazon Rekognition. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
+++ b/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Resource Groups'
   spec.description   = 'Official AWS Ruby gem for AWS Resource Groups (Resource Groups). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
+++ b/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Resource Groups Tagging API'
   spec.description   = 'Official AWS Ruby gem for AWS Resource Groups Tagging API. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-resources/aws-sdk-resources.gemspec
+++ b/gems/aws-sdk-resources/aws-sdk-resources.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby'
   spec.description   = 'The official AWS SDK for Ruby. Provides both resource oriented interfaces and API clients for AWS services.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.files         = Dir['lib/**/*.rb']

--- a/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
+++ b/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - RoboMaker'
   spec.description   = 'Official AWS Ruby gem for AWS RoboMaker (RoboMaker). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-route53/aws-sdk-route53.gemspec
+++ b/gems/aws-sdk-route53/aws-sdk-route53.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Route 53'
   spec.description   = 'Official AWS Ruby gem for Amazon Route 53 (Route 53). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
+++ b/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Route 53 Domains'
   spec.description   = 'Official AWS Ruby gem for Amazon Route 53 Domains. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
+++ b/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Route53Resolver'
   spec.description   = 'Official AWS Ruby gem for Amazon Route 53 Resolver (Route53Resolver). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-s3/aws-sdk-s3.gemspec
+++ b/gems/aws-sdk-s3/aws-sdk-s3.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon S3'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
+++ b/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS S3 Control'
   spec.description   = 'Official AWS Ruby gem for AWS S3 Control. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
+++ b/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - SageMaker'
   spec.description   = 'Official AWS Ruby gem for Amazon SageMaker Service (SageMaker). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
+++ b/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SageMaker Runtime'
   spec.description   = 'Official AWS Ruby gem for Amazon SageMaker Runtime. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
+++ b/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Secrets Manager'
   spec.description   = 'Official AWS Ruby gem for AWS Secrets Manager. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
+++ b/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS SecurityHub'
   spec.description   = 'Official AWS Ruby gem for AWS SecurityHub. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
+++ b/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWSServerlessApplicationRepository'
   spec.description   = 'Official AWS Ruby gem for AWSServerlessApplicationRepository. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
+++ b/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Service Catalog'
   spec.description   = 'Official AWS Ruby gem for AWS Service Catalog. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
+++ b/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - ServiceDiscovery'
   spec.description   = 'Official AWS Ruby gem for AWS Cloud Map (ServiceDiscovery). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ses/aws-sdk-ses.gemspec
+++ b/gems/aws-sdk-ses/aws-sdk-ses.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SES'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Email Service (Amazon SES). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sfn/aws-sdk-sfn.gemspec
+++ b/gems/aws-sdk-sfn/aws-sdk-sfn.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS SFN'
   spec.description   = 'This gem is deprecated, please use `aws-sdk-states` instead. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-shield/aws-sdk-shield.gemspec
+++ b/gems/aws-sdk-shield/aws-sdk-shield.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Shield'
   spec.description   = 'Official AWS Ruby gem for AWS Shield. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-signer/aws-sdk-signer.gemspec
+++ b/gems/aws-sdk-signer/aws-sdk-signer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - signer'
   spec.description   = 'Official AWS Ruby gem for AWS Signer (signer). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
+++ b/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SimpleDB'
   spec.description   = 'Official AWS Ruby gem for Amazon SimpleDB. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sms/aws-sdk-sms.gemspec
+++ b/gems/aws-sdk-sms/aws-sdk-sms.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - SMS'
   spec.description   = 'Official AWS Ruby gem for AWS Server Migration Service (SMS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
+++ b/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Snowball'
   spec.description   = 'Official AWS Ruby gem for Amazon Import/Export Snowball (Amazon Snowball). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sns/aws-sdk-sns.gemspec
+++ b/gems/aws-sdk-sns/aws-sdk-sns.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SNS'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Notification Service (Amazon SNS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
+++ b/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SQS'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Queue Service (Amazon SQS). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
+++ b/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SSM'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Systems Manager (SSM) (Amazon SSM). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-states/aws-sdk-states.gemspec
+++ b/gems/aws-sdk-states/aws-sdk-states.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS SFN'
   spec.description   = 'Official AWS Ruby gem for AWS Step Functions (AWS SFN). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
+++ b/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Storage Gateway'
   spec.description   = 'Official AWS Ruby gem for AWS Storage Gateway. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-support/aws-sdk-support.gemspec
+++ b/gems/aws-sdk-support/aws-sdk-support.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Support'
   spec.description   = 'Official AWS Ruby gem for AWS Support. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-swf/aws-sdk-swf.gemspec
+++ b/gems/aws-sdk-swf/aws-sdk-swf.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon SWF'
   spec.description   = 'Official AWS Ruby gem for Amazon Simple Workflow Service (Amazon SWF). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-textract/aws-sdk-textract.gemspec
+++ b/gems/aws-sdk-textract/aws-sdk-textract.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Textract'
   spec.description   = 'Official AWS Ruby gem for Amazon Textract. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
+++ b/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Transcribe Service'
   spec.description   = 'Official AWS Ruby gem for Amazon Transcribe Service. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
+++ b/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS Transfer'
   spec.description   = 'Official AWS Ruby gem for AWS Transfer for SFTP (AWS Transfer). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-translate/aws-sdk-translate.gemspec
+++ b/gems/aws-sdk-translate/aws-sdk-translate.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon Translate'
   spec.description   = 'Official AWS Ruby gem for Amazon Translate. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-waf/aws-sdk-waf.gemspec
+++ b/gems/aws-sdk-waf/aws-sdk-waf.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - WAF'
   spec.description   = 'Official AWS Ruby gem for AWS WAF (WAF). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
+++ b/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - WAF Regional'
   spec.description   = 'Official AWS Ruby gem for AWS WAF Regional (WAF Regional). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
+++ b/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon WorkDocs'
   spec.description   = 'Official AWS Ruby gem for Amazon WorkDocs. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
+++ b/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - WorkLink'
   spec.description   = 'Official AWS Ruby gem for Amazon WorkLink (WorkLink). This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
+++ b/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon WorkMail'
   spec.description   = 'Official AWS Ruby gem for Amazon WorkMail. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
+++ b/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - Amazon WorkSpaces'
   spec.description   = 'Official AWS Ruby gem for Amazon WorkSpaces. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk-xray/aws-sdk-xray.gemspec
+++ b/gems/aws-sdk-xray/aws-sdk-xray.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby - AWS X-Ray'
   spec.description   = 'Official AWS Ruby gem for AWS X-Ray. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.require_paths = ['lib']

--- a/gems/aws-sdk/aws-sdk.gemspec
+++ b/gems/aws-sdk/aws-sdk.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS SDK for Ruby'
   spec.description   = 'The official AWS SDK for Ruby. Provides both resource oriented interfaces and API clients for AWS services.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.email         = ['trevrowe@amazon.com']
   spec.files         = Dir['lib/**/*.rb']

--- a/gems/aws-sigv2/aws-sigv2.gemspec
+++ b/gems/aws-sigv2/aws-sigv2.gemspec
@@ -2,9 +2,9 @@ Gem::Specification.new do |spec|
   spec.name          = 'aws-sigv2'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
   spec.summary       = 'AWS Signature Version 2 library.'
-  spec.description   = 'Amazon Web Services Signature Version 2 signing ligrary. Generates sigv2 signature for HTTP requests.'
+  spec.description   = 'Amazon Web Services Signature Version 2 signing library. Generates sigv2 signature for HTTP requests.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
 

--- a/gems/aws-sigv4/aws-sigv4.gemspec
+++ b/gems/aws-sigv4/aws-sigv4.gemspec
@@ -2,9 +2,9 @@ Gem::Specification.new do |spec|
   spec.name          = 'aws-sigv4'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
   spec.summary       = 'AWS Signature Version 4 library.'
-  spec.description   = 'Amazon Web Services Signature Version 4 signing ligrary. Generates sigv4 signature for HTTP requests.'
+  spec.description   = 'Amazon Web Services Signature Version 4 signing library. Generates sigv4 signature for HTTP requests.'
   spec.author        = 'Amazon Web Services'
-  spec.homepage      = 'http://github.com/aws/aws-sdk-ruby'
+  spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
 


### PR DESCRIPTION
This changes Github URLs to use https to avoid a redirect. It also fixes two typos in descriptions.