### PR TITLE
Add plugin for content-type header for SSO GetRoleCredentials operation

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -163,11 +163,11 @@ module Seahorse
         # @return [Hash] Returns a vanilla hash of headers to send with the
         #   HTTP request.
         def headers(request)
-          # Net::HTTP adds a content-type (1.8.7+) and accept-encoding (2.0.0+)
-          # to the request if these headers are not set.  Setting a default
-          # empty value defeats this.
+          # Net::HTTP adds default headers for content-type to POSTs (1.8.7+)
+          # and accept-encoding (2.0.0+). Setting a default empty value defeats
+          # this.
           #
-          # Removing these are necessary for most services to no break request
+          # Removing these are necessary for most services to not break request
           # signatures as well as dynamodb crc32 checks (these fail if the
           # response is gzipped).
           headers = { 'content-type' => '', 'accept-encoding' => '' }

--- a/gems/aws-sdk-sso/CHANGELOG.md
+++ b/gems/aws-sdk-sso/CHANGELOG.md
@@ -1,8 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Feature - Fix `GetRoleCredentials` calls by providing a non-empty `Content-Type` header.
+
 1.0.0 (2019-11-07)
 ------------------
 
 * Feature - Initial release of `aws-sdk-sso`.
-

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/client.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/client.rb
@@ -26,6 +26,7 @@ require 'aws-sdk-core/plugins/client_metrics_send_plugin.rb'
 require 'aws-sdk-core/plugins/transfer_encoding.rb'
 require 'aws-sdk-core/plugins/signature_v4.rb'
 require 'aws-sdk-core/plugins/protocols/rest_json.rb'
+require 'aws-sdk-sso/plugins/content_type.rb'
 
 Aws::Plugins::GlobalConfiguration.add_identifier(:sso)
 
@@ -59,6 +60,7 @@ module Aws::SSO
     add_plugin(Aws::Plugins::TransferEncoding)
     add_plugin(Aws::Plugins::SignatureV4)
     add_plugin(Aws::Plugins::Protocols::RestJson)
+    add_plugin(Aws::SSO::Plugins::ContentType)
 
     # @overload initialize(options)
     #   @param [Hash] options

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
@@ -1,0 +1,25 @@
+module Aws
+  module SSO
+    module Plugins
+      class ContentType < Seahorse::Client::Plugin
+
+        def add_handlers(handlers, config)
+          handlers.add(Handler)
+        end
+
+        class Handler < Seahorse::Client::Handler
+          def call(context)
+            # SSO GetRoleCredentials operation breaks when given an empty
+            # content-type header. The SDK adds this blank content-type header
+            # since Net::HTTP provides a default that can break services.
+            # We're setting one here even though it's not used or necessary.
+            if context.operation.name == 'GetRoleCredentials'
+              context.http_request.headers['content-type'] = 'application/json'
+            end
+            @handler.call(context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
@@ -4,7 +4,7 @@ module Aws
       class ContentType < Seahorse::Client::Plugin
 
         def add_handlers(handlers, config)
-          handlers.add(Handler)
+          handlers.add(Handler, operations: [:get_role_credentials])
         end
 
         class Handler < Seahorse::Client::Handler
@@ -13,9 +13,7 @@ module Aws
             # content-type header. The SDK adds this blank content-type header
             # since Net::HTTP provides a default that can break services.
             # We're setting one here even though it's not used or necessary.
-            if context.operation.name == 'GetRoleCredentials'
-              context.http_request.headers['content-type'] = 'application/json'
-            end
+            context.http_request.headers['content-type'] = 'application/json'
             @handler.call(context)
           end
         end

--- a/services.json
+++ b/services.json
@@ -643,7 +643,10 @@
     "models": "ssm/2014-11-06"
   },
   "SSO": {
-    "models": "sso/2019-06-10"
+    "models": "sso/2019-06-10",
+    "addPlugins": [
+      "Aws::SSO::Plugins::ContentType"
+    ]
   },
   "SSOOIDC": {
     "models": "sso-oidc/2019-06-10"


### PR DESCRIPTION
Fixes #2196

SSO team doesn't care to make changes to their service to handle empty headers (even though other services handle it just fine). I have two client side options - I tried to prefer the 'correct' fix of option 1 here but I couldn't get it to work.

1) Remove the empty `Content-Type` header from the net_http handler. This cannot be done by itself as it breaks integ tests in s3. In the [Rest handler](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/rest/handler.rb#L6) I tried adding logic for checking `context.config.api.metadata['protocol']` for 'rest-xml' or 'rest-json' and adding appropriate content types there, however, this fails for some reason for h2/async services that use rest-json. I could special case this around h2 but decided it to be messy and unnecessarily high risk.

2) Add a plugin (this approach) - this looks for GetRoleCredentials API calls and adds `application/json` as a Content-Type. The big downside of this approach is that it won't fix any new services or operations that don't handle empty headers. It also carries forward more legacy (sigh) that I won't be able to ever remove unless the service can handle it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.