### PR TITLE
[Credential Chain] fix default STS client credential sourcing in AssumeRoleWebIdentityCredentialProvider

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -8,7 +8,7 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.58.0"
+    MINIMUM_CORE_VERSION = "3.61.1"
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 
     # @option options [String] :manifest_path (MANIFEST_PATH)

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix default STS Client credential sourcing in Aws::AssumeRoleWebIdentityCredentialsProvider
+
 3.61.0 (2019-07-24)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
@@ -52,7 +52,7 @@ module Aws
         # not provided, generate encoded UUID as session name
         @assume_role_web_identity_params[:role_session_name] = _session_name
       end
-      @client = client_opts[:client] || STS::Client.new(client_opts)
+      @client = client_opts[:client] || STS::Client.new(client_opts.merge(credentials: false))
       super
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -100,8 +100,8 @@ module Aws
     end
 
     def assume_role_web_identity_credentials(options)
-      if role_arn = ENV['AWS_ROLE_ARN'] &&
-        token_file = ENV['AWS_WEB_IDENTITY_TOKEN_FILE']
+      if (role_arn = ENV['AWS_ROLE_ARN']) &&
+        (token_file = ENV['AWS_WEB_IDENTITY_TOKEN_FILE'])
         AssumeRoleWebIdentityCredentials.new(
           role_arn: role_arn,
           web_identity_token_file: token_file,

--- a/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
@@ -107,16 +107,17 @@ module Aws
     end
 
     it 'accepts client options' do
-      client = STS::Client.new(stub_responses: true)
+      expected_client = STS::Client.new(
+        credentials: false, stub_responses: true)
       expect(STS::Client).to receive(:new).
-        with(region: 'region-name').
-        and_return(client)
+        with(region: 'region-name', credentials: false).
+        and_return(expected_client)
       creds = AssumeRoleWebIdentityCredentials.new(
         region: 'region-name',
         role_arn: 'arn',
         web_identity_token_file: token_file_path,
       )
-      expect(creds.client).to be(client)
+      expect(creds.client).to be(expected_client)
     end
 
     it 'assumes role with web identity using the client' do


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.