### PR TITLE
Presign a WebSocket URL - wss://domain.com/mqtt

### DIFF
--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -558,7 +558,9 @@ module Aws
 
       def standard_port?(uri)
         (uri.scheme == 'http' && uri.port == 80) ||
-        (uri.scheme == 'https' && uri.port == 443)
+        (uri.scheme == 'https' && uri.port == 443) ||
+        (uri.scheme == 'ws' && (uri.port == 80 || uri.port.nil?)) ||
+        (uri.scheme == 'wss' && (uri.port == 443 || uri.port.nil?))
       end
 
       # @param [File, Tempfile, IO#read, String] value

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -549,18 +549,12 @@ module Aws
       end
 
       def host(uri)
-        if standard_port?(uri)
+        # Handles known and unknown URI schemes; default_port nil when unknown.
+        if uri.default_port == uri.port
           uri.host
         else
           "#{uri.host}:#{uri.port}"
         end
-      end
-
-      def standard_port?(uri)
-        (uri.scheme == 'http' && uri.port == 80) ||
-        (uri.scheme == 'https' && uri.port == 443) ||
-        (uri.scheme == 'ws' && (uri.port == 80 || uri.port.nil?)) ||
-        (uri.scheme == 'wss' && (uri.port == 443 || uri.port.nil?))
       end
 
       # @param [File, Tempfile, IO#read, String] value

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -143,6 +143,38 @@ module Aws
           expect(signature.headers['host']).to eq('domain.com:123')
         end
 
+        it 'includes WS port in Host when not 80' do
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'ws://domain.com:123'
+          )
+          expect(signature.headers['host']).to eq('domain.com:123')
+        end
+
+        it 'includes WSS port in Host when not 443' do
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'wss://domain.com:123'
+          )
+          expect(signature.headers['host']).to eq('domain.com:123')
+        end
+
+        it 'does not include trailing colon in HOST if WS default port' do
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'ws://domain.com'
+          )
+          expect(signature.headers['host']).to eq('domain.com')
+        end
+
+        it 'does not include trailing colon in HOST if WSS default port' do
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'wss://domain.com'
+          )
+          expect(signature.headers['host']).to eq('domain.com')
+        end
+
         it 'sets the X-Amz-Date header' do
           now = Time.now
           allow(Time).to receive(:now).and_return(now)

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -127,7 +127,15 @@ module Aws
           expect(signature.headers['host']).to eq('domain.com')
         end
 
-        context '#known URI schema' do
+        context 'when URI schema is known' do
+
+          it 'ommits port in Host when port not provided' do
+            signature = Signer.new(options).sign_request(
+              http_method: 'GET',
+              url: 'https://domain.com'
+            )
+            expect(signature.headers['host']).to eq('domain.com')
+          end
 
           it 'ommits port in Host when default port and uri port are the same' do
             signature = Signer.new(options).sign_request(
@@ -147,7 +155,7 @@ module Aws
 
         end
 
-        context '#unknown uri schema' do
+        context 'when URI schema is unknown' do
 
           it 'ommits port in Host when uri port not provided' do
             signature = Signer.new(options).sign_request(

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -127,52 +127,45 @@ module Aws
           expect(signature.headers['host']).to eq('domain.com')
         end
 
-        it 'includes HTTP port in Host when not 80' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'http://domain.com:123'
-          )
-          expect(signature.headers['host']).to eq('domain.com:123')
+        context '#known URI schema' do
+
+          it 'ommits port in Host when default port and uri port are the same' do
+            signature = Signer.new(options).sign_request(
+              http_method: 'GET',
+              url: 'https://domain.com:443'
+            )
+            expect(signature.headers['host']).to eq('domain.com')
+          end
+
+          it 'includes port in Host when default port and uri port are different' do
+            signature = Signer.new(options).sign_request(
+              http_method: 'GET',
+              url: 'https://domain.com:123'
+            )
+            expect(signature.headers['host']).to eq('domain.com:123')
+          end
+
         end
 
-        it 'includes HTTPS port in Host when not 443' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'https://domain.com:123'
-          )
-          expect(signature.headers['host']).to eq('domain.com:123')
-        end
+        context '#unknown uri schema' do
 
-        it 'includes WS port in Host when not 80' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'ws://domain.com:123'
-          )
-          expect(signature.headers['host']).to eq('domain.com:123')
-        end
+          it 'ommits port in Host when uri port not provided' do
+            signature = Signer.new(options).sign_request(
+              http_method: 'GET',
+              url: 'abcd://domain.com'
+            )
+            expect(signature.headers['host']).to eq('domain.com')
 
-        it 'includes WSS port in Host when not 443' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'wss://domain.com:123'
-          )
-          expect(signature.headers['host']).to eq('domain.com:123')
-        end
+          end
 
-        it 'does not include trailing colon in HOST if WS default port' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'ws://domain.com'
-          )
-          expect(signature.headers['host']).to eq('domain.com')
-        end
+          it 'includes port in Host when uri port provided' do
+            signature = Signer.new(options).sign_request(
+              http_method: 'GET',
+              url: 'abcd://domain.com:123'
+            )
+            expect(signature.headers['host']).to eq('domain.com:123')
+          end
 
-        it 'does not include trailing colon in HOST if WSS default port' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'GET',
-            url: 'wss://domain.com'
-          )
-          expect(signature.headers['host']).to eq('domain.com')
         end
 
         it 'sets the X-Amz-Date header' do


### PR DESCRIPTION
Before this commit, it was not possible to presign a WebSocket url. The
method to determine if the url was "standard" only took into account
http:80 and https:443 as standard. If a wss url was provided for
presign, it resulted in the signed header host including a trailing
colon and prevented the signautre from working.

For example, before this commit, a call to presign_url with url:
'wss://domain.com', would result in a signed header host of:
'domain.com:' instead of 'domain.com', which would prevent the signature from working.

Here is a simple sample of code that works with this pull request, but results in an invalid presigned_url without it

```
def generate_presig_url
    signer = Aws::Sigv4::Signer.new(service: 'iotdevicegateway',
      region: ENV['AWS_REGION'],
      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
    signer.presign_url(http_method: 'GET',
      url: 'wss://' + ENV['AWS_IOT_ENDPOINT_HOST'].to_s + '/mqtt',
      expires_in: 3600)
  end
```
I fully appreciate the question over if WebSockets are an actual URI scheme or subset of HTTP, and that the Ruby URI library doesn't treat WSS or WS as an official scheme, and therefore when WSS or WS urls are requested for presign in the Ruby library, the default port is not evaluated to 80 or 443, which is what causes the bug of a signed host record of "domain.com:" instead of "domain.com" when presigning default port WSS urls. But, I think the choice of using URI to parse the URL into parts is an implantation detail, and would expect that a wss request could get a valid presign_url. Some services use WebSocket and accept SigV4 presigns (i.e. AWS IOT supports MQTT over WebSockets and the url to connect is WSS). Other AWS SDK Sigv4 libraries (Node for example) result in valid, usable presigned wss urls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!