### PR TITLE
Deduplicate empty strings in seahorse shapes

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Small memory retention reduction.
+* Issue - Small memory retention reduction.
 
 3.48.3 (2019-03-26)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Small memory retention reduction.
+
 3.48.3 (2019-03-26)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -15,9 +15,9 @@ module Seahorse
           @event = false
           @eventstream = false
           @eventpayload = false
-          @eventpayload_type = ''
+          @eventpayload_type = ''.freeze
           @eventheader = false
-          @eventheader_type = ''
+          @eventheader_type = ''.freeze
           options.each do |key, value|
             if key == :metadata
               value.each do |k,v|


### PR DESCRIPTION
While doing some memory profiling, I noticed that `ShapeRef` instances were holding onto a lot of duplicated empty strings:

```
Retained String Report
-----------------------------------
      1636  ""
       583  [REDACTED]
       401  /tmp/bundle/ruby/2.5.0/gems/aws-sdk-core-3.48.2/lib/seahorse/model/shapes.rb:18
       401  /tmp/bundle/ruby/2.5.0/gems/aws-sdk-core-3.48.2/lib/seahorse/model/shapes.rb:20
       ....
```

By calling `.freeze` on them, we allow MRI to intern them.