### PR TITLE
[Doc Gen] avoid leaving span tags in markdown docs

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
@@ -133,6 +133,10 @@ module AwsSdkCodeGenerator
           # turn them into YARD links.
           html = html.gsub(/<a>(.+?)<\/a>/) { $1 }
 
+          # For span tags, it can contain customized attributes, e.g. data-target
+          # keeping text context only for now
+          #html = html.gsub(/<span.*?>(.+?)<\/span>/) { $1 }
+
           # <important> tag doesn't render well
           html = html.gsub(/<important>(.+?)<\/important>/){ "<p>#{$1}</p>" }
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
@@ -135,7 +135,7 @@ module AwsSdkCodeGenerator
 
           # For span tags, it can contain customized attributes, e.g. data-target
           # keeping text context only for now
-          #html = html.gsub(/<span.*?>(.+?)<\/span>/) { $1 }
+          html = html.gsub(/<span.*?>(.+?)<\/span>/) { $1 }
 
           # <important> tag doesn't render well
           html = html.gsub(/<important>(.+?)<\/important>/){ "<p>#{$1}</p>" }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
