### PR TITLE
Remove IO documentation from param validator

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove misleading IO documentation from `BlobShape` error output.
+
 3.68.0 (2019-09-16)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -141,8 +141,8 @@ module Aws
           errors << expected_got(context, "true or false", value)
         end
       when BlobShape
-        unless io_like?(value) or value.is_a?(String)
-          errors << expected_got(context, "a String or IO object", value)
+        unless value.is_a?(String) || io_like?(value)
+          errors << expected_got(context, "a String or File object", value)
         end
       else
         raise "unhandled shape type: #{ref.shape.class.name}"
@@ -166,9 +166,8 @@ module Aws
     end
 
     def io_like?(value)
-      value.respond_to?(:read) &&
-      value.respond_to?(:rewind) &&
-      value.respond_to?(:size)
+      value.respond_to?(:read) && value.respond_to?(:rewind) &&
+        value.respond_to?(:size)
     end
 
     def error_messages(errors)

--- a/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -184,7 +184,7 @@ module Aws
         validate(blob: double('d', :read => 'abc', :size => 3, :rewind => 0))
         validate({ blob: 'abc' })
         validate({ blob: 123 },
-          [/expected params\[:blob\] to be a String or IO object, got value 123 \(class: (Fixnum|Integer)\) instead./])
+          [/expected params\[:blob\] to be a String or File object, got value 123 \(class: (Fixnum|Integer)\) instead./])
       end
 
     end


### PR DESCRIPTION
closes #1927

The [IO](https://ruby-doc.org/core-2.6.4/IO.html) class states:
"Many of the examples in this section use the File class, the only standard subclass of IO. The two classes are closely associated."

I've simplified the error to only say String or File. You can still use StringIO or any other class that implements `size` on top of IO. Those are more advanced use cases; I would think that the common use case would be to use a String or File.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.