### PR TITLE
Allow running state while waiting for getting replication task stopped

### DIFF
--- a/apis/dms/2016-01-01/waiters-2.json
+++ b/apis/dms/2016-01-01/waiters-2.json
@@ -193,12 +193,6 @@
                 },
                 {
                     "argument":"ReplicationTasks[].Status",
-                    "expected":"running",
-                    "matcher":"pathAny",
-                    "state":"failure"
-                },
-                {
-                    "argument":"ReplicationTasks[].Status",
                     "expected":"failed",
                     "matcher":"pathAny",
                     "state":"failure"

--- a/gems/aws-sdk-databasemigrationservice/CHANGELOG.md
+++ b/gems/aws-sdk-databasemigrationservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Allow a replication task to be running state while waiting for getting replication task stopped by ReplicationTaskStopped waiter.
+
 1.26.0 (2019-07-17)
 ------------------
 

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
@@ -452,12 +452,6 @@ module Aws::DatabaseMigrationService
               },
               {
                 "argument" => "replication_tasks[].status",
-                "expected" => "running",
-                "matcher" => "pathAny",
-                "state" => "failure"
-              },
-              {
-                "argument" => "replication_tasks[].status",
                 "expected" => "failed",
                 "matcher" => "pathAny",
                 "state" => "failure"


### PR DESCRIPTION
The current implementation of DMS ReplicationTaskStopped waiter handles 'running' state
as a failure while waiting for getting target replication task stopped.

However, I guess that following state transition and use case is natural.

```
[stopped]
   ↓ Use StartReplicationTask API
[starting]
   ↓ Wait with ReplicationTaskRunning waiter.
[running]
   ↓ Wait with ReplicationTaskStopped waiter.
[stopping]
```

This change allows the above use case of ReplicationTaskStopped waiter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
