### PR TITLE
feat(aws-sdk-core): case-insensitive log filtering

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Perform a case-insensitive comparison when filtering sensitive parameters from logs
+
 3.90.0 (2020-02-12)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -7,7 +7,7 @@ module Aws
 
       # A managed list of sensitive parameters that should be filtered from
       # logs. This is updated automatically as part of each release. See the
-      # `tasks/sensitive.rake` for more information.
+      # `tasks/update-sensitive-params.rake` for more information.
       #
       # @api private
       # begin
@@ -31,7 +31,7 @@ module Aws
       def filter_hash(values)
         filtered = {}
         values.each_pair do |key, value|
-          filtered[key] = @filters.include?(key) ? '[FILTERED]' : filter(value)
+          filtered[key] = @filters.any? { |f| f.to_s.casecmp(key.to_s).zero? } ? '[FILTERED]' : filter(value)
         end
         filtered
       end

--- a/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
@@ -1,0 +1,60 @@
+require_relative '../../spec_helper'
+
+module Aws
+  module Log
+    describe ParamFilter do
+      describe '#filter' do
+        context 'with an array' do
+          context 'with a filtered parameter name' do
+            it 'filters lowercase parameter names' do
+              expect(subject.filter([{ password: 'p@assw0rd'}])).to eq([{ password: '[FILTERED]'} ])
+            end
+
+            it 'filters uppercase parameter names' do
+              expect(subject.filter([{ PASSWORD: 'p@assw0rd'}])).to eq([{ PASSWORD: '[FILTERED]'} ])
+            end
+
+            it 'filters mixed-case parameter names' do
+              expect(subject.filter([{ Password: 'p@assw0rd'}])).to eq([{ Password: '[FILTERED]'} ])
+            end
+          end
+        end
+
+        context 'with a Struct' do
+          context 'with a filtered parameter name' do
+            it 'filters lowercase parameter names' do
+              instance = Struct.new(:password).new('p@assw0rd')
+              expect(subject.filter(instance)).to eq(password: '[FILTERED]')
+            end
+
+            it 'filters uppercase parameter names' do
+              instance = Struct.new(:PASSWORD).new('p@assw0rd')
+              expect(subject.filter(instance)).to eq(PASSWORD: '[FILTERED]')
+            end
+
+            it 'filters mixed-case parameter names' do
+              instance = Struct.new(:Password).new('p@assw0rd')
+              expect(subject.filter(instance)).to eq(Password: '[FILTERED]')
+            end
+          end
+        end
+
+        context 'with a hash' do
+          context 'with a filtered parameter name' do
+            it 'filters lowercase parameter names' do
+              expect(subject.filter(password: 'p@ssw0rd')).to eq(password: '[FILTERED]')
+            end
+
+            it 'filters uppercase parameter names' do
+              expect(subject.filter(PASSWORD: 'p@ssw0rd')).to eq(PASSWORD: '[FILTERED]')
+            end
+
+            it 'filters mixed-case parameter names' do
+              expect(subject.filter(Password: 'p@ssw0rd')).to eq(Password: '[FILTERED]')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
resolves: https://github.com/aws/aws-sdk-ruby/issues/2122

* There are AWS API calls that may require alternate casing for
  sensitive parameters (i.e. Cognito `initiate_auth` with an
  uppercased `PASSWORD` parameter).
* To be safe, perform a case-insensitive comparison when looping
  through parameter names to filter.
* Add test cases for `Aws::Log::ParamFilter#filter` that explicitly
  check for a case-insensitive comparison when filtering log
  parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
