### PR TITLE
Add More retry errors [Aws::STS::InvalidIdentityToken, Aws::Errors::NoSuchEndpointError]

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add `Aws::STS::InvalidIdentityToken` error for retry
+
 3.61.1 (2019-07-25)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Add `Aws::STS::InvalidIdentityToken` error for retry
+* Issue - Add `Aws::STS::InvalidIdentityToken` and `Aws::Errors::NoSuchEndpointError` error for retry
 
 3.61.1 (2019-07-25)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -72,6 +72,7 @@ A delay randomiser function used by the default backoff function. Some predefine
           'UnrecognizedClientException', # json services
           'InvalidAccessKeyId',          # s3
           'AuthFailure',                 # ec2
+          'InvalidIdentityToken',        # sts
         ])
 
         THROTTLING_ERRORS = Set.new([

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -118,6 +118,7 @@ A delay randomiser function used by the default backoff function. Some predefine
 
         def networking?
           @error.is_a?(Seahorse::Client::NetworkingError) ||
+          @error.is_a?(Errors::NoSuchEndpointError) ||
           NETWORKING_ERRORS.include?(@name)
         end
 

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -42,7 +42,7 @@ module Aws
         end
 
         expect(e).to be_kind_of(Errors::NoSuchEndpointError)
-        expect(e.context.retries).to be(0) # should not retry these
+        expect(e.context.retries).to be(3) # updated to retry based on customer request 
         expect(e.message).to include('us-east-1')
         expect(e.message).to include('us-west-1')
         expect(e.message).to include('cn-north-1')

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -193,6 +193,13 @@ module Aws
             expect(inspector(error, 200).networking?).to be(true)
           end
 
+          it 'returns true if the error is wrapped in a NoSuchEndpointError' do
+            req = double('request', endpoint: 'https://example.com')
+            context = double('ctx', http_request: req)
+            error = Errors::NoSuchEndpointError.new(context: context)
+            expect(inspector(error).networking?).to be(true)
+          end
+
         end
 
       end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Retry Aws::STS::InvalidIdentityToken for AssumeRoleWebIdentityCredentialsProvider
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html

Also retry "NoSuchEndointError" as it can be related to DNS resolve issues that are not handled gracefully. [add to retry based on customer request]