### PR TITLE
port over BigDecimal fix for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Aws::DynamoDB - Replaced BigDecimal.new() with BigDecimal() #1937
+
 2.11.269 (2019-05-06)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,11 @@ gem 'nokogiri', '1.6.8.1' unless ENV['PURE_RUBY']
 gem 'oga'
 
 group :test do
-  gem 'rspec'
+
   if RUBY_VERSION == '1.9.3'
+    # '3.8.3' fails 1.9.3 test suits
+    gem 'rspec-expectations', '3.8.2'
+
     # webmock dropped support for Ruby 1.9.3 after version 2.2.0
     gem 'webmock', '2.2.0'
     # webmock depends on addressable, but the latest version of addressable
@@ -45,6 +48,9 @@ group :test do
   end
   gem 'simplecov', require: false
   gem 'coveralls', require: false if RUBY_VERSION > '1.9.3'
+
+  gem 'rspec'
+
   gem 'json-schema'
   gem 'multipart-post'
 end

--- a/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/dynamodb/attribute_value.rb
@@ -76,12 +76,12 @@ module Aws
             end
           when :l then value.map { |v| format(v) }
           when :s then value
-          when :n then BigDecimal.new(value)
+          when :n then BigDecimal(value)
           when :b then StringIO.new(value)
           when :null then nil
           when :bool then value
           when :ss then Set.new(value)
-          when :ns then Set.new(value.map { |n| BigDecimal.new(n) })
+          when :ns then Set.new(value.map { |n| BigDecimal(n) })
           when :bs then Set.new(value.map { |b| StringIO.new(b) })
           when :es then Set.new
           else

--- a/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
+++ b/aws-sdk-core/spec/aws/dynamodb/attribute_value_spec.rb
@@ -79,7 +79,7 @@ module Aws
 
           # Ruby 2.4 changed the casing of BigDecimal's to_s value.
           # We need to check in a case insensitive manner
-          big_decimal_value = value.marshal(BigDecimal.new("0.1E125"))
+          big_decimal_value = value.marshal(BigDecimal("0.1E125"))
           expect(big_decimal_value.keys).to eq([:n])
           expect(big_decimal_value[:n]).to match(/0.1E125/i)
         end
@@ -201,7 +201,7 @@ module Aws
 
         it 'converts :ns to a set of big decimals (to preserve precision)' do
           expect(value.unmarshal(ns: %w(123 456))).to eq(
-            Set.new([BigDecimal.new('123'), BigDecimal.new('456')]))
+            Set.new([BigDecimal('123'), BigDecimal('456')]))
         end
 
         it 'converts :bs to a set of binary values' do
@@ -217,9 +217,9 @@ module Aws
 
         it 'converts :n to big decimals' do
           # supports integers, floats, and big decimals
-          expect(value.unmarshal(n: '123')).to eq(BigDecimal.new('123'))
-          expect(value.unmarshal(n: '12.34')).to eq(BigDecimal.new('12.34'))
-          expect(value.unmarshal(n: '0.1E125')).to eq(BigDecimal.new('0.1E125'))
+          expect(value.unmarshal(n: '123')).to eq(BigDecimal('123'))
+          expect(value.unmarshal(n: '12.34')).to eq(BigDecimal('12.34'))
+          expect(value.unmarshal(n: '0.1E125')).to eq(BigDecimal('0.1E125'))
         end
 
         it 'converts :s to a string' do
@@ -297,9 +297,9 @@ module Aws
               },
             ],
             'scores' => [
-              BigDecimal.new('4.5'),
-              BigDecimal.new('5'),
-              BigDecimal.new('3.9'),
+              BigDecimal('4.5'),
+              BigDecimal('5'),
+              BigDecimal('3.9'),
               nil,
               'perfect'
             ]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Port over https://github.com/aws/aws-sdk-ruby/pull/1937/files for V2
#2038 