### PR TITLE
Support VPC Endpoint SQS Queue URL

### DIFF
--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support VPC Endpoint pattern in Aws::SQS::Plugins::QueueUrl (Github #2114)
+
 1.23.0 (2019-10-23)
 ------------------
 

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
@@ -22,7 +22,7 @@ module Aws
           # region, then we will modify the request to have
           # a sigv4 signer for the proper region.
           def update_region(context, queue_url)
-            if queue_region = queue_url.to_s.split('.')[1]
+            if queue_region = parse_region(queue_url)
               if queue_region != context.config.region
                 config = context.config.dup
                 config.region = queue_region
@@ -31,6 +31,16 @@ module Aws
                 context.config = config
               end
             end
+          end
+
+          private
+
+          # take the first conponemnt after service delimiter
+          # https://sqs.us-east-1.amazonaws.com/1234567890/demo
+          # https://vpce-x-y.sqs.us-east-1.vpce.amazonaws.com/1234567890/demo
+          def parse_region(url)
+            parts = url.split('sqs.')
+            parts[1].split('.').first if parts.size > 1
           end
 
         end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
@@ -35,7 +35,7 @@ module Aws
 
           private
 
-          # take the first conponemnt after service delimiter
+          # take the first component after service delimiter
           # https://sqs.us-east-1.amazonaws.com/1234567890/demo
           # https://vpce-x-y.sqs.us-east-1.vpce.amazonaws.com/1234567890/demo
           def parse_region(url)

--- a/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
@@ -45,6 +45,15 @@ module Aws
             expect(resp.context.http_request.headers['authorization']).to include('cn-north-1')
           end
 
+          it 'supports vpc endpoint queue URL' do
+            url = "https://vpce-xxxx-yyyy.sqs.us-east-1.vpce."\
+              "amazonaws.com/1234567890/demo"
+            client = Client.new(stub_responses:true, region: 'cn-north-1')
+            resp = client.send(method, params.merge(queue_url: url))
+            expect(resp.context.http_request.headers['authorization'])
+              .to include('us-east-1')
+          end
+
           it 'raises an error for a badly formatted queue url' do
             expect {
               client = Client.new(stub_responses:true)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #2114 

SDK should support queue URL behavior and support correct region parsing from VPC Endpoint pattern