### PR TITLE
Deprecate credential methods

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
@@ -397,7 +397,7 @@ describe 'Interfaces' do
         band = Sample::Band.new(name:'name', client: client)
         expect {
           band.identifiers
-        }.to output(/DEPRECATION WARNING: called deprecated method `identifiers'/).to_stderr
+        }.to output(/DEPRECATION WARNING/).to_stderr
         # second invocation generates no warning, even from new instance
         band2 = Sample::Band.new(name:'name', client: client)
         expect {

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,12 @@
 Unreleased Changes
 ------------------
 
+<<<<<<< HEAD
 * Issue - Remove misleading IO documentation from `BlobShape` error output.
+=======
+* Feature - Remove deprecated methods `access_key_id`, `secret_access_key`, and
+`session_token` from credential providers.
+>>>>>>> 9615a656f... Fully deprecate methods in credential provider
 
 3.68.0 (2019-09-16)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -2,11 +2,15 @@ Unreleased Changes
 ------------------
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 * Issue - Remove misleading IO documentation from `BlobShape` error output.
 =======
 * Feature - Remove deprecated methods `access_key_id`, `secret_access_key`, and
 `session_token` from credential providers.
 >>>>>>> 9615a656f... Fully deprecate methods in credential provider
+=======
+* Feature - Remove deprecated methods `access_key_id`, `secret_access_key`, and `session_token` from credential providers.
+>>>>>>> 59ec29701... Add version option to deprecation module
 
 3.68.0 (2019-09-16)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,16 +1,9 @@
 Unreleased Changes
 ------------------
 
-<<<<<<< HEAD
-<<<<<<< HEAD
+* Issue - Add final deprecation warnings to `access_key_id`, `secret_access_key`, and `session_token` in credential providers.
+
 * Issue - Remove misleading IO documentation from `BlobShape` error output.
-=======
-* Feature - Remove deprecated methods `access_key_id`, `secret_access_key`, and
-`session_token` from credential providers.
->>>>>>> 9615a656f... Fully deprecate methods in credential provider
-=======
-* Feature - Remove deprecated methods `access_key_id`, `secret_access_key`, and `session_token` from credential providers.
->>>>>>> 59ec29701... Add version option to deprecation module
 
 3.68.0 (2019-09-16)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
@@ -1,9 +1,5 @@
-require_relative 'deprecations'
-
 module Aws
   module CredentialProvider
-
-    extend Deprecations
 
     # @return [Credentials]
     attr_reader :credentials
@@ -12,33 +8,5 @@ module Aws
     def set?
       !!credentials && credentials.set?
     end
-
-    # @deprecated Deprecated in 2.1.0. This method is subject to errors
-    #   from a race condition when called against refreshable credential
-    #   objects. Will be removed in 2.2.0.
-    # @see #credentials
-    def access_key_id
-      credentials ? credentials.access_key_id : nil
-    end
-    deprecated(:access_key_id, use: '#credentials')
-
-    # @deprecated Deprecated in 2.1.0. This method is subject to errors
-    #   from a race condition when called against refreshable credential
-    #   objects. Will be removed in 2.2.0.
-    # @see #credentials
-    def secret_access_key
-      credentials ? credentials.secret_access_key : nil
-    end
-    deprecated(:secret_access_key, use: '#credentials')
-
-    # @deprecated Deprecated in 2.1.0. This method is subject to errors
-    #   from a race condition when called against refreshable credential
-    #   objects. Will be removed in 2.2.0.
-    # @see #credentials
-    def session_token
-      credentials ? credentials.session_token : nil
-    end
-    deprecated(:session_token, use: '#credentials')
-
   end
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
@@ -1,5 +1,9 @@
+require_relative 'deprecations'
+
 module Aws
   module CredentialProvider
+
+    extend Deprecations
 
     # @return [Credentials]
     attr_reader :credentials
@@ -8,5 +12,30 @@ module Aws
     def set?
       !!credentials && credentials.set?
     end
+
+    # @deprecated This method is subject to errors from a race condition when
+    # called against refreshable credential objects. This will be removed.
+    # @see #credentials
+    def access_key_id
+      credentials ? credentials.access_key_id : nil
+    end
+    deprecated(:access_key_id, use: '#credentials', version: '3.75')
+
+    # @deprecated This method is subject to errors from a race condition when
+    # called against refreshable credential objects. This will be removed.
+    # @see #credentials
+    def secret_access_key
+      credentials ? credentials.secret_access_key : nil
+    end
+    deprecated(:secret_access_key, use: '#credentials', version: '3.75')
+
+    # @deprecated This method is subject to errors from a race condition when
+    # called against refreshable credential objects. This will be removed.
+    # @see #credentials
+    def session_token
+      credentials ? credentials.session_token : nil
+    end
+    deprecated(:session_token, use: '#credentials', version: '3.75')
+
   end
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
@@ -35,33 +35,39 @@ module Aws
   # @api private
   module Deprecations
 
-    # @param [Symbol] method_name The name of the deprecated method.
+    # @param [Symbol] method The name of the deprecated method.
     #
     # @option options [String] :message The warning message to issue
     #   when the deprecated method is called.
     #
-    # @option options [Symbol] :use The name of an use
-    #   method that should be used.
+    # @option options [String] :use The name of a method that should be used.
     #
-    def deprecated(method_name, options = {})
+    # @option options [String] :version The version that will remove the
+    #   deprecated method.
+    #
+    def deprecated(method, options = {})
 
       deprecation_msg = options[:message] || begin
-        msg = "DEPRECATION WARNING: called deprecated method `#{method_name}' "
-        msg << "of an #{self}"
-        msg << ", use #{options[:use]} instead" if options[:use]
+        msg = "#################### DEPRECATION WARNING ####################\n"
+        msg << "Called deprecated method `#{method}` of #{self}."
+        msg << " Use `#{options[:use]}` instead.\n" if options[:use]
+        if options[:version]
+          msg << "Method `#{method}` will be removed in #{options[:version]}."
+        end
+        msg << "\n#############################################################"
         msg
       end
 
-      alias_method(:"deprecated_#{method_name}", method_name)
+      alias_method(:"deprecated_#{method}", method)
 
       warned = false # we only want to issue this warning once
 
-      define_method(method_name) do |*args,&block|
+      define_method(method) do |*args, &block|
         unless warned
           warned = true
           warn(deprecation_msg + "\n" + caller.join("\n"))
         end
-        send("deprecated_#{method_name}", *args, &block)
+        send("deprecated_#{method}", *args, &block)
       end
     end
 

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -100,22 +100,5 @@ module Aws
       c.credentials
     end
 
-    it 'generates deprecation warnings for credential accessors' do
-      c = AssumeRoleCredentials.new(
-        role_arn: 'arn',
-        role_session_name: 'session')
-
-      expect(c).to receive(:warn).exactly(3).times
-
-      c.access_key_id
-      c.secret_access_key
-      c.session_token
-
-      # warnings are not duplicated
-      c.access_key_id
-      c.secret_access_key
-      c.session_token
-    end
-
   end
 end

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -100,5 +100,22 @@ module Aws
       c.credentials
     end
 
+    it 'generates deprecation warnings for credential accessors' do
+      c = AssumeRoleCredentials.new(
+        role_arn: 'arn',
+        role_session_name: 'session')
+
+      expect(c).to receive(:warn).exactly(3).times
+
+      c.access_key_id
+      c.secret_access_key
+      c.session_token
+
+      # warnings are not duplicated
+      c.access_key_id
+      c.secret_access_key
+      c.session_token
+    end
+
   end
 end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -190,7 +190,7 @@ module Aws::DynamoDB
     #
     #     @see https://www.awsarchitectureblog.com/2015/03/backoff.html
     #
-    #   @option options [Integer] :retry_limit (3)
+    #   @option options [Integer] :retry_limit (10)
     #     The maximum number of times to retry failed requests.  Only
     #     ~ 500 level server errors and certain ~ 400 level client errors
     #     are retried.  Generally, these are throttling errors, data

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -202,7 +202,7 @@ module Aws
       #
       def sign_request(request)
 
-        creds = get_credentials
+        creds = fetch_credentials
 
         http_method = extract_http_method(request)
         url = extract_url(request)
@@ -280,7 +280,7 @@ module Aws
       #   signature value (a binary string) used at ':chunk-signature' needs to converted to
       #   hex-encoded string using #unpack
       def sign_event(prior_signature, payload, encoder)
-        creds = get_credentials
+        creds = fetch_credentials
         time = Time.now
         headers = {}
 
@@ -367,7 +367,7 @@ module Aws
       #
       def presign_url(options)
 
-        creds = get_credentials
+        creds = fetch_credentials
 
         http_method = extract_http_method(options)
         url = extract_url(options)
@@ -656,18 +656,14 @@ module Aws
         self.class.uri_escape_path(string)
       end
 
-      def get_credentials
+      def fetch_credentials
         credentials = @credentials_provider.credentials
-        if credentials_set?(credentials)
+        if credentials.access_key_id && credentials.secret_access_key
           credentials
         else
-          msg = 'unable to sign request without credentials set'
-          raise Errors::MissingCredentialsError.new(msg)
+          raise Errors::MissingCredentialsError,
+                'unable to sign request without credentials set'
         end
-      end
-
-      def credentials_set?(credentials)
-        credentials.access_key_id && credentials.secret_access_key
       end
 
       class << self


### PR DESCRIPTION
This PR does two big things.

1) Start the deprecation process of credential accessor methods on the credential provider.

2) Adds stronger printing for deprecations and includes a version printed to the console that we intend to make minor backwards incompatible changes.

As per @cjyclaire's recommendation, we can do this in two stages. The first being this PR to add the warnings and the second to remove the methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

