### PR TITLE
Handle EncodingError coming from oj gem

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Handle `EncodingError` when using Oj gem [Github Issue](https://github.com/aws/aws-sdk-ruby/issues/1831)
+
 3.59.0 (2019-07-03)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
@@ -23,7 +23,7 @@ module Aws
 
       def load(json)
         ENGINE.load(json, *ENGINE_LOAD_OPTIONS)
-      rescue ENGINE_ERROR => e
+      rescue *ENGINE_ERRORS => e
         raise ParseError.new(e)
       end
 
@@ -45,21 +45,21 @@ module Aws
       end
 
       def json_engine
-        [JSON, [], [], JSON::ParserError]
+        [JSON, [], [], [JSON::ParserError]]
       end
 
       def oj_parse_error
         if Oj.const_defined?('ParseError')
-          Oj::ParseError
+          [Oj::ParseError, EncodingError]
         else
-          SyntaxError
+          [SyntaxError]
         end
       end
 
     end
 
     # @api private
-    ENGINE, ENGINE_LOAD_OPTIONS, ENGINE_DUMP_OPTIONS, ENGINE_ERROR =
+    ENGINE, ENGINE_LOAD_OPTIONS, ENGINE_DUMP_OPTIONS, ENGINE_ERRORS =
       oj_engine || json_engine
 
   end

--- a/gems/aws-sdk-core/spec/aws/json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json_spec.rb
@@ -1,0 +1,55 @@
+require_relative '../spec_helper'
+
+module Aws
+  describe Json do
+
+    describe '.load' do
+      subject(:load) { described_class.load(raw_json) }
+
+      shared_examples 'loads JSON correctly' do
+        let(:raw_json) {'{ "foo": "bar" }'}
+
+        it 'returns an empty hash' do
+          expect(subject).to eq({ 'foo' => 'bar' })
+        end
+
+        context 'not JSON' do
+          # OJ gem raises EncodingError in this case
+          let(:raw_json) {'<ServiceUnavailableException/>'}
+
+          it 'raises a ParseError' do
+            expect { subject }.to raise_error(Aws::Json::ParseError)
+          end
+        end
+
+        context 'invalid JSON' do
+          let(:raw_json) {'{ "steve": }'}
+
+          it 'raises a ParseError' do
+            expect { subject }.to raise_error(Aws::Json::ParseError)
+          end
+        end
+
+      end
+
+      context 'when using oj gem' do
+        include_examples 'loads JSON correctly'
+      end
+
+      context 'when using bundled json' do
+
+        before do
+          engine, load_options, dump_options, errors = described_class.send(:json_engine)
+
+          stub_const("Aws::Json::ENGINE", engine)
+          stub_const("Aws::Json::ENGINE_LOAD_OPTIONS", load_options)
+          stub_const("Aws::Json::ENGINE_DUMP_OPTIONS", dump_options)
+          stub_const("Aws::Json::ENGINE_ERRORS", errors)
+        end
+
+        include_examples 'loads JSON correctly'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Also adds some test coverage for the `Aws::Json` module.

Fixes: https://github.com/aws/aws-sdk-ruby/issues/1831

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For context, I'm using the `aws-sdk-kinesis` library which sometimes receives `<ServiceUnavailableException/>` when writing records.  The SDK seems to translate these into failure responses when I *don't* have the `oj` gem installed, but with it present the `EncodingError` bubbles all the way out of the SDK.
