### PR TITLE
Update MINIMUM_CORE_VERSION to 3.52.0

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -8,7 +8,7 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.48.2"
+    MINIMUM_CORE_VERSION = "3.52.0"
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 
     # @option options [String] :manifest_path (MANIFEST_PATH)

--- a/gems/aws-sdk-acm/aws-sdk-acm.gemspec
+++ b/gems/aws-sdk-acm/aws-sdk-acm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-acm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
+++ b/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-acmpca/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
+++ b/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-alexaforbusiness/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
+++ b/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-amplify/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
+++ b/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-apigateway/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
+++ b/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-apigatewaymanagementapi/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
+++ b/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-apigatewayv2/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
+++ b/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationautoscaling/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
+++ b/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-applicationdiscoveryservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
+++ b/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-appmesh/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
+++ b/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-appstream/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
+++ b/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-appsync/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-athena/aws-sdk-athena.gemspec
+++ b/gems/aws-sdk-athena/aws-sdk-athena.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-athena/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
+++ b/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-autoscaling/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
+++ b/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-autoscalingplans/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-backup/aws-sdk-backup.gemspec
+++ b/gems/aws-sdk-backup/aws-sdk-backup.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-backup/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-batch/aws-sdk-batch.gemspec
+++ b/gems/aws-sdk-batch/aws-sdk-batch.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-batch/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
+++ b/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-budgets/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-chime/aws-sdk-chime.gemspec
+++ b/gems/aws-sdk-chime/aws-sdk-chime.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-chime/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
+++ b/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloud9/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
+++ b/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-clouddirectory/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
+++ b/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudformation/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
+++ b/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudfront/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
+++ b/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
+++ b/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudhsmv2/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
+++ b/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearch/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
+++ b/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudsearchdomain/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
+++ b/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudtrail/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
+++ b/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatch/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
+++ b/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchevents/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
+++ b/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cloudwatchlogs/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
+++ b/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codebuild/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
+++ b/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codecommit/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
+++ b/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codedeploy/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
+++ b/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codepipeline/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
+++ b/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-codestar/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
+++ b/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentity/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
+++ b/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitoidentityprovider/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
+++ b/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-cognitosync/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
+++ b/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-comprehend/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
+++ b/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-comprehendmedical/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
+++ b/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-configservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-connect/aws-sdk-connect.gemspec
+++ b/gems/aws-sdk-connect/aws-sdk-connect.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-connect/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
+++ b/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-costandusagereportservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
+++ b/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-costexplorer/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
+++ b/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-databasemigrationservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
+++ b/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-datapipeline/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
+++ b/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-datasync/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-dax/aws-sdk-dax.gemspec
+++ b/gems/aws-sdk-dax/aws-sdk-dax.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dax/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
+++ b/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-devicefarm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
+++ b/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directconnect/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
+++ b/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-directoryservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
+++ b/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dlm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
+++ b/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-docdb/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
+++ b/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodb/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
+++ b/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-dynamodbstreams/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
+++ b/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency('aws-sigv4', '~> 1.1')
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
 
 end

--- a/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
+++ b/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecr/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
+++ b/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ecs/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-efs/aws-sdk-efs.gemspec
+++ b/gems/aws-sdk-efs/aws-sdk-efs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-efs/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-eks/aws-sdk-eks.gemspec
+++ b/gems/aws-sdk-eks/aws-sdk-eks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-eks/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
+++ b/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticache/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
+++ b/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticbeanstalk/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
+++ b/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancing/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
+++ b/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticloadbalancingv2/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
+++ b/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elasticsearchservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
+++ b/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-elastictranscoder/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-emr/aws-sdk-emr.gemspec
+++ b/gems/aws-sdk-emr/aws-sdk-emr.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-emr/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
+++ b/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-firehose/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-fms/aws-sdk-fms.gemspec
+++ b/gems/aws-sdk-fms/aws-sdk-fms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-fms/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
+++ b/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-fsx/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
+++ b/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-gamelift/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
+++ b/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glacier/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
+++ b/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-globalaccelerator/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-glue/aws-sdk-glue.gemspec
+++ b/gems/aws-sdk-glue/aws-sdk-glue.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-glue/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
+++ b/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-greengrass/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
+++ b/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-guardduty/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-health/aws-sdk-health.gemspec
+++ b/gems/aws-sdk-health/aws-sdk-health.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-health/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iam/aws-sdk-iam.gemspec
+++ b/gems/aws-sdk-iam/aws-sdk-iam.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iam/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
+++ b/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-importexport/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv2', '~> 1.0')
 
 end

