### PR TITLE
Support struct #to_h with :members key

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support #to_hash for Struct with `:members` member #2053
+
 3.53.0 (2019-05-21)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -29,8 +29,7 @@ module Aws
     def to_h(obj = self)
       case obj
       when Struct
-        obj.each_pair.with_object({}) do |(member,_), hash|
-          value = obj[member]
+        obj.each_pair.with_object({}) do |(member, value), hash|
           hash[member] = to_hash(value) unless value.nil?
         end
       when Hash

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -29,7 +29,7 @@ module Aws
     def to_h(obj = self)
       case obj
       when Struct
-        obj.members.each.with_object({}) do |member, hash|
+        obj.each_pair.with_object({}) do |(member,_), hash|
           value = obj[member]
           hash[member] = to_hash(value) unless value.nil?
         end

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -22,6 +22,14 @@ module Aws
         expect(Structure.new(:abc).new.to_hash).to eq({})
       end
 
+      it 'accepts :members member' do
+        s = Structure.new(:members, :foo).new(foo: 'bar', members: ['foo'])
+        expect(s.to_hash).to eq({
+          foo: 'bar',
+          members: ['foo']
+        })
+      end
+
       it 'only serializes non-nil members' do
         s = Structure.new(:abc, :mno).new(abc:'abc')
         expect(s.to_hash).to eq(abc: 'abc')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Ideally, this should not be accepted from service model, yet `#to_h` need to handle this
https://ruby-doc.org/core-2.4.2/Struct.html

addressing #2053 