### PR TITLE
Fix method redefinition warnings

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix method redefinition warnings
+
 3.69.0 (2019-10-17)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/base.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/base.rb
@@ -194,13 +194,15 @@ module Seahorse
         private
 
         def define_operation_methods
+          operations_module = Module.new
           @api.operation_names.each do |method_name|
-            define_method(method_name) do |*args, &block|
+            operations_module.send(:define_method, method_name) do |*args, &block|
               params = args[0] || {}
               options = args[1] || {}
               build_request(method_name, params).send_request(options, &block)
             end
           end
+          include(operations_module)
         end
 
         def build_plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
@@ -119,7 +119,7 @@ module Seahorse
         attr_accessor :default_block
         attr_accessor :required
         attr_accessor :doc_type
-        attr_accessor :doc_default
+        attr_writer :doc_default
         attr_accessor :docstring
 
         def doc_default


### PR DESCRIPTION
`Seahorse::Client::Base.define_operation_methods` generically defines methods for a client API.  Later, generated client class code explicitly defines those methods.  To prevent method redefinition warnings, make `define_operation_methods` define the generic methods in an anonymous module, which is then included into the client class.

Also, fix a conflict between an `attr_accessor` and an explicitly defined reader method.

Fixes #2070.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
