### PR TITLE
Fix error message for missing Seahorse options

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -77,8 +77,8 @@ module Seahorse
         if options.key?(name)
           options[name]
         else
-          msg = "invalid :priority `%s', must be between 0 and 99"
-          raise ArgumentError, msg % priority.inspect
+          msg = "missing option: `%s'"
+          raise ArgumentError, msg % name.inspect
         end
       end
 


### PR DESCRIPTION
When a required option is missing, the `ArgumentError` message should include meaningful information for the caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

