### PR TITLE
Support QueueUrl Plugin override

### DIFF
--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support setting `:disable_queue_url_override` to `true` for disabling endpoint and region override from `:queue_url` value (Github #2114)
+
 1.23.0 (2019-10-23)
 ------------------
 

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
@@ -4,10 +4,20 @@ module Aws
       # @api private
       class QueueUrls < Seahorse::Client::Plugin
 
+        option(:disable_queue_url_override,
+              default: false,
+              doc_type: 'Boolean',
+              docstring: <<-DOCS
+Set to `true` to disable region and endpoint override from
+`:queue_url` value, default to `false`
+              DOCS
+        )
+
         class Handler < Seahorse::Client::Handler
 
           def call(context)
-            if queue_url = context.params[:queue_url]
+            disable = !!context.config.disable_queue_url_override
+            if !disable && (queue_url = context.params[:queue_url])
               update_endpoint(context, queue_url)
               update_region(context, queue_url)
             end

--- a/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
@@ -59,6 +59,16 @@ module Aws
               client.send(method, params.merge(queue_url: url))
             }.to_not raise_error
           end
+
+          it 'does not override endpoint and region when disabled' do
+            endpoint = 'https://vpc-123234.sqs.us-west-2.vpc.amazonaws.com'
+            url = 'https://sqs.us-east-1.amazonaws.com/1234567890/demo'
+            client = Client.new(stub_responses: true, endpoint: endpoint, disable_queue_url_override: true)
+            resp = client.send(method, params.merge(queue_url: url))
+            expect(resp.context.http_request.endpoint.to_s).to eq(endpoint)
+            expect(resp.context.http_request.headers['authorization']).not_to include('us-east-1')
+            expect(resp.context.http_request.headers['authorization']).to include('us-stubbed-1')
+          end
         end
       end
     end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Addressing #2114 

```
Aws::SQS::Client.new(disable_queue_url_override: true)
```
will disable endpoint and region override from the `:queue _url` provided

Note:

Pending on sync with Java team