### PR TITLE
fix ruby 2.7 warning

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -306,10 +306,7 @@ module Seahorse
           now = Aws::Util.monotonic_milliseconds
           @pool.each_pair do |endpoint,sessions|
             sessions.delete_if do |session|
-              if
-                session.last_used.nil? or
-                now - session.last_used > http_idle_timeout * 1000
-              then
+              if session.last_used.nil? or now - session.last_used > http_idle_timeout * 1000
                 session.finish
                 true
               end


### PR DESCRIPTION
fixes
```
lib/seahorse/client/net_http/connection_pool.rb:309: warning: `if' at the end of line without an expression
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
