### PR TITLE
Remove JSON dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - JSON - Removed the dependency on the json gem because it is a default gem since ruby 1.9.
+
 1.67.0 (2017-04-03)
 ------------------
 

--- a/aws-sdk-v1.gemspec
+++ b/aws-sdk-v1.gemspec
@@ -12,7 +12,6 @@ application.
   s.homepage = 'http://aws.amazon.com/sdkforruby'
 
   s.add_dependency('nokogiri', '~> 1')
-  s.add_dependency('json', '~> 1.4')
 
   s.files = [
     'ca-bundle.crt',


### PR DESCRIPTION
I know that gem is deprecated and all, and we're trying to get rid of it, but in the meantime this dependency on `json ~> 1.4` is causing us lots of trouble.

@awood45 since you relaxed the dependency on Nokogiri, would it be possible to do the same with JSON?