### PR TITLE
Add PriorRequestNotComplete to throttling errors

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Add PriorRequestNotComplete to throttling errors.
+* Issue - Add PriorRequestNotComplete to throttling errors.
 
 3.48.4 (2019-04-18)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add PriorRequestNotComplete to throttling errors.
+
 3.48.4 (2019-04-18)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -85,6 +85,7 @@ A delay randomiser function used by the default backoff function. Some predefine
           'BandwidthLimitExceeded',                 # cloud search
           'LimitExceededException',                 # kinesis
           'TooManyRequestsException',               # batch
+          'PriorRequestNotComplete',                # route53
         ])
 
         CHECKSUM_ERRORS = Set.new([

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -120,6 +120,11 @@ module Aws
             expect(inspector(error).throttling_error?).to be(true)
           end
 
+          it 'returns true for PriorRequestNotComplete' do
+            error = RetryErrorsSvc::Errors::PriorRequestNotComplete.new(nil,nil)
+            expect(inspector(error).throttling_error?).to be(true)
+          end
+
           it 'returns true for error codes that match /throttl/' do
             error = RetryErrorsSvc::Errors::Throttled.new(nil,nil)
             expect(inspector(error).throttling_error?).to be(true)

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -115,6 +115,11 @@ module Aws
             expect(inspector(error).throttling_error?).to be(true)
           end
 
+          it 'returns true for TooManyRequestsException' do
+            error = RetryErrorsSvc::Errors::TooManyRequestsException.new(nil,nil)
+            expect(inspector(error).throttling_error?).to be(true)
+          end
+
           it 'returns true for error codes that match /throttl/' do
             error = RetryErrorsSvc::Errors::Throttled.new(nil,nil)
             expect(inspector(error).throttling_error?).to be(true)

--- a/gems/aws-sdk-route53/CHANGELOG.md
+++ b/gems/aws-sdk-route53/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add PriorRequestNotComplete to throttling errors.
+
 1.21.0 (2019-03-22)
 ------------------
 

--- a/gems/aws-sdk-route53/CHANGELOG.md
+++ b/gems/aws-sdk-route53/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Feature - Add PriorRequestNotComplete to throttling errors.
-
 1.21.0 (2019-03-22)
 ------------------
 


### PR DESCRIPTION
As other sdks like aws-sdk-js and aws-sdk-go handle
PriorRequestNotComplete as the throttling error,
handle it as the throttling error in aws-sdk-ruby as well.