### PR TITLE
Fix ineffective option `http_idle_timeout` in `Seahorse::Client::NetHttp::ConnectionPool`

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased Changes
 ------------------
 
 * Issue - Fix erroneously reaped sessions from `Seahorse::Client::NetHttp::ConnectionPool` due to bad `last_used` time calculation
+* Issue - Use monotonic clocks when reaping sessions in `Seahorse::Client::NetHttp::ConnectionPool`
 
 3.89.0 (2020-01-13)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix erroneously reaped sessions from `Seahorse::Client::NetHttp::ConnectionPool` due to bad `last_used` time calculation
+
 3.89.0 (2020-01-13)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased Changes
 
 * Issue - Fix erroneously reaped sessions from `Seahorse::Client::NetHttp::ConnectionPool` due to bad `last_used` time calculation
 * Issue - Use monotonic clocks when reaping sessions in `Seahorse::Client::NetHttp::ConnectionPool`
+* Issue - Fix "Conn close because of keep_alive_timeout" when reusing  `Seahorse::Client::NetHttp::ConnectionPool` sessions
 
 3.89.0 (2020-01-13)
 ------------------

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -339,8 +339,8 @@ module Seahorse
 
           # Sends the request and tracks that this session has been used.
           def request(*args, &block)
-            @last_used = Time.now
             @http.request(*args, &block)
+            @last_used = Time.now
           end
 
           # Attempts to close/finish the session without raising an error.

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -132,7 +132,7 @@ module Seahorse
           nil
         end
 
-        # Closes and removes removes all sessions from the pool.
+        # Closes and removes all sessions from the pool.
         # If empty! is called while there are outstanding requests they may
         # get checked back into the pool, leaving the pool in a non-empty
         # state.
@@ -166,16 +166,16 @@ module Seahorse
           #   requests through.  Formatted like 'http://proxy.com:123'.
           #
           # @option options [Float] :http_open_timeout (15) The number of
-          #   seconds to wait when opening a HTTP session before rasing a
+          #   seconds to wait when opening an HTTP session before raising a
           #   `Timeout::Error`.
           #
           # @option options [Integer] :http_read_timeout (60) The default
           #   number of seconds to wait for response data.  This value can
           #   safely be set
-          #   per-request on the session yeidled by {#session_for}.
+          #   per-request on the session yielded by {#session_for}.
           #
           # @option options [Float] :http_idle_timeout (5) The number of
-          #   seconds a connection is allowed to sit idble before it is
+          #   seconds a connection is allowed to sit idle before it is
           #   considered stale.  Stale connections are closed and removed
           #   from the pool before making a request.
           #
@@ -184,7 +184,7 @@ module Seahorse
           #   request body.  This option has no effect unless the request has
           #   "Expect" header set to "100-continue".  Defaults to `nil` which
           #   disables this behaviour.  This value can safely be set per
-          #   request on the session yeidled by {#session_for}.
+          #   request on the session yielded by {#session_for}.
           #
           # @option options [Boolean] :http_wire_trace (false) When `true`,
           #   HTTP debug output will be sent to the `:logger`.
@@ -201,13 +201,13 @@ module Seahorse
           # @option options [String] :ssl_ca_bundle Full path to the SSL
           #   certificate authority bundle file that should be used when
           #   verifying peer certificates.  If you do not pass
-          #   `:ssl_ca_bundle` or `:ssl_ca_directory` the the system default
+          #   `:ssl_ca_bundle` or `:ssl_ca_directory` the system default
           #   will be used if available.
           #
           # @option options [String] :ssl_ca_directory Full path of the
           #   directory that contains the unbundled SSL certificate
           #   authority files for verifying peer certificates.  If you do
-          #   not pass `:ssl_ca_bundle` or `:ssl_ca_directory` the the
+          #   not pass `:ssl_ca_bundle` or `:ssl_ca_directory` the
           #   system default will be used if available.
           #
           # @return [ConnectionPool]
@@ -218,7 +218,7 @@ module Seahorse
             end
           end
 
-          # @return [Array<ConnectionPool>] Returns a list of of the
+          # @return [Array<ConnectionPool>] Returns a list of the
           #   constructed connection pools.
           def pools
             @pools_mutex.synchronize do
@@ -316,7 +316,7 @@ module Seahorse
           end
         end
 
-        # Helper methods extended onto Net::HTTPSession objects opend by the
+        # Helper methods extended onto Net::HTTPSession objects opened by the
         # connection pool.
         # @api private
         class ExtendedSession < Delegator

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -302,12 +302,12 @@ module Seahorse
         # Removes stale sessions from the pool.  This method *must* be called
         # @note **Must** be called behind a `@pool_mutex` synchronize block.
         def _clean
