### PR TITLE
Reuse connections even if http_wire_trace is true

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Reuse connections even if `http_wire_trace` is true.
+
 3.86.0 (2019-12-13)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -18,6 +18,7 @@ module Seahorse
 
         @pools_mutex = Mutex.new
         @pools = {}
+        @default_logger = Logger.new($stdout)
 
         OPTIONS = {
           http_proxy: nil,
@@ -231,7 +232,7 @@ module Seahorse
           # @return [Hash]
           def pool_options options
             wire_trace = !!options[:http_wire_trace]
-            logger = options[:logger] || Logger.new($stdout) if wire_trace
+            logger = options[:logger] || @default_logger if wire_trace
             verify_peer = options.key?(:ssl_verify_peer) ?
               !!options[:ssl_verify_peer] : true
             {

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
@@ -23,6 +23,14 @@ module Seahorse
             expect(pool.send(:http_proxy_parts)).to eq ["proxy.com", 8080, ":@/username", "password:@/"]
           end
         end
+
+        describe ".for" do
+          it "returns the same connection pool" do
+            first_pool = described_class.for(:http_wire_trace => true)
+            second_pool = described_class.for(:http_wire_trace => true)
+            expect(first_pool).to eq second_pool
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
ConnectionPool.pool_options always includes a new logger if http_wire_trace is true, so ConnectionPool.for always returns a new instance. Connections will be reused by this commit even if http_wire_trace is true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.