### PR TITLE
Fix up documentation around customized S3 object

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -1,14 +1,14 @@
 module Aws
   module S3
     class Object
-
       alias size content_length
 
       # Copies another object to this object. Use `multipart_copy: true`
       # for large objects. This is required for objects that exceed 5GB.
       #
-      # @param [S3::Object, S3::ObjectVersion, S3::ObjectSummary, String, Hash] source
-      #   Where to copy object data from. `source` must be one of the following:
+      # @param [S3::Object, S3::ObjectVersion, S3::ObjectSummary, String, Hash]
+      #   source Where to copy object data from. `source` must be one of the
+      #   following:
       #
       #   * {Aws::S3::Object}
       #   * {Aws::S3::ObjectSummary}
@@ -103,8 +103,9 @@ module Aws
         ObjectCopier.new(self, options).copy_to(target, options)
       end
 
-      # Copies and deletes the current object. The object will only be
-      # deleted if the copy operation succeeds.
+      # Copies and deletes the current object. The object will only be deleted
+      # if the copy operation succeeds.
+      #
       # @param (see Object#copy_to)
       # @option (see Object#copy_to)
       # @return [void]
@@ -129,10 +130,7 @@ module Aws
           client.config.credentials,
           client.config.region,
           bucket_name,
-          {
-            key: key,
-            url: bucket.url,
-          }.merge(options)
+          { key: key, url: bucket.url }.merge(options)
         )
       end
 
@@ -186,10 +184,10 @@ module Aws
       #
       def presigned_url(http_method, params = {})
         presigner = Presigner.new(client: client)
-        presigner.presigned_url("#{http_method.downcase}_object", params.merge(
-          bucket: bucket_name,
-          key: key,
-        ))
+        presigner.presigned_url(
+          "#{http_method.downcase}_object",
+          params.merge(bucket: bucket_name, key: key)
+        )
       end
 
       # Returns the public (un-signed) URL for this object.
@@ -199,7 +197,8 @@ module Aws
       #
       # To use virtual hosted bucket url (disables https):
       #
-      #     s3.bucket('my.bucket.com').object('key').public_url(virtual_host: true)
+      #     s3.bucket('my.bucket.com').object('key')
+      #       .public_url(virtual_host: true)
       #     #=> "http://my.bucket.com/key"
       #
       # @option options [Boolean] :virtual_host (false) When `true`, the bucket
@@ -216,11 +215,12 @@ module Aws
 
       # Uploads a stream in a streaming fashion to the current object in S3.
       #
-      #     # Passed chunks automatically split into multipart upload parts
-      #     # and the parts are uploaded in parallel. This allows for streaming uploads
-      #     # that never touch the disk.
+      # Passed chunks automatically split into multipart upload parts and the
+      # parts are uploaded in parallel. This allows for streaming uploads that
+      # never touch the disk.
       #
-      #  Note that this is known to have issues in JRuby until jruby-9.1.15.0, so avoid using this with older versions of JRuby.
+      # Note that this is known to have issues in JRuby until jruby-9.1.15.0,
+      # so avoid using this with older versions of JRuby.
       #
       # @example Streaming chunks of data
       #     obj.upload_stream do |write_stream|
@@ -235,17 +235,15 @@ module Aws
       #       IO.copy_stream(STDIN, write_stream)
       #     end
       #
-      # @option options [Integer] :thread_count
-      #   The number of parallel multipart uploads
-      #   Default `:thread_count` is `10`.
+      # @option options [Integer] :thread_count (10) The number of parallel
+      #   multipart uploads
       #
-      # @option options [Boolean] :tempfile
-      #   Normally read data is stored in memory when building the parts in order to complete
-      #   the underlying multipart upload. By passing `:tempfile => true` data read will be
+      # @option options [Boolean] :tempfile (false) Normally read data is stored
+      #   in memory when building the parts in order to complete the underlying
+      #   multipart upload. By passing `:tempfile => true` data read will be
       #   temporarily stored on disk reducing the memory footprint vastly.
-      #   Default `:tempfile` is `false`.
       #
-      # @option options [Integer] :part_size
+      # @option options [Integer] :part_size (5242880)
       #   Define how big each part size but the last should be.
       #   Default `:part_size` is `5 * 1024 * 1024`.
       #
@@ -264,9 +262,12 @@ module Aws
           client: client,
           thread_count: uploading_options.delete(:thread_count),
           tempfile: uploading_options.delete(:tempfile),
-          part_size: uploading_options.delete(:part_size),
+          part_size: uploading_options.delete(:part_size)
         )
-        uploader.upload(uploading_options.merge(bucket: bucket_name, key: key), &block)
+        uploader.upload(
+          uploading_options.merge(bucket: bucket_name, key: key),
+          &block
+        )
         true
       end
 
@@ -282,14 +283,21 @@ module Aws
       #     # and the parts are uploaded in parallel
       #     obj.upload_file('/path/to/very_large_file')
       #
