### PR TITLE
Fix log formatters not responding to rewind when using blocks

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased Changes
 
 * Feature - Add STS Presigner module with a method to generate a presigned EKS token.
 
+* Issue - Fix issue for log formatters in clients where http_response_body does not respond to `rewind` when using a block.
+
 3.84.0 (2019-12-04)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
@@ -171,7 +171,13 @@ module Aws
       end
 
       def _http_response_body(response)
-        @param_formatter.summarize(response.context.http_response.body_contents)
+        if response.context.http_response.body.respond_to?(:rewind)
+          @param_formatter.summarize(
+            response.context.http_response.body_contents
+          )
+        else
+          ''
+        end
       end
 
       def _error_class(response)

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -173,9 +173,11 @@ module Seahorse
         end
 
         def _http_response_body(response)
-          response.context.http_response.body.respond_to?(:rewind) ?
-            summarize_value(response.context.http_response.body_contents) :
+          if response.context.http_response.body.respond_to?(:rewind)
+            summarize_value(response.context.http_response.body_contents)
+          else
             ''
+          end
         end
 
         def _error_class(response)

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -111,6 +111,8 @@ module Aws
           response.context.http_response.body = '-' * 1024 * 1024
           formatted = format(':http_response_body', max_string_size: 5)
           expect(formatted).to eq("#<String \"-----\" ... (1048576 bytes)>")
+          response.context.http_response.body = Seahorse::Client::BlockIO.new
+          expect(format(':http_response_body')).to eq('')
         end
 
         it 'provides a :error_class replacement' do


### PR DESCRIPTION
Fix issue for log formatters in clients where http_response_body does not respond to `rewind` when using a block.

closes #2183

similar change to #1479

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.