### PR TITLE
Fix an issue where S3 Resorce clients could not use Encryption clients

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow `Aws::S3::Encrypted::Client` to be used with a Resource client.
+
 1.60.1 (2019-12-19)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -181,7 +181,7 @@ module Aws
 
         extend Deprecations
         extend Forwardable
-        def_delegators :@client, :delete_object, :head_object
+        def_delegators :@client, :config, :delete_object, :head_object
 
         # Creates a new encryption client. You must provide one of the following
         # options:

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -24,6 +24,11 @@ module Aws
         let(:client) { Encryption::Client.new(options) }
 
         describe 'configuration' do
+          it 'can be used with a Resource client' do
+            resource = S3::Resource.new(client: client)
+            expect(resource.client.config).to eq(api_client.config)
+          end
+
           it 'constructs a default s3 client when one is not given' do
             api_client = double('client')
             expect(S3::Client).to receive(:new).and_return(api_client)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #2221