--- a/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
+++ b/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-inspector/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iot/aws-sdk-iot.gemspec
+++ b/gems/aws-sdk-iot/aws-sdk-iot.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iot/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
+++ b/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iot1clickdevicesservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
+++ b/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iot1clickprojects/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
+++ b/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iotanalytics/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
+++ b/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iotdataplane/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
+++ b/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-iotjobsdataplane/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
+++ b/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kafka/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesis/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
+++ b/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisanalytics/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
+++ b/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisanalyticsv2/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
+++ b/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisvideo/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisvideoarchivedmedia/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
+++ b/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kinesisvideomedia/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-kms/aws-sdk-kms.gemspec
+++ b/gems/aws-sdk-kms/aws-sdk-kms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-kms/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
+++ b/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambda/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
+++ b/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lambdapreview/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-lex/aws-sdk-lex.gemspec
+++ b/gems/aws-sdk-lex/aws-sdk-lex.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lex/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
+++ b/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lexmodelbuildingservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
+++ b/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-licensemanager/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
+++ b/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-lightsail/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
+++ b/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-machinelearning/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-macie/aws-sdk-macie.gemspec
+++ b/gems/aws-sdk-macie/aws-sdk-macie.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-macie/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-managedblockchain/aws-sdk-managedblockchain.gemspec
+++ b/gems/aws-sdk-managedblockchain/aws-sdk-managedblockchain.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-managedblockchain/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
+++ b/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacecommerceanalytics/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
+++ b/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplaceentitlementservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
+++ b/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-marketplacemetering/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
+++ b/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediaconnect/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
+++ b/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediaconvert/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
+++ b/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-medialive/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
+++ b/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediapackage/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
+++ b/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediastore/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
+++ b/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediastoredata/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
+++ b/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mediatailor/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
+++ b/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-migrationhub/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
+++ b/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mobile/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mq/aws-sdk-mq.gemspec
+++ b/gems/aws-sdk-mq/aws-sdk-mq.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mq/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
+++ b/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-mturk/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
+++ b/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-neptune/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
+++ b/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworks/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
+++ b/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-opsworkscm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
+++ b/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-organizations/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-pi/aws-sdk-pi.gemspec
+++ b/gems/aws-sdk-pi/aws-sdk-pi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pi/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
+++ b/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pinpoint/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
+++ b/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pinpointemail/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
+++ b/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pinpointsmsvoice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-polly/aws-sdk-polly.gemspec
+++ b/gems/aws-sdk-polly/aws-sdk-polly.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-polly/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
+++ b/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pricing/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
+++ b/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-quicksight/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-ram/aws-sdk-ram.gemspec
+++ b/gems/aws-sdk-ram/aws-sdk-ram.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ram/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-rds/aws-sdk-rds.gemspec
+++ b/gems/aws-sdk-rds/aws-sdk-rds.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency('aws-sigv4', '~> 1.1')
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
 
 end

--- a/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
+++ b/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rdsdataservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
+++ b/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-redshift/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
+++ b/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-rekognition/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
+++ b/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resourcegroups/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
+++ b/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-resourcegroupstaggingapi/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
+++ b/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-robomaker/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-route53/aws-sdk-route53.gemspec
+++ b/gems/aws-sdk-route53/aws-sdk-route53.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
+++ b/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53domains/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
+++ b/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-route53resolver/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-s3/aws-sdk-s3.gemspec
+++ b/gems/aws-sdk-s3/aws-sdk-s3.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('aws-sdk-kms', '~> 1')
   spec.add_dependency('aws-sigv4', '~> 1.0')
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
 
 end

--- a/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
+++ b/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency('aws-sigv4', '~> 1.0')
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
 
 end

--- a/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
+++ b/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sagemaker/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
+++ b/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sagemakerruntime/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
+++ b/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-secretsmanager/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
+++ b/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-securityhub/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
+++ b/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-serverlessapplicationrepository/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
+++ b/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-servicecatalog/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
+++ b/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-servicediscovery/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-ses/aws-sdk-ses.gemspec
+++ b/gems/aws-sdk-ses/aws-sdk-ses.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ses/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-shield/aws-sdk-shield.gemspec
+++ b/gems/aws-sdk-shield/aws-sdk-shield.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-shield/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-signer/aws-sdk-signer.gemspec
+++ b/gems/aws-sdk-signer/aws-sdk-signer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-signer/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
+++ b/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-simpledb/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv2', '~> 1.0')
 
 end

--- a/gems/aws-sdk-sms/aws-sdk-sms.gemspec
+++ b/gems/aws-sdk-sms/aws-sdk-sms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sms/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
+++ b/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-snowball/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-sns/aws-sdk-sns.gemspec
+++ b/gems/aws-sdk-sns/aws-sdk-sns.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sns/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
+++ b/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-sqs/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
+++ b/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-ssm/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-states/aws-sdk-states.gemspec
+++ b/gems/aws-sdk-states/aws-sdk-states.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-states/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
+++ b/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-storagegateway/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-support/aws-sdk-support.gemspec
+++ b/gems/aws-sdk-support/aws-sdk-support.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-support/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-swf/aws-sdk-swf.gemspec
+++ b/gems/aws-sdk-swf/aws-sdk-swf.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-swf/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-textract/aws-sdk-textract.gemspec
+++ b/gems/aws-sdk-textract/aws-sdk-textract.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-textract/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
+++ b/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-transcribeservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-transcribestreamingservice/aws-sdk-transcribestreamingservice.gemspec
+++ b/gems/aws-sdk-transcribestreamingservice/aws-sdk-transcribestreamingservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
+++ b/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-transfer/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-translate/aws-sdk-translate.gemspec
+++ b/gems/aws-sdk-translate/aws-sdk-translate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-translate/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-waf/aws-sdk-waf.gemspec
+++ b/gems/aws-sdk-waf/aws-sdk-waf.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-waf/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
+++ b/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-wafregional/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
+++ b/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workdocs/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
+++ b/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-worklink/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
+++ b/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workmail/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
+++ b/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-workspaces/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end

--- a/gems/aws-sdk-xray/aws-sdk-xray.gemspec
+++ b/gems/aws-sdk-xray/aws-sdk-xray.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-xray/CHANGELOG.md'
   }
 
-  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.48.2')
+  spec.add_dependency('aws-sdk-core', '~> 3', '>= 3.52.0')
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
 end


### PR DESCRIPTION
**Description**
In recent update a new plugin transfer_encoding was added to sdk-core.
This plugin is in use in many gems which are using sdk-core.
But minimum version of sdk core was stayed on old version 3.48.2.
Since we are introduced a new pluging and used it everywhere we have to
bump minimal version to 3.52.0. Because new plugin was introduced in
this version.

**Changes**
 * Update MINIMUM_CORE_VERSION to version "3.52.0" 
 * Regenerate gems

**Related issue**
 * https://github.com/aws/aws-sdk-ruby/issues/2046

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.