### PR TITLE
Support passing role duration seconds from shared credentials/config file

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased Changes
 ------------------
 
 * Feature - Updated Aws::STS::Client with the latest API changes.
+* Feature - Support passing AssumeRole duration_seconds from shared credentials/config file.
 
 3.61.2 (2019-07-29)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -250,6 +250,7 @@ module Aws
             opts[:role_session_name] ||= prof_cfg["role_session_name"]
             opts[:role_session_name] ||= "default_session"
             opts[:role_arn] ||= prof_cfg["role_arn"]
+            opts[:duration_seconds] ||= prof_cfg["duration_seconds"]
             opts[:external_id] ||= prof_cfg["external_id"]
             opts[:serial_number] ||= prof_cfg["mfa_serial"]
             opts[:profile] = opts.delete(:source_profile)
@@ -269,6 +270,7 @@ module Aws
             opts[:role_session_name] ||= prof_cfg["role_session_name"]
             opts[:role_session_name] ||= "default_session"
             opts[:role_arn] ||= prof_cfg["role_arn"]
+            opts[:duration_seconds] ||= prof_cfg["duration_seconds"]
             opts[:external_id] ||= prof_cfg["external_id"]
             opts[:serial_number] ||= prof_cfg["mfa_serial"]
             opts.delete(:source_profile) # Cleanup


### PR DESCRIPTION
Support passing role duration seconds from shared credentials/config file