### PR TITLE
Processcredential fix

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Call RefreshingCredentials initialize method in ProcessCredentials to set mutex. 
 
 3.48.5 (2019-04-24)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+
 * Issue - Call RefreshingCredentials initialize method in ProcessCredentials to set mutex. 
 
 3.48.5 (2019-04-24)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
@@ -27,6 +27,8 @@ module Aws
     def initialize(process)
       @process = process
       @credentials = credentials_from_process(@process)
+      
+      super
     end
 
     private


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

When refreshing credentials using the ProcessCredentials provider the following error is producedd:
```
#0 got unrecoverable error in primary and no secondary error_class=NoMethodError error="undefined method `synchronize' for nil:NilClass"
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/refreshing_credentials.rb:47:in `refresh_if_near_expiration'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/refreshing_credentials.rb:25:in `credentials'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sigv4-1.1.0/lib/aws-sigv4/signer.rb:660:in `get_credentials'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sigv4-1.1.0/lib/aws-sigv4/signer.rb:205:in `sign_request'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/signature_v4.rb:112:in `apply_signature'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/signature_v4.rb:65:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:10:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/retry_errors.rb:172:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/json/handler.rb:11:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/user_agent.rb:13:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/endpoint_pattern.rb:28:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/endpoint_discovery.rb:78:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/seahorse/client/plugins/endpoint.rb:45:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/param_validator.rb:24:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/seahorse/client/plugins/response_target.rb:23:in `call'
  2019-04-24 08:16:36 -0700 [warn]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.48.4/lib/seahorse/client/request.rb:70:in `send_request'
```

Adding `super` into ProcessCredentials initialize method avoids `nil:NilClass` for `mutex` attribute.