### PR TITLE
TranscribeStreaming API update

### DIFF
--- a/apis/transcribe-streaming/2017-10-26/api-2.json
+++ b/apis/transcribe-streaming/2017-10-26/api-2.json
@@ -109,7 +109,10 @@
       "type":"string",
       "enum":[
         "en-US",
-        "es-US"
+        "en-GB",
+        "es-US",
+        "fr-CA",
+        "fr-FR"
       ]
     },
     "LimitExceededException":{

--- a/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
+++ b/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Amazon Transcribe now supports GB English, CA French and FR French which expands upon the existing language support for US English and US Spanish.
+
 1.0.1 (2019-03-26)
 ------------------
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Amazon Transcribe now supports GB English, CA French and FR French which expands upon the existing language support for US English and US Spanish.