### PR TITLE
Allow S3::EncryptedClient to be used as a resource client

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow EncryptedClient to be used as a Resource client.
+
 1.60.1 (2019-12-19)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -181,7 +181,7 @@ module Aws
 
         extend Deprecations
         extend Forwardable
-        def_delegators :@client, :delete_object, :head_object
+        def_delegators :@client, :delete_object, :head_object, :config
 
         # Creates a new encryption client. You must provide one of the following
         # options:

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -24,6 +24,11 @@ module Aws
         let(:client) { Encryption::Client.new(options) }
 
         describe 'configuration' do
+          it 'can be used as a Resource client' do
+            resource = S3::Resource.new(client: client)
+            resource.bucket('bucket')
+          end
+
           it 'constructs a default s3 client when one is not given' do
             api_client = double('client')
             expect(S3::Client).to receive(:new).and_return(api_client)


### PR DESCRIPTION
Otherwise the following code fails:

```ruby
s3 = Aws::S3::Resource.new(client: Aws::S3::Encryption::Client.new(S3_CREDENTIALS.merge(encryption_key: @key)))
s3.bucket('bucket')
```

```ruby
aws-sdk-s3-1.60.1/lib/aws-sdk-s3/resource.rb:75:in `bucket'
aws-sdk-s3-1.60.1/lib/aws-sdk-s3/resource.rb:75:in `new'
aws-sdk-s3-1.60.1/lib/aws-sdk-s3/customizations/bucket.rb:13:in `block in <class:Bucket>'
NoMethodError (undefined method `config' for #<Aws::S3::Encryption::Client:0x00007fc6aed6aa98>)
```
