### PR TITLE
Remove Final Instances of Error Output

### DIFF
--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -4,9 +4,7 @@
 if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
-  rescue LoadError
-    STDERR.puts "Unable to load the http/2 gem."
-  end
+  rescue LoadError; end
 end
 {{#plugin_requires}}
 require '{{.}}'

--- a/gems/aws-sdk-kinesis/CHANGELOG.md
+++ b/gems/aws-sdk-kinesis/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove debug message spam when `http-2` gem is not present.
+
 1.13.0 (2019-03-22)
 ------------------
 

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -8,9 +8,7 @@
 if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
-  rescue LoadError
-    STDERR.puts "Unable to load the http/2 gem."
-  end
+  rescue LoadError; end
 end
 require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'

--- a/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
+++ b/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove debug message spam when `http-2` gem is not present.
+
 1.0.0 (2019-03-21)
 ------------------
 

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
@@ -8,9 +8,7 @@
 if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'
-  rescue LoadError
-    STDERR.puts "Unable to load the http/2 gem."
-  end
+  rescue LoadError; end
 end
 require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'


### PR DESCRIPTION
It does seem more reasonable to have AsyncClient instances emit this
error, but since they are eager loaded, this in effect has the error
appear anytime someone loads `aws-sdk-kinesis` or
`aws-sdk-transscribestreamingservice`, and the former case especially is
a bit of a regression.

Since AsyncClient creation will always generate an exception if the gem
isn't present, I'm removing these also.

Resolves #1998

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