-          now = Time.now
+          now = Aws::Util.monotonic_milliseconds
           @pool.each_pair do |endpoint,sessions|
             sessions.delete_if do |session|
               if
                 session.last_used.nil? or
-                now - session.last_used > http_idle_timeout
+                now - session.last_used > http_idle_timeout * 1000
               then
                 session.finish
                 true
@@ -326,7 +326,7 @@ module Seahorse
             @http = http
           end
 
-          # @return [Time,nil]
+          # @return [Integer,nil]
           attr_reader :last_used
 
           def __getobj__
@@ -340,7 +340,7 @@ module Seahorse
           # Sends the request and tracks that this session has been used.
           def request(*args, &block)
             @http.request(*args, &block)
-            @last_used = Time.now
+            @last_used = Aws::Util.monotonic_milliseconds
           end
 
           # Attempts to close/finish the session without raising an error.

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -53,14 +53,14 @@ module Seahorse
 
         # Makes an HTTP request, yielding a Net::HTTPResponse object.
         #
-        #   pool.request('http://domain', Net::HTTP::Get.new('/')) do |resp|
+        #   pool.request(URI.parse('http://domain'), Net::HTTP::Get.new('/')) do |resp|
         #     puts resp.code # status code
         #     puts resp.to_h.inspect # dump the headers
         #     puts resp.body
         #   end
         #
-        # @param [String] endpoint The HTTP(S) endpoint to
-        #    connect to (e.g. 'https://domain.com').
+        # @param [URI::HTTP, URI::HTTPS] endpoint The HTTP(S) endpoint
+        #    to connect to (e.g. 'https://domain.com').
         #
         # @param [Net::HTTPRequest] request The request to make.  This can be
         #   any request object from Net::HTTP (e.g. Net::HTTP::Get,

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -280,6 +280,7 @@ module Seahorse
           http = ExtendedSession.new(Net::HTTP.new(*args.compact))
           http.set_debug_output(logger) if http_wire_trace?
           http.open_timeout = http_open_timeout
+          http.keep_alive_timeout = http_idle_timeout if http.respond_to?(:keep_alive_timeout=)
 
           if endpoint.scheme == 'https'
             http.use_ssl = true

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
@@ -96,6 +96,14 @@ module Seahorse
             expect(handler_pool.http_idle_timeout).to eq(123)
           end
 
+          it 'configures the Net::HTTP#keep_alive_timeout' do
+            config.http_idle_timeout = 123
+            handler_pool.session_for(URI.parse('http://foo.com')) do |http|
+              skip 'not supported' unless http.respond_to?(:keep_alive_timeout)
+              expect(http.keep_alive_timeout).to eq(123)
+            end
+          end
+
           it 'configures the pool#http_wire_trace' do
             config.http_wire_trace = true
             expect(handler_pool.http_wire_trace).to eq(true)

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
@@ -31,7 +31,7 @@ module Seahorse
         describe '#session_for' do
 
           it 're-uses session for endpoints that share port, scheme and host' do
-            session = double('http-session', last_used: Time.now).as_null_object
+            session = double('http-session', last_used: Aws::Util.monotonic_milliseconds).as_null_object
             pool = ConnectionPool.for({})
             expect(pool).to receive(:start_session).
               exactly(1).times.


### PR DESCRIPTION
This PR attempts to address two issues that are making for unanticipated TCP reconnections when interacting with S3 repositories.

- Fix erroneously reaped sessions from `Seahorse::Client::NetHttp::ConnectionPool` due to bad `last_used` time calculation. The issue here is that the `session.last_used` value is set to be the time right before a request is made thus wrongfully including the request duration in the idle time equation consequently terminating the session instead of reusing it. This is often manifested when a slow connection causes a request (e.g. uploaded part) to take longer than the configured `http_idle_timeout`. Moving the time sampling after the request is complete fixes the issue and is in line with how Ruby `Net::HTTP` is doing its internal `keep_alive_timeout` calculations.
- Fix "Conn close because of keep_alive_timeout" when reusing 
 `Seahorse::Client::NetHttp::ConnectionPool` sessions. Currently, the `http_idle_timeout` is described as "The number of seconds a connection is allowed to sit idble before it is considered stale" with a default value of 5 seconds. These sessions are keeping a reference to the opened `Net::HTTP` connections that have `keep_alive_timeout` defaulting to 2 seconds. The issue here is that any session in the pool reused after the 2 seconds mark will result in an automatic reconnect (i.e. re-establishing a TCP session). This means that setting `http_idle_timeout` to any value greater than 2 seconds is irrelevant. Setting the `http.keep_alive_timeout` to equals the configured `http_idle_timeout` should allow for all sessions in the pool to be readily used upon checkout.

A few minor improvements are also included and full changes are documented throughout the commit messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.