-      # @param [String,Pathname,File,Tempfile] source A file or path to a file
-      #   on the local file system that should be uploaded to this object.
-      #   If you pass an open file object, then it is your responsibility
-      #   to close the file object once the upload completes.
+      # @param [String, Pathname, File, Tempfile] source A file on the local
+      #   file system that will be uploaded as this object. This can either be
+      #   a String or Pathname to the file, an open File object, or an open
+      #   Tempfile object. If you pass an open File or Tempfile object, then
+      #   you are responsible for closing it after the upload completes. When
+      #   using an open Tempfile, rewind it before uploading or else the object
+      #   will be empty.
       #
       # @option options [Integer] :multipart_threshold (15728640) Files larger
       #   than `:multipart_threshold` are uploaded using the S3 multipart APIs.
       #   Default threshold is 15MB.
+      #
+      # @option options [Integer] :thread_count (10) The number of parallel
+      #   multipart uploads. This option is not used if the file is smaller than
+      #   `:multipart_threshold`.
       #
       # @raise [MultipartUploadError] If an object is being uploaded in
       #   parts, and the upload can not be completed, then the upload is
@@ -304,8 +312,12 @@ module Aws
         uploading_options = options.dup
         uploader = FileUploader.new(
           multipart_threshold: uploading_options.delete(:multipart_threshold),
-          client: client)
-        uploader.upload(source, uploading_options.merge(bucket: bucket_name, key: key))
+          client: client
+        )
+        uploader.upload(
+          source,
+          uploading_options.merge(bucket: bucket_name, key: key)
+        )
         true
       end
 
@@ -320,7 +332,7 @@ module Aws
       #     # and the parts are downloaded in parallel
       #     obj.download_file('/path/to/very_large_file')
       #
-      # @param [String] destination Where to download the file to
+      # @param [String] destination Where to download the file to.
       #
       # @option options [String] mode `auto`, `single_request`, `get_range`
       #  `single_request` mode forces only 1 GET request is made in download,
@@ -328,21 +340,23 @@ module Aws
       #  customizing each range size in multipart_download,
       #  By default, `auto` mode is enabled, which performs multipart_download
       #
-      # @option options [String] chunk_size required in get_range mode
+      # @option options [String] chunk_size required in get_range mode.
       #
-      # @option options [String] thread_count Customize threads used in multipart
-      #   download, if not provided, 10 is default value
+      # @option options [Integer] thread_count (10) Customize threads used in
+      #   the multipart download.
       #
-      # @option options [String] version_id The object version id used to retrieve
-      #   the object, to know more about object versioning, see:
+      # @option options [String] version_id The object version id used to
+      #   retrieve the object. For more about object versioning, see:
       #   https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectVersioning.html
       #
-      # @return [Boolean] Returns `true` when the file is downloaded
-      #   without any errors.
+      # @return [Boolean] Returns `true` when the file is downloaded without
+      #   any errors.
       def download_file(destination, options = {})
         downloader = FileDownloader.new(client: client)
         downloader.download(
-          destination, options.merge(bucket: bucket_name, key: key))
+          destination,
+          options.merge(bucket: bucket_name, key: key)
+        )
         true
       end
     end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
@@ -1,15 +1,18 @@
 module Aws
   module S3
 
-    # A utility class that provides an IO-like interface to a portion of
-    # a file on disk.
+    # A utility class that provides an IO-like interface to a portion of a file
+    # on disk.
     # @api private
     class FilePart
 
-      # @option options [required,String,Pathname,File,Tempfile] :source
-      # @option options [required,Integer] :offset The file part will read
+      # @option options [required, String, Pathname, File, Tempfile] :source
+      #   The file to upload.
+      #
+      # @option options [required, Integer] :offset The file part will read
       #   starting at this byte offset.
-      # @option options [required,Integer] :size The maximum number of bytes to
+      #
+      # @option options [required, Integer] :size The maximum number of bytes to
       #   read from the `:offset`.
       def initialize(options = {})
         @source = options[:source]
@@ -19,7 +22,7 @@ module Aws
         @file = nil
       end
 
-      # @return [String,Pathname,File,Tempfile]
+      # @return [String, Pathname, File, Tempfile]
       attr_reader :source
 
       # @return [Integer]

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
@@ -7,13 +7,14 @@ module Aws
 
       FIFTEEN_MEGABYTES = 15 * 1024 * 1024
 
+      # @param [Hash] options
       # @option options [Client] :client
-      # @option options [Integer] :multipart_threshold Files greater than
-      #   `:multipart_threshold` bytes are uploaded using S3 multipart APIs.
+      # @option options [Integer] :multipart_threshold (15728640)
       def initialize(options = {})
         @options = options
         @client = options[:client] || Client.new
-        @multipart_threshold = options[:multipart_threshold] || FIFTEEN_MEGABYTES
+        @multipart_threshold = options[:multipart_threshold] ||
+                               FIFTEEN_MEGABYTES
       end
 
       # @return [Client]
@@ -23,9 +24,9 @@ module Aws
       #   using a {MultipartFileUploader}.
       attr_reader :multipart_threshold
 
-      # @param [String,Pathname,File,Tempfile] source
-      # @option options [required,String] :bucket
-      # @option options [required,String] :key
+      # @param [String, Pathname, File, Tempfile] source The file to upload.
+      # @option options [required, String] :bucket The bucket to upload to.
+      # @option options [required, String] :key The key for the object.
       # @return [void]
       def upload(source, options = {})
         if File.size(source) >= multipart_threshold
@@ -37,17 +38,17 @@ module Aws
 
       private
 
-      def put_object(source, options)
-        open_file(source) do |file|
-          @client.put_object(options.merge(body: file))
-        end
-      end
-
       def open_file(source)
         if String === source || Pathname === source
           File.open(source, 'rb') { |file| yield(file) }
         else
           yield(source)
+        end
+      end
+
+      def put_object(source, options)
+        open_file(source) do |file|
+          @client.put_object(options.merge(body: file))
         end
       end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'thread'
 require 'set'
 
 module Aws
@@ -16,14 +15,17 @@ module Aws
       THREAD_COUNT = 10
 
       # @api private
-      CREATE_OPTIONS =
-        Set.new(Client.api.operation(:create_multipart_upload).input.shape.member_names)
+      CREATE_OPTIONS = Set.new(
+        Client.api.operation(:create_multipart_upload).input.shape.member_names
+      )
 
       # @api private
-      UPLOAD_PART_OPTIONS =
-        Set.new(Client.api.operation(:upload_part).input.shape.member_names)
+      UPLOAD_PART_OPTIONS = Set.new(
+        Client.api.operation(:upload_part).input.shape.member_names
+      )
 
       # @option options [Client] :client
+      # @option options [Integer] :thread_count (THREAD_COUNT)
       def initialize(options = {})
         @client = options[:client] || Client.new
         @thread_count = options[:thread_count] || THREAD_COUNT
@@ -32,9 +34,9 @@ module Aws
       # @return [Client]
       attr_reader :client
 
-      # @param [String,Pathname,File,Tempfile] source
-      # @option options [required,String] :bucket
-      # @option options [required,String] :key
+      # @param [String, Pathname, File, Tempfile] source The file to upload.
+      # @option options [required, String] :bucket The bucket to upload to.
+      # @option options [required, String] :key The key for the object.
       # @return [void]
       def upload(source, options = {})
         if File.size(source) < MIN_PART_SIZE
@@ -57,7 +59,8 @@ module Aws
           bucket: options[:bucket],
           key: options[:key],
           upload_id: upload_id,
-          multipart_upload: { parts: parts })
+          multipart_upload: { parts: parts }
+        )
       end
 
       def upload_parts(upload_id, source, options)
@@ -93,7 +96,7 @@ module Aws
         part_number = 1
         parts = []
         while offset < size
-          parts << upload_part_opts(options).merge({
+          parts << upload_part_opts(options).merge(
             upload_id: upload_id,
             part_number: part_number,
             body: FilePart.new(
@@ -101,7 +104,7 @@ module Aws
               offset: offset,
               size: part_size(size, default_part_size, offset)
             )
-          })
+          )
           part_number += 1
           offset += default_part_size
         end

--- a/gems/aws-sdk-s3/spec/object_spec.rb
+++ b/gems/aws-sdk-s3/spec/object_spec.rb
@@ -3,6 +3,19 @@ require_relative 'spec_helper'
 module Aws
   module S3
     class Object
+
+      describe '#copy_from' do
+        it 'pending'
+      end
+
+      describe '#copy_to' do
+        it 'pending'
+      end
+
+      describe '#move_to' do
+        it 'pending'
+      end
+
       describe '#presigned_post' do
 
         let(:object) { Object.new('bucket', 'key', stub_responses: true) }
@@ -14,6 +27,27 @@ module Aws
         end
 
       end
+
+      describe '#presigned_url' do
+        it 'pending'
+      end
+
+      describe '#public_url' do
+        it 'pending'
+      end
+
+      describe '#upload_stream' do
+        it 'pending'
+      end
+
+      describe '#upload_file' do
+        it 'pending'
+      end
+
+      describe '#download_file' do
+        it 'pending'
+      end
+
     end
   end
 end


### PR DESCRIPTION
This change updates documentation around Object#upload_file, as well as some general code clean-up via Rubocop and pending tests.

I bounced back and forth on adding a check for Tempfiles to determine its size, but decided that the doc updates made more sense. A change would allow closed Tempfiles to be uploaded but not closed Files, and that was inconsistent.

Closes #1967, #2120

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.