### PR TITLE
When AssumeRoleCredentials fails to assume due to permission errors,

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix NoMethodError when assume role fails
+
 1.1.0 (2019-03-13)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -658,7 +658,7 @@ module Aws
 
       def get_credentials
         credentials = @credentials_provider.credentials
-        if credentials_set?(credentials)
+        if credentials && credentials_set?(credentials)
           credentials
         else
           msg = 'unable to sign request without credentials set'

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -7,6 +7,12 @@ module Aws
   module Sigv4
     describe Signer do
 
+      class NilCredentialsProvider
+        def credentials
+          nil
+        end
+      end
+
       let(:credentials) {{
         access_key_id: 'akid',
         secret_access_key: 'secret',
@@ -99,6 +105,18 @@ module Aws
           expect(creds.access_key_id).to eq('akid')
           expect(creds.secret_access_key).to eq('secret')
           expect(creds.session_token).to eq('token')
+        end
+
+        it 'checks nil credentials' do
+          signer = Signer.new(options.merge(
+            credentials_provider: NilCredentialsProvider.new
+          ))
+          creds = signer.credentials_provider.credentials
+          expect(signer.credentials_provider.credentials).to eq(nil)
+
+          expect do
+            signer.sign_request(nil)
+          end.to raise_error(Errors::MissingCredentialsError)
         end
 
         it 'accepts :credentials_provider' do


### PR DESCRIPTION
When AssumeRoleCredentials fails to assume due to permission errors, credentials_provider.credentials returns nil. That causes a NoMethodError when checking credentials_set? Instead, raise a more standard error.

Cryptic error:
```
NoMethodError: undefined method `access_key_id' for nil:NilClass
from /usr/local/bundle/gems/aws-sigv4-1.1.0/lib/aws-sigv4/signer.rb:670:in `credentials_set?'
```