### PR TITLE
Consider empty member exception structs as errors

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
@@ -9,7 +9,7 @@ module AwsSdkCodeGenerator
       @errors = @api['shapes'].inject([]) do |es, (name, shape)|
         # only generate error shape with non empty members
         # excluding event shapes marked as error
-        if non_empty_error_struct?(shape)
+        if error_struct?(shape)
           members = shape['members'].keys.map {|k| Underscore.underscore(k) }
           members = shape['members'].inject([]) do |arr, (k, v)|
             arr << {
@@ -29,7 +29,7 @@ module AwsSdkCodeGenerator
       end
     end
 
-    def non_empty_error_struct?(shape)
+    def error_struct?(shape)
       shape['type'] == 'structure' && !!!shape['event'] &&
         (shape['error'] || shape['exception'])
     end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
@@ -31,8 +31,7 @@ module AwsSdkCodeGenerator
 
     def non_empty_error_struct?(shape)
       shape['type'] == 'structure' && !!!shape['event'] &&
-        (shape['error'] || shape['exception']) &&
-        shape['members'] && shape['members'].size > 0
+        (shape['error'] || shape['exception'])
     end
 
     def each(&block)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -304,9 +304,8 @@ module AwsSdkCodeGenerator
       end
 
       def error_struct?(shape)
-        shape['type'] == 'structure' && !!!shape['event']
-          (shape['error'] || shape['exception']) &&
-          shape['members'] && shape['members'].size > 0
+        shape['type'] == 'structure' && !!!shape['event'] &&
+          (shape['error'] || shape['exception'])
       end
 
       def structure_shape_enum

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -156,13 +156,7 @@ module AwsSdkCodeGenerator
       end
 
       def struct_type?(shape)
-        if !!!shape['event'] && (shape['error'] || shape['exception'])
-          # non event error shape with more than one member
-          shape['type'] == 'structure' &&
-            shape['members'] && shape['members'].size > 0
-        else
-          shape['type'] == 'structure'
-        end
+        shape['type'] == 'structure'
       end
 
       def compute_input_shapes(api)

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client_api.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client_api.rb
@@ -27,6 +27,8 @@ module Aws::ApiGatewayManagementApi
     DeleteConnectionRequest.add_member(:connection_id, Shapes::ShapeRef.new(shape: __string, required: true, location: "uri", location_name: "connectionId"))
     DeleteConnectionRequest.struct_class = Types::DeleteConnectionRequest
 
+    ForbiddenException.struct_class = Types::ForbiddenException
+
     GetConnectionRequest.add_member(:connection_id, Shapes::ShapeRef.new(shape: __string, required: true, location: "uri", location_name: "connectionId"))
     GetConnectionRequest.struct_class = Types::GetConnectionRequest
 
@@ -35,9 +37,13 @@ module Aws::ApiGatewayManagementApi
     GetConnectionResponse.add_member(:last_active_at, Shapes::ShapeRef.new(shape: __timestampIso8601, location_name: "lastActiveAt"))
     GetConnectionResponse.struct_class = Types::GetConnectionResponse
 
+    GoneException.struct_class = Types::GoneException
+
     Identity.add_member(:source_ip, Shapes::ShapeRef.new(shape: __string, required: true, location_name: "sourceIp"))
     Identity.add_member(:user_agent, Shapes::ShapeRef.new(shape: __string, required: true, location_name: "userAgent"))
     Identity.struct_class = Types::Identity
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     PayloadTooLargeException.add_member(:message, Shapes::ShapeRef.new(shape: __string, location_name: "message"))
     PayloadTooLargeException.struct_class = Types::PayloadTooLargeException

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/errors.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/errors.rb
@@ -10,6 +10,28 @@ module Aws::ApiGatewayManagementApi
 
     extend Aws::Errors::DynamicErrors
 
+    class ForbiddenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ApiGatewayManagementApi::Types::ForbiddenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GoneException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ApiGatewayManagementApi::Types::GoneException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class PayloadTooLargeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -22,6 +44,17 @@ module Aws::ApiGatewayManagementApi
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ApiGatewayManagementApi::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/types.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/types.rb
@@ -23,6 +23,10 @@ module Aws::ApiGatewayManagementApi
       include Aws::Structure
     end
 
+    # The caller is not authorized to invoke this operation.
+    #
+    class ForbiddenException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass GetConnectionRequest
     #   data as a hash:
     #
@@ -53,6 +57,10 @@ module Aws::ApiGatewayManagementApi
       :last_active_at)
       include Aws::Structure
     end
+
+    # The connection with the provided id no longer exists.
+    #
+    class GoneException < Aws::EmptyStructure; end
 
     # @!attribute [rw] source_ip
     #   The source IP address of the TCP connection making the request to
@@ -99,6 +107,11 @@ module Aws::ApiGatewayManagementApi
       :connection_id)
       include Aws::Structure
     end
+
+    # The client is sending more than the allowed number of requests per
+    # unit of time or the WebSocket client side buffer is full.
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
@@ -75,7 +75,11 @@ module Aws::Cloud9
     UpdateEnvironmentResult = Shapes::StructureShape.new(name: 'UpdateEnvironmentResult')
     UserArn = Shapes::StringShape.new(name: 'UserArn')
 
+    BadRequestException.struct_class = Types::BadRequestException
+
     BoundedEnvironmentIdList.member = Shapes::ShapeRef.new(shape: EnvironmentId)
+
+    ConflictException.struct_class = Types::ConflictException
 
     CreateEnvironmentEC2Request.add_member(:name, Shapes::ShapeRef.new(shape: EnvironmentName, required: true, location_name: "name"))
     CreateEnvironmentEC2Request.add_member(:description, Shapes::ShapeRef.new(shape: EnvironmentDescription, location_name: "description"))
@@ -160,6 +164,12 @@ module Aws::Cloud9
 
     EnvironmentMembersList.member = Shapes::ShapeRef.new(shape: EnvironmentMember)
 
+    ForbiddenException.struct_class = Types::ForbiddenException
+
+    InternalServerErrorException.struct_class = Types::InternalServerErrorException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     ListEnvironmentsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: String, location_name: "nextToken"))
     ListEnvironmentsRequest.add_member(:max_results, Shapes::ShapeRef.new(shape: MaxResults, location_name: "maxResults"))
     ListEnvironmentsRequest.struct_class = Types::ListEnvironmentsRequest
@@ -173,6 +183,8 @@ module Aws::Cloud9
 
     ListTagsForResourceResponse.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     ListTagsForResourceResponse.struct_class = Types::ListTagsForResourceResponse
+
+    NotFoundException.struct_class = Types::NotFoundException
 
     PermissionsList.member = Shapes::ShapeRef.new(shape: Permissions)
 
@@ -189,6 +201,8 @@ module Aws::Cloud9
     TagResourceRequest.struct_class = Types::TagResourceRequest
 
     TagResourceResponse.struct_class = Types::TagResourceResponse
+
+    TooManyRequestsException.struct_class = Types::TooManyRequestsException
 
     UntagResourceRequest.add_member(:resource_arn, Shapes::ShapeRef.new(shape: EnvironmentArn, required: true, location_name: "ResourceARN"))
     UntagResourceRequest.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "TagKeys"))

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
@@ -10,5 +10,82 @@ module Aws::Cloud9
 
     extend Aws::Errors::DynamicErrors
 
+    class BadRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::BadRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ConflictException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::ConflictException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ForbiddenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::ForbiddenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalServerErrorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::InternalServerErrorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::NotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyRequestsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Cloud9::Types::TooManyRequestsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
@@ -8,6 +8,18 @@
 module Aws::Cloud9
   module Types
 
+    # The target request is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/BadRequestException AWS API Documentation
+    #
+    class BadRequestException < Aws::EmptyStructure; end
+
+    # A conflict occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/ConflictException AWS API Documentation
+    #
+    class ConflictException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass CreateEnvironmentEC2Request
     #   data as a hash:
     #
@@ -483,6 +495,24 @@ module Aws::Cloud9
       include Aws::Structure
     end
 
+    # An access permissions issue occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/ForbiddenException AWS API Documentation
+    #
+    class ForbiddenException < Aws::EmptyStructure; end
+
+    # An internal server error occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/InternalServerErrorException AWS API Documentation
+    #
+    class InternalServerErrorException < Aws::EmptyStructure; end
+
+    # A service limit was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass ListEnvironmentsRequest
     #   data as a hash:
     #
@@ -563,6 +593,12 @@ module Aws::Cloud9
       include Aws::Structure
     end
 
+    # The target resource cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/NotFoundException AWS API Documentation
+    #
+    class NotFoundException < Aws::EmptyStructure; end
+
     # Metadata that is associated with AWS resources. In particular, a
     # name-value pair that can be associated with an AWS Cloud9 development
     # environment. There are two types of tags: *user tags* and *system
@@ -628,6 +664,12 @@ module Aws::Cloud9
     # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/TagResourceResponse AWS API Documentation
     #
     class TagResourceResponse < Aws::EmptyStructure; end
+
+    # Too many service requests were made over the given time period.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloud9-2017-09-23/TooManyRequestsException AWS API Documentation
+    #
+    class TooManyRequestsException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagResourceRequest
     #   data as a hash:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
@@ -389,6 +389,8 @@ module Aws::CloudFormation
 
     AllowedValues.member = Shapes::ShapeRef.new(shape: AllowedValue)
 
+    AlreadyExistsException.struct_class = Types::AlreadyExistsException
+
     AutoDeployment.add_member(:enabled, Shapes::ShapeRef.new(shape: AutoDeploymentNullable, location_name: "Enabled"))
     AutoDeployment.add_member(:retain_stacks_on_account_removal, Shapes::ShapeRef.new(shape: RetainStacksOnAccountRemovalNullable, location_name: "RetainStacksOnAccountRemoval"))
     AutoDeployment.struct_class = Types::AutoDeployment
@@ -405,6 +407,8 @@ module Aws::CloudFormation
     Change.add_member(:type, Shapes::ShapeRef.new(shape: ChangeType, location_name: "Type"))
     Change.add_member(:resource_change, Shapes::ShapeRef.new(shape: ResourceChange, location_name: "ResourceChange"))
     Change.struct_class = Types::Change
+
+    ChangeSetNotFoundException.struct_class = Types::ChangeSetNotFoundException
 
     ChangeSetSummaries.member = Shapes::ShapeRef.new(shape: ChangeSetSummary)
 
@@ -501,6 +505,8 @@ module Aws::CloudFormation
 
     CreateStackSetOutput.add_member(:stack_set_id, Shapes::ShapeRef.new(shape: StackSetId, location_name: "StackSetId"))
     CreateStackSetOutput.struct_class = Types::CreateStackSetOutput
+
+    CreatedButModifiedException.struct_class = Types::CreatedButModifiedException
 
     DeleteChangeSetInput.add_member(:change_set_name, Shapes::ShapeRef.new(shape: ChangeSetNameOrId, required: true, location_name: "ChangeSetName"))
     DeleteChangeSetInput.add_member(:stack_name, Shapes::ShapeRef.new(shape: StackNameOrId, location_name: "StackName"))
@@ -757,6 +763,16 @@ module Aws::CloudFormation
 
     Imports.member = Shapes::ShapeRef.new(shape: StackName)
 
+    InsufficientCapabilitiesException.struct_class = Types::InsufficientCapabilitiesException
+
+    InvalidChangeSetStatusException.struct_class = Types::InvalidChangeSetStatusException
+
+    InvalidOperationException.struct_class = Types::InvalidOperationException
+
+    InvalidStateTransitionException.struct_class = Types::InvalidStateTransitionException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     ListChangeSetsInput.add_member(:stack_name, Shapes::ShapeRef.new(shape: StackNameOrId, required: true, location_name: "StackName"))
     ListChangeSetsInput.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListChangeSetsInput.struct_class = Types::ListChangeSetsInput
@@ -876,7 +892,17 @@ module Aws::CloudFormation
 
     LogicalResourceIds.member = Shapes::ShapeRef.new(shape: LogicalResourceId)
 
+    NameAlreadyExistsException.struct_class = Types::NameAlreadyExistsException
+
     NotificationARNs.member = Shapes::ShapeRef.new(shape: NotificationARN)
+
+    OperationIdAlreadyExistsException.struct_class = Types::OperationIdAlreadyExistsException
+
+    OperationInProgressException.struct_class = Types::OperationInProgressException
+
+    OperationNotFoundException.struct_class = Types::OperationNotFoundException
+
+    OperationStatusCheckFailedException.struct_class = Types::OperationStatusCheckFailedException
 
     OrganizationalUnitIdList.member = Shapes::ShapeRef.new(shape: OrganizationalUnitId)
 
@@ -1086,6 +1112,8 @@ module Aws::CloudFormation
     StackInstance.add_member(:last_drift_check_timestamp, Shapes::ShapeRef.new(shape: Timestamp, location_name: "LastDriftCheckTimestamp"))
     StackInstance.struct_class = Types::StackInstance
 
+    StackInstanceNotFoundException.struct_class = Types::StackInstanceNotFoundException
+
     StackInstanceSummaries.member = Shapes::ShapeRef.new(shape: StackInstanceSummary)
 
     StackInstanceSummary.add_member(:stack_set_id, Shapes::ShapeRef.new(shape: StackSetId, location_name: "StackSetId"))
@@ -1188,6 +1216,10 @@ module Aws::CloudFormation
     StackSetDriftDetectionDetails.add_member(:failed_stack_instances_count, Shapes::ShapeRef.new(shape: FailedStackInstancesCount, location_name: "FailedStackInstancesCount"))
     StackSetDriftDetectionDetails.struct_class = Types::StackSetDriftDetectionDetails
 
+    StackSetNotEmptyException.struct_class = Types::StackSetNotEmptyException
+
+    StackSetNotFoundException.struct_class = Types::StackSetNotFoundException
+
     StackSetOperation.add_member(:operation_id, Shapes::ShapeRef.new(shape: ClientRequestToken, location_name: "OperationId"))
     StackSetOperation.add_member(:stack_set_id, Shapes::ShapeRef.new(shape: StackSetId, location_name: "StackSetId"))
     StackSetOperation.add_member(:action, Shapes::ShapeRef.new(shape: StackSetOperationAction, location_name: "Action"))
@@ -1261,6 +1293,8 @@ module Aws::CloudFormation
 
     StageList.member = Shapes::ShapeRef.new(shape: TemplateStage)
 
+    StaleRequestException.struct_class = Types::StaleRequestException
+
     StopStackSetOperationInput.add_member(:stack_set_name, Shapes::ShapeRef.new(shape: StackSetName, required: true, location_name: "StackSetName"))
     StopStackSetOperationInput.add_member(:operation_id, Shapes::ShapeRef.new(shape: ClientRequestToken, required: true, location_name: "OperationId"))
     StopStackSetOperationInput.struct_class = Types::StopStackSetOperationInput
@@ -1281,7 +1315,11 @@ module Aws::CloudFormation
 
     TemplateParameters.member = Shapes::ShapeRef.new(shape: TemplateParameter)
 
+    TokenAlreadyExistsException.struct_class = Types::TokenAlreadyExistsException
+
     TransformsList.member = Shapes::ShapeRef.new(shape: TransformName)
+
+    TypeNotFoundException.struct_class = Types::TypeNotFoundException
 
     TypeSummaries.member = Shapes::ShapeRef.new(shape: TypeSummary)
 

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
@@ -10,6 +10,17 @@ module Aws::CloudFormation
 
     extend Aws::Errors::DynamicErrors
 
+    class AlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::AlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class CFNRegistryException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -22,6 +33,204 @@ module Aws::CloudFormation
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class ChangeSetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::ChangeSetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CreatedButModifiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::CreatedButModifiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientCapabilitiesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::InsufficientCapabilitiesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidChangeSetStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::InvalidChangeSetStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::InvalidOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStateTransitionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::InvalidStateTransitionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NameAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::NameAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationIdAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::OperationIdAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationInProgressException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::OperationInProgressException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::OperationNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationStatusCheckFailedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::OperationStatusCheckFailedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StackInstanceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::StackInstanceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StackSetNotEmptyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::StackSetNotEmptyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StackSetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::StackSetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StaleRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::StaleRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TokenAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::TokenAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TypeNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudFormation::Types::TypeNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
@@ -109,6 +109,12 @@ module Aws::CloudFormation
       include Aws::Structure
     end
 
+    # The resource with the name requested already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/AlreadyExistsException AWS API Documentation
+    #
+    class AlreadyExistsException < Aws::EmptyStructure; end
+
     # \[`Service-managed` permissions\] Describes whether StackSets
     # automatically deploys to AWS Organizations accounts that are added to
     # a target organization or organizational unit (OU).
@@ -205,6 +211,13 @@ module Aws::CloudFormation
       :resource_change)
       include Aws::Structure
     end
+
+    # The specified change set name or ID doesn't exit. To view valid
+    # change sets for a stack, use the `ListChangeSets` action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/ChangeSetNotFoundException AWS API Documentation
+    #
+    class ChangeSetNotFoundException < Aws::EmptyStructure; end
 
     # The `ChangeSetSummary` structure describes a change set, its status,
     # and the stack with which it's associated.
@@ -1459,6 +1472,12 @@ module Aws::CloudFormation
       :stack_set_id)
       include Aws::Structure
     end
+
+    # The specified resource exists, but has been changed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreatedButModifiedException AWS API Documentation
+    #
+    class CreatedButModifiedException < Aws::EmptyStructure; end
 
     # The input for the DeleteChangeSet action.
     #
@@ -3286,6 +3305,51 @@ module Aws::CloudFormation
       include Aws::Structure
     end
 
+    # The template contains resources with capabilities that weren't
+    # specified in the Capabilities parameter.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/InsufficientCapabilitiesException AWS API Documentation
+    #
+    class InsufficientCapabilitiesException < Aws::EmptyStructure; end
+
+    # The specified change set can't be used to update the stack. For
+    # example, the change set status might be `CREATE_IN_PROGRESS`, or the
+    # stack status might be `UPDATE_IN_PROGRESS`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/InvalidChangeSetStatusException AWS API Documentation
+    #
+    class InvalidChangeSetStatusException < Aws::EmptyStructure; end
+
+    # The specified operation isn't valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/InvalidOperationException AWS API Documentation
+    #
+    class InvalidOperationException < Aws::EmptyStructure; end
+
+    # Error reserved for use by the [CloudFormation CLI][1]. CloudFormation
+    # does not return this error to users.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/InvalidStateTransitionException AWS API Documentation
+    #
+    class InvalidStateTransitionException < Aws::EmptyStructure; end
+
+    # The quota for the resource has already been reached.
+    #
+    # For information on resource and stack limitations, see [Limits][1] in
+    # the *AWS CloudFormation User Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # The input for the ListChangeSets action.
     #
     # @note When making an API call, you may pass ListChangeSetsInput
@@ -4111,6 +4175,42 @@ module Aws::CloudFormation
       :log_group_name)
       include Aws::Structure
     end
+
+    # The specified name is already in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/NameAlreadyExistsException AWS API Documentation
+    #
+    class NameAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The specified operation ID already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/OperationIdAlreadyExistsException AWS API Documentation
+    #
+    class OperationIdAlreadyExistsException < Aws::EmptyStructure; end
+
+    # Another operation is currently in progress for this stack set. Only
+    # one operation can be performed for a stack set at a given time.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/OperationInProgressException AWS API Documentation
+    #
+    class OperationInProgressException < Aws::EmptyStructure; end
+
+    # The specified ID refers to an operation that doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/OperationNotFoundException AWS API Documentation
+    #
+    class OperationNotFoundException < Aws::EmptyStructure; end
+
+    # Error reserved for use by the [CloudFormation CLI][1]. CloudFormation
+    # does not return this error to users.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/OperationStatusCheckFailedException AWS API Documentation
+    #
+    class OperationStatusCheckFailedException < Aws::EmptyStructure; end
 
     # The Output data type.
     #
@@ -5461,6 +5561,12 @@ module Aws::CloudFormation
       include Aws::Structure
     end
 
+    # The specified stack instance doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/StackInstanceNotFoundException AWS API Documentation
+    #
+    class StackInstanceNotFoundException < Aws::EmptyStructure; end
+
     # The structure that contains summary information about a stack
     # instance.
     #
@@ -6214,6 +6320,20 @@ module Aws::CloudFormation
       include Aws::Structure
     end
 
+    # You can't yet delete this stack set, because it still contains one or
+    # more stack instances. Delete all stack instances from the stack set
+    # before deleting the stack set.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/StackSetNotEmptyException AWS API Documentation
+    #
+    class StackSetNotEmptyException < Aws::EmptyStructure; end
+
+    # The specified stack set doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/StackSetNotFoundException AWS API Documentation
+    #
+    class StackSetNotFoundException < Aws::EmptyStructure; end
+
     # The structure that contains information about a stack set operation.
     #
     # @!attribute [rw] operation_id
@@ -6770,6 +6890,13 @@ module Aws::CloudFormation
       include Aws::Structure
     end
 
+    # Another operation has been performed on this stack set since the
+    # specified operation was performed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/StaleRequestException AWS API Documentation
+    #
+    class StaleRequestException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass StopStackSetOperationInput
     #   data as a hash:
     #
@@ -6857,6 +6984,18 @@ module Aws::CloudFormation
       :description)
       include Aws::Structure
     end
+
+    # A client request token already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/TokenAlreadyExistsException AWS API Documentation
+    #
+    class TokenAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The specified type does not exist in the CloudFormation registry.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/TypeNotFoundException AWS API Documentation
+    #
+    class TypeNotFoundException < Aws::EmptyStructure; end
 
     # Contains summary information about the specified CloudFormation type.
     #

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
@@ -104,6 +104,8 @@ module Aws::CloudHSM
 
     ClientList.member = Shapes::ShapeRef.new(shape: ClientArn)
 
+    CloudHsmInternalException.struct_class = Types::CloudHsmInternalException
+
     CloudHsmServiceException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "message"))
     CloudHsmServiceException.add_member(:retryable, Shapes::ShapeRef.new(shape: Boolean, location_name: "retryable"))
     CloudHsmServiceException.struct_class = Types::CloudHsmServiceException
@@ -217,6 +219,8 @@ module Aws::CloudHSM
     HapgList.member = Shapes::ShapeRef.new(shape: HapgArn)
 
     HsmList.member = Shapes::ShapeRef.new(shape: HsmArn)
+
+    InvalidRequestException.struct_class = Types::InvalidRequestException
 
     ListAvailableZonesRequest.struct_class = Types::ListAvailableZonesRequest
 

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
@@ -10,6 +10,17 @@ module Aws::CloudHSM
 
     extend Aws::Errors::DynamicErrors
 
+    class CloudHsmInternalException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudHSM::Types::CloudHsmInternalException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class CloudHsmServiceException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -27,6 +38,17 @@ module Aws::CloudHSM
       # @return [String]
       def retryable
         @data[:retryable]
+      end
+
+    end
+
+    class InvalidRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudHSM::Types::InvalidRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
@@ -48,6 +48,12 @@ module Aws::CloudHSM
       include Aws::Structure
     end
 
+    # Indicates that an internal error occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudhsm-2014-05-30/CloudHsmInternalException AWS API Documentation
+    #
+    class CloudHsmInternalException < Aws::EmptyStructure; end
+
     # Indicates that an exception occurred in the AWS CloudHSM service.
     #
     # @!attribute [rw] message
@@ -645,6 +651,12 @@ module Aws::CloudHSM
       :config_cred)
       include Aws::Structure
     end
+
+    # Indicates that one or more of the request parameters are not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudhsm-2014-05-30/InvalidRequestException AWS API Documentation
+    #
+    class InvalidRequestException < Aws::EmptyStructure; end
 
     # Contains the inputs for the ListAvailableZones action.
     #

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
@@ -329,6 +329,8 @@ module Aws::CloudSearch
     DescribeSuggestersResponse.add_member(:suggesters, Shapes::ShapeRef.new(shape: SuggesterStatusList, required: true, location_name: "Suggesters"))
     DescribeSuggestersResponse.struct_class = Types::DescribeSuggestersResponse
 
+    DisabledOperationException.struct_class = Types::DisabledOperationException
+
     DocumentSuggesterOptions.add_member(:source_field, Shapes::ShapeRef.new(shape: FieldName, required: true, location_name: "SourceField"))
     DocumentSuggesterOptions.add_member(:fuzzy_matching, Shapes::ShapeRef.new(shape: SuggesterFuzzyMatching, location_name: "FuzzyMatching"))
     DocumentSuggesterOptions.add_member(:sort_expression, Shapes::ShapeRef.new(shape: String, location_name: "SortExpression"))
@@ -435,6 +437,10 @@ module Aws::CloudSearch
     IntOptions.add_member(:sort_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "SortEnabled"))
     IntOptions.struct_class = Types::IntOptions
 
+    InternalException.struct_class = Types::InternalException
+
+    InvalidTypeException.struct_class = Types::InvalidTypeException
+
     LatLonOptions.add_member(:default_value, Shapes::ShapeRef.new(shape: FieldValue, location_name: "DefaultValue"))
     LatLonOptions.add_member(:source_field, Shapes::ShapeRef.new(shape: FieldName, location_name: "SourceField"))
     LatLonOptions.add_member(:facet_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "FacetEnabled"))
@@ -442,6 +448,8 @@ module Aws::CloudSearch
     LatLonOptions.add_member(:return_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "ReturnEnabled"))
     LatLonOptions.add_member(:sort_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "SortEnabled"))
     LatLonOptions.struct_class = Types::LatLonOptions
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     Limits.add_member(:maximum_replication_count, Shapes::ShapeRef.new(shape: MaximumReplicationCount, required: true, location_name: "MaximumReplicationCount"))
     Limits.add_member(:maximum_partition_count, Shapes::ShapeRef.new(shape: MaximumPartitionCount, required: true, location_name: "MaximumPartitionCount"))
@@ -471,6 +479,8 @@ module Aws::CloudSearch
     OptionStatus.add_member(:state, Shapes::ShapeRef.new(shape: OptionState, required: true, location_name: "State"))
     OptionStatus.add_member(:pending_deletion, Shapes::ShapeRef.new(shape: Boolean, location_name: "PendingDeletion"))
     OptionStatus.struct_class = Types::OptionStatus
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
 
     ScalingParameters.add_member(:desired_instance_type, Shapes::ShapeRef.new(shape: PartitionInstanceType, location_name: "DesiredInstanceType"))
     ScalingParameters.add_member(:desired_replication_count, Shapes::ShapeRef.new(shape: UIntValue, location_name: "DesiredReplicationCount"))
@@ -538,6 +548,8 @@ module Aws::CloudSearch
 
     UpdateServiceAccessPoliciesResponse.add_member(:access_policies, Shapes::ShapeRef.new(shape: AccessPoliciesStatus, required: true, location_name: "AccessPolicies"))
     UpdateServiceAccessPoliciesResponse.struct_class = Types::UpdateServiceAccessPoliciesResponse
+
+    ValidationException.struct_class = Types::ValidationException
 
 
     # @api private

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
@@ -31,5 +31,71 @@ module Aws::CloudSearch
 
     end
 
+    class DisabledOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::DisabledOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::InternalException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::InvalidTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudSearch::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
@@ -1243,6 +1243,11 @@ module Aws::CloudSearch
       include Aws::Structure
     end
 
+    # The request was rejected because it attempted an operation which is
+    # not enabled.
+    #
+    class DisabledOperationException < Aws::EmptyStructure; end
+
     # Options for a search suggester.
     #
     # @note When making an API call, you may pass DocumentSuggesterOptions
@@ -1926,6 +1931,21 @@ module Aws::CloudSearch
       include Aws::Structure
     end
 
+    # An internal error occurred while processing the request. If this
+    # problem persists, report an issue from the [Service Health
+    # Dashboard][1].
+    #
+    #
+    #
+    # [1]: http://status.aws.amazon.com/
+    #
+    class InternalException < Aws::EmptyStructure; end
+
+    # The request was rejected because it specified an invalid type
+    # definition.
+    #
+    class InvalidTypeException < Aws::EmptyStructure; end
+
     # Options for a latlon field. A latlon field contains a location stored
     # as a latitude and longitude value pair. Present if `IndexFieldType`
     # specifies the field is of type `latlon`. All options are enabled by
@@ -1993,6 +2013,11 @@ module Aws::CloudSearch
       :sort_enabled)
       include Aws::Structure
     end
+
+    # The request was rejected because a resource limit has already been
+    # met.
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @!attribute [rw] maximum_replication_count
     #   @return [Integer]
@@ -2172,6 +2197,11 @@ module Aws::CloudSearch
       :pending_deletion)
       include Aws::Structure
     end
+
+    # The request was rejected because it attempted to reference a resource
+    # that does not exist.
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # The desired instance type and desired number of replicas of each index
     # partition.
@@ -2582,6 +2612,10 @@ module Aws::CloudSearch
       :access_policies)
       include Aws::Structure
     end
+
+    # The request was rejected because it has invalid parameters.
+    #
+    class ValidationException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
@@ -132,6 +132,12 @@ module Aws::CloudTrail
 
     AddTagsResponse.struct_class = Types::AddTagsResponse
 
+    CloudTrailARNInvalidException.struct_class = Types::CloudTrailARNInvalidException
+
+    CloudTrailAccessNotEnabledException.struct_class = Types::CloudTrailAccessNotEnabledException
+
+    CloudWatchLogsDeliveryUnavailableException.struct_class = Types::CloudWatchLogsDeliveryUnavailableException
+
     CreateTrailRequest.add_member(:name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Name"))
     CreateTrailRequest.add_member(:s3_bucket_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "S3BucketName"))
     CreateTrailRequest.add_member(:s3_key_prefix, Shapes::ShapeRef.new(shape: String, location_name: "S3KeyPrefix"))
@@ -246,10 +252,62 @@ module Aws::CloudTrail
     GetTrailStatusResponse.add_member(:time_logging_stopped, Shapes::ShapeRef.new(shape: String, location_name: "TimeLoggingStopped"))
     GetTrailStatusResponse.struct_class = Types::GetTrailStatusResponse
 
+    InsightNotEnabledException.struct_class = Types::InsightNotEnabledException
+
     InsightSelector.add_member(:insight_type, Shapes::ShapeRef.new(shape: InsightType, location_name: "InsightType"))
     InsightSelector.struct_class = Types::InsightSelector
 
     InsightSelectors.member = Shapes::ShapeRef.new(shape: InsightSelector)
+
+    InsufficientDependencyServiceAccessPermissionException.struct_class = Types::InsufficientDependencyServiceAccessPermissionException
+
+    InsufficientEncryptionPolicyException.struct_class = Types::InsufficientEncryptionPolicyException
+
+    InsufficientS3BucketPolicyException.struct_class = Types::InsufficientS3BucketPolicyException
+
+    InsufficientSnsTopicPolicyException.struct_class = Types::InsufficientSnsTopicPolicyException
+
+    InvalidCloudWatchLogsLogGroupArnException.struct_class = Types::InvalidCloudWatchLogsLogGroupArnException
+
+    InvalidCloudWatchLogsRoleArnException.struct_class = Types::InvalidCloudWatchLogsRoleArnException
+
+    InvalidEventCategoryException.struct_class = Types::InvalidEventCategoryException
+
+    InvalidEventSelectorsException.struct_class = Types::InvalidEventSelectorsException
+
+    InvalidHomeRegionException.struct_class = Types::InvalidHomeRegionException
+
+    InvalidInsightSelectorsException.struct_class = Types::InvalidInsightSelectorsException
+
+    InvalidKmsKeyIdException.struct_class = Types::InvalidKmsKeyIdException
+
+    InvalidLookupAttributesException.struct_class = Types::InvalidLookupAttributesException
+
+    InvalidMaxResultsException.struct_class = Types::InvalidMaxResultsException
+
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
+    InvalidParameterCombinationException.struct_class = Types::InvalidParameterCombinationException
+
+    InvalidS3BucketNameException.struct_class = Types::InvalidS3BucketNameException
+
+    InvalidS3PrefixException.struct_class = Types::InvalidS3PrefixException
+
+    InvalidSnsTopicNameException.struct_class = Types::InvalidSnsTopicNameException
+
+    InvalidTagParameterException.struct_class = Types::InvalidTagParameterException
+
+    InvalidTimeRangeException.struct_class = Types::InvalidTimeRangeException
+
+    InvalidTokenException.struct_class = Types::InvalidTokenException
+
+    InvalidTrailNameException.struct_class = Types::InvalidTrailNameException
+
+    KmsException.struct_class = Types::KmsException
+
+    KmsKeyDisabledException.struct_class = Types::KmsKeyDisabledException
+
+    KmsKeyNotFoundException.struct_class = Types::KmsKeyNotFoundException
 
     ListPublicKeysRequest.add_member(:start_time, Shapes::ShapeRef.new(shape: Date, location_name: "StartTime"))
     ListPublicKeysRequest.add_member(:end_time, Shapes::ShapeRef.new(shape: Date, location_name: "EndTime"))
@@ -293,6 +351,16 @@ module Aws::CloudTrail
     LookupEventsResponse.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     LookupEventsResponse.struct_class = Types::LookupEventsResponse
 
+    MaximumNumberOfTrailsExceededException.struct_class = Types::MaximumNumberOfTrailsExceededException
+
+    NotOrganizationMasterAccountException.struct_class = Types::NotOrganizationMasterAccountException
+
+    OperationNotPermittedException.struct_class = Types::OperationNotPermittedException
+
+    OrganizationNotInAllFeaturesModeException.struct_class = Types::OrganizationNotInAllFeaturesModeException
+
+    OrganizationsNotInUseException.struct_class = Types::OrganizationsNotInUseException
+
     PublicKey.add_member(:value, Shapes::ShapeRef.new(shape: ByteBuffer, location_name: "Value"))
     PublicKey.add_member(:validity_start_time, Shapes::ShapeRef.new(shape: Date, location_name: "ValidityStartTime"))
     PublicKey.add_member(:validity_end_time, Shapes::ShapeRef.new(shape: Date, location_name: "ValidityEndTime"))
@@ -331,11 +399,17 @@ module Aws::CloudTrail
 
     ResourceList.member = Shapes::ShapeRef.new(shape: Resource)
 
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ResourceTag.add_member(:resource_id, Shapes::ShapeRef.new(shape: String, location_name: "ResourceId"))
     ResourceTag.add_member(:tags_list, Shapes::ShapeRef.new(shape: TagsList, location_name: "TagsList"))
     ResourceTag.struct_class = Types::ResourceTag
 
     ResourceTagList.member = Shapes::ShapeRef.new(shape: ResourceTag)
+
+    ResourceTypeNotSupportedException.struct_class = Types::ResourceTypeNotSupportedException
+
+    S3BucketDoesNotExistException.struct_class = Types::S3BucketDoesNotExistException
 
     StartLoggingRequest.add_member(:name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Name"))
     StartLoggingRequest.struct_class = Types::StartLoggingRequest
@@ -350,6 +424,8 @@ module Aws::CloudTrail
     Tag.add_member(:key, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Key"))
     Tag.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "Value"))
     Tag.struct_class = Types::Tag
+
+    TagsLimitExceededException.struct_class = Types::TagsLimitExceededException
 
     TagsList.member = Shapes::ShapeRef.new(shape: Tag)
 
@@ -371,6 +447,8 @@ module Aws::CloudTrail
     Trail.add_member(:is_organization_trail, Shapes::ShapeRef.new(shape: Boolean, location_name: "IsOrganizationTrail"))
     Trail.struct_class = Types::Trail
 
+    TrailAlreadyExistsException.struct_class = Types::TrailAlreadyExistsException
+
     TrailInfo.add_member(:trail_arn, Shapes::ShapeRef.new(shape: String, location_name: "TrailARN"))
     TrailInfo.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     TrailInfo.add_member(:home_region, Shapes::ShapeRef.new(shape: String, location_name: "HomeRegion"))
@@ -380,7 +458,13 @@ module Aws::CloudTrail
 
     TrailNameList.member = Shapes::ShapeRef.new(shape: String)
 
+    TrailNotFoundException.struct_class = Types::TrailNotFoundException
+
+    TrailNotProvidedException.struct_class = Types::TrailNotProvidedException
+
     Trails.member = Shapes::ShapeRef.new(shape: TrailInfo)
+
+    UnsupportedOperationException.struct_class = Types::UnsupportedOperationException
 
     UpdateTrailRequest.add_member(:name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Name"))
     UpdateTrailRequest.add_member(:s3_bucket_name, Shapes::ShapeRef.new(shape: String, location_name: "S3BucketName"))

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
@@ -10,5 +10,467 @@ module Aws::CloudTrail
 
     extend Aws::Errors::DynamicErrors
 
+    class CloudTrailARNInvalidException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::CloudTrailARNInvalidException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CloudTrailAccessNotEnabledException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::CloudTrailAccessNotEnabledException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CloudWatchLogsDeliveryUnavailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::CloudWatchLogsDeliveryUnavailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsightNotEnabledException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InsightNotEnabledException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDependencyServiceAccessPermissionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InsufficientDependencyServiceAccessPermissionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientEncryptionPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InsufficientEncryptionPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientS3BucketPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InsufficientS3BucketPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientSnsTopicPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InsufficientSnsTopicPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCloudWatchLogsLogGroupArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidCloudWatchLogsLogGroupArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCloudWatchLogsRoleArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidCloudWatchLogsRoleArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventCategoryException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidEventCategoryException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventSelectorsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidEventSelectorsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidHomeRegionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidHomeRegionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInsightSelectorsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidInsightSelectorsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidKmsKeyIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidKmsKeyIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLookupAttributesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidLookupAttributesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMaxResultsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidMaxResultsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterCombinationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidParameterCombinationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3BucketNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidS3BucketNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3PrefixException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidS3PrefixException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSnsTopicNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidSnsTopicNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidTagParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTimeRangeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidTimeRangeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTrailNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::InvalidTrailNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KmsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::KmsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KmsKeyDisabledException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::KmsKeyDisabledException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KmsKeyNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::KmsKeyNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumNumberOfTrailsExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::MaximumNumberOfTrailsExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NotOrganizationMasterAccountException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::NotOrganizationMasterAccountException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotPermittedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::OperationNotPermittedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OrganizationNotInAllFeaturesModeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::OrganizationNotInAllFeaturesModeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OrganizationsNotInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::OrganizationsNotInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceTypeNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::ResourceTypeNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class S3BucketDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::S3BucketDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagsLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::TagsLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TrailAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::TrailAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TrailNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::TrailNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TrailNotProvidedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::TrailNotProvidedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudTrail::Types::UnsupportedOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
@@ -49,6 +49,35 @@ module Aws::CloudTrail
     #
     class AddTagsResponse < Aws::EmptyStructure; end
 
+    # This exception is thrown when an operation is called with an invalid
+    # trail ARN. The format of a trail ARN is:
+    #
+    # `arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail`
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/CloudTrailARNInvalidException AWS API Documentation
+    #
+    class CloudTrailARNInvalidException < Aws::EmptyStructure; end
+
+    # This exception is thrown when trusted access has not been enabled
+    # between AWS CloudTrail and AWS Organizations. For more information,
+    # see [Enabling Trusted Access with Other AWS Services][1] and [Prepare
+    # For Creating a Trail For Your Organization][2].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html
+    # [2]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/CloudTrailAccessNotEnabledException AWS API Documentation
+    #
+    class CloudTrailAccessNotEnabledException < Aws::EmptyStructure; end
+
+    # Cannot set a CloudWatch Logs delivery for this region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/CloudWatchLogsDeliveryUnavailableException AWS API Documentation
+    #
+    class CloudWatchLogsDeliveryUnavailableException < Aws::EmptyStructure; end
+
     # Specifies the settings for each trail.
     #
     # @note When making an API call, you may pass CreateTrailRequest
@@ -959,6 +988,14 @@ module Aws::CloudTrail
       include Aws::Structure
     end
 
+    # If you run `GetInsightSelectors` on a trail that does not have
+    # Insights events enabled, the operation throws the exception
+    # `InsightNotEnabledException`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InsightNotEnabledException AWS API Documentation
+    #
+    class InsightNotEnabledException < Aws::EmptyStructure; end
+
     # A JSON string that contains a list of insight types that are logged on
     # a trail.
     #
@@ -980,6 +1017,215 @@ module Aws::CloudTrail
       :insight_type)
       include Aws::Structure
     end
+
+    # This exception is thrown when the IAM user or role that is used to
+    # create the organization trail is lacking one or more required
+    # permissions for creating an organization trail in a required service.
+    # For more information, see [Prepare For Creating a Trail For Your
+    # Organization][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InsufficientDependencyServiceAccessPermissionException AWS API Documentation
+    #
+    class InsufficientDependencyServiceAccessPermissionException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the policy on the S3 bucket or KMS key
+    # is not sufficient.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InsufficientEncryptionPolicyException AWS API Documentation
+    #
+    class InsufficientEncryptionPolicyException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the policy on the S3 bucket is not
+    # sufficient.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InsufficientS3BucketPolicyException AWS API Documentation
+    #
+    class InsufficientS3BucketPolicyException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the policy on the SNS topic is not
+    # sufficient.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InsufficientSnsTopicPolicyException AWS API Documentation
+    #
+    class InsufficientSnsTopicPolicyException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided CloudWatch log group is not
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidCloudWatchLogsLogGroupArnException AWS API Documentation
+    #
+    class InvalidCloudWatchLogsLogGroupArnException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided role is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidCloudWatchLogsRoleArnException AWS API Documentation
+    #
+    class InvalidCloudWatchLogsRoleArnException < Aws::EmptyStructure; end
+
+    # Occurs if an event category that is not valid is specified as a value
+    # of `EventCategory`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidEventCategoryException AWS API Documentation
+    #
+    class InvalidEventCategoryException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the `PutEventSelectors` operation is
+    # called with a number of event selectors or data resources that is not
+    # valid. The combination of event selectors and data resources is not
+    # valid. A trail can have up to 5 event selectors. A trail is limited to
+    # 250 data resources. These data resources can be distributed across
+    # event selectors, but the overall total cannot exceed 250.
+    #
+    # You can:
+    #
+    # * Specify a valid number of event selectors (1 to 5) for a trail.
+    #
+    # * Specify a valid number of data resources (1 to 250) for an event
+    #   selector. The limit of number of resources on an individual event
+    #   selector is configurable up to 250. However, this upper limit is
+    #   allowed only if the total number of data resources does not exceed
+    #   250 across all event selectors for a trail.
+    #
+    # * Specify a valid value for a parameter. For example, specifying the
+    #   `ReadWriteType` parameter with a value of `read-only` is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidEventSelectorsException AWS API Documentation
+    #
+    class InvalidEventSelectorsException < Aws::EmptyStructure; end
+
+    # This exception is thrown when an operation is called on a trail from a
+    # region other than the region in which the trail was created.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidHomeRegionException AWS API Documentation
+    #
+    class InvalidHomeRegionException < Aws::EmptyStructure; end
+
+    # The formatting or syntax of the `InsightSelectors` JSON statement in
+    # your `PutInsightSelectors` or `GetInsightSelectors` request is not
+    # valid, or the specified insight type in the `InsightSelectors`
+    # statement is not a valid insight type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidInsightSelectorsException AWS API Documentation
+    #
+    class InvalidInsightSelectorsException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the KMS key ARN is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidKmsKeyIdException AWS API Documentation
+    #
+    class InvalidKmsKeyIdException < Aws::EmptyStructure; end
+
+    # Occurs when an invalid lookup attribute is specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidLookupAttributesException AWS API Documentation
+    #
+    class InvalidLookupAttributesException < Aws::EmptyStructure; end
+
+    # This exception is thrown if the limit specified is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidMaxResultsException AWS API Documentation
+    #
+    class InvalidMaxResultsException < Aws::EmptyStructure; end
+
+    # Invalid token or token that was previously used in a request with
+    # different parameters. This exception is thrown if the token is
+    # invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the combination of parameters provided
+    # is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidParameterCombinationException AWS API Documentation
+    #
+    class InvalidParameterCombinationException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided S3 bucket name is not
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidS3BucketNameException AWS API Documentation
+    #
+    class InvalidS3BucketNameException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided S3 prefix is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidS3PrefixException AWS API Documentation
+    #
+    class InvalidS3PrefixException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided SNS topic name is not
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidSnsTopicNameException AWS API Documentation
+    #
+    class InvalidSnsTopicNameException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the specified tag key or values are not
+    # valid. It can also occur if there are duplicate tags or too many tags
+    # on the resource.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidTagParameterException AWS API Documentation
+    #
+    class InvalidTagParameterException < Aws::EmptyStructure; end
+
+    # Occurs if the timestamp values are invalid. Either the start time
+    # occurs after the end time or the time range is outside the range of
+    # possible values.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidTimeRangeException AWS API Documentation
+    #
+    class InvalidTimeRangeException < Aws::EmptyStructure; end
+
+    # Reserved for future use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidTokenException AWS API Documentation
+    #
+    class InvalidTokenException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the provided trail name is not valid.
+    # Trail names must meet the following requirements:
+    #
+    # * Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.),
+    #   underscores (\_), or dashes (-)
+    #
+    # * Start with a letter or number, and end with a letter or number
+    #
+    # * Be between 3 and 128 characters
+    #
+    # * Have no adjacent periods, underscores or dashes. Names like
+    #   `my-_namespace` and `my--namespace` are invalid.
+    #
+    # * Not be in IP address format (for example, 192.168.5.4)
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/InvalidTrailNameException AWS API Documentation
+    #
+    class InvalidTrailNameException < Aws::EmptyStructure; end
+
+    # This exception is thrown when there is an issue with the specified KMS
+    # key and the trail can’t be updated.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/KmsException AWS API Documentation
+    #
+    class KmsException < Aws::EmptyStructure; end
+
+    # This exception is no longer in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/KmsKeyDisabledException AWS API Documentation
+    #
+    class KmsKeyDisabledException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the KMS key does not exist, or when the
+    # S3 bucket and the KMS key are not in the same region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/KmsKeyNotFoundException AWS API Documentation
+    #
+    class KmsKeyNotFoundException < Aws::EmptyStructure; end
 
     # Requests the public keys for a specified time range.
     #
@@ -1253,6 +1499,53 @@ module Aws::CloudTrail
       include Aws::Structure
     end
 
+    # This exception is thrown when the maximum number of trails is reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/MaximumNumberOfTrailsExceededException AWS API Documentation
+    #
+    class MaximumNumberOfTrailsExceededException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the AWS account making the request to
+    # create or update an organization trail is not the master account for
+    # an organization in AWS Organizations. For more information, see
+    # [Prepare For Creating a Trail For Your Organization][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/NotOrganizationMasterAccountException AWS API Documentation
+    #
+    class NotOrganizationMasterAccountException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the requested operation is not
+    # permitted.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/OperationNotPermittedException AWS API Documentation
+    #
+    class OperationNotPermittedException < Aws::EmptyStructure; end
+
+    # This exception is thrown when AWS Organizations is not configured to
+    # support all features. All features must be enabled in AWS Organization
+    # to support creating an organization trail. For more information, see
+    # [Prepare For Creating a Trail For Your Organization][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/OrganizationNotInAllFeaturesModeException AWS API Documentation
+    #
+    class OrganizationNotInAllFeaturesModeException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the request is made from an AWS account
+    # that is not a member of an organization. To make this request, sign in
+    # using the credentials of an account that belongs to an organization.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/OrganizationsNotInUseException AWS API Documentation
+    #
+    class OrganizationsNotInUseException < Aws::EmptyStructure; end
+
     # Contains information about a returned public key.
     #
     # @!attribute [rw] value
@@ -1475,6 +1768,12 @@ module Aws::CloudTrail
       include Aws::Structure
     end
 
+    # This exception is thrown when the specified resource is not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # A resource tag.
     #
     # @!attribute [rw] resource_id
@@ -1492,6 +1791,19 @@ module Aws::CloudTrail
       :tags_list)
       include Aws::Structure
     end
+
+    # This exception is thrown when the specified resource type is not
+    # supported by CloudTrail.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/ResourceTypeNotSupportedException AWS API Documentation
+    #
+    class ResourceTypeNotSupportedException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the specified S3 bucket does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/S3BucketDoesNotExistException AWS API Documentation
+    #
+    class S3BucketDoesNotExistException < Aws::EmptyStructure; end
 
     # The request to CloudTrail to start logging AWS API calls for an
     # account.
@@ -1585,6 +1897,13 @@ module Aws::CloudTrail
       :value)
       include Aws::Structure
     end
+
+    # The number of tags per trail has exceeded the permitted amount.
+    # Currently, the limit is 50.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/TagsLimitExceededException AWS API Documentation
+    #
+    class TagsLimitExceededException < Aws::EmptyStructure; end
 
     # The settings for a trail.
     #
@@ -1702,6 +2021,12 @@ module Aws::CloudTrail
       include Aws::Structure
     end
 
+    # This exception is thrown when the specified trail already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/TrailAlreadyExistsException AWS API Documentation
+    #
+    class TrailAlreadyExistsException < Aws::EmptyStructure; end
+
     # Information about a CloudTrail trail, including the trail's name,
     # home region, and Amazon Resource Name (ARN).
     #
@@ -1725,6 +2050,26 @@ module Aws::CloudTrail
       :home_region)
       include Aws::Structure
     end
+
+    # This exception is thrown when the trail with the given name is not
+    # found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/TrailNotFoundException AWS API Documentation
+    #
+    class TrailNotFoundException < Aws::EmptyStructure; end
+
+    # This exception is no longer in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/TrailNotProvidedException AWS API Documentation
+    #
+    class TrailNotProvidedException < Aws::EmptyStructure; end
+
+    # This exception is thrown when the requested operation is not
+    # supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudtrail-2013-11-01/UnsupportedOperationException AWS API Documentation
+    #
+    class UnsupportedOperationException < Aws::EmptyStructure; end
 
     # Specifies settings to update for the trail.
     #

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
@@ -246,6 +246,8 @@ module Aws::CloudWatch
 
     BatchFailures.member = Shapes::ShapeRef.new(shape: PartialFailure)
 
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
+
     Counts.member = Shapes::ShapeRef.new(shape: DatapointValue)
 
     DashboardEntries.member = Shapes::ShapeRef.new(shape: DashboardEntry)
@@ -512,6 +514,8 @@ module Aws::CloudWatch
 
     InvalidParameterValueException.add_member(:message, Shapes::ShapeRef.new(shape: AwsQueryErrorMessage, location_name: "message"))
     InvalidParameterValueException.struct_class = Types::InvalidParameterValueException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     LimitExceededFault.add_member(:message, Shapes::ShapeRef.new(shape: ErrorMessage, location_name: "message"))
     LimitExceededFault.struct_class = Types::LimitExceededFault

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
@@ -10,6 +10,17 @@ module Aws::CloudWatch
 
     extend Aws::Errors::DynamicErrors
 
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatch::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class DashboardInvalidInputError < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -123,6 +134,17 @@ module Aws::CloudWatch
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatch::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
@@ -131,6 +131,12 @@ module Aws::CloudWatch
       include Aws::Structure
     end
 
+    # More than one process tried to modify a resource at the same time.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/monitoring-2010-08-01/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
+
     # Represents a specific dashboard.
     #
     # @!attribute [rw] dashboard_name
@@ -1654,6 +1660,12 @@ module Aws::CloudWatch
       :message)
       include Aws::Structure
     end
+
+    # The operation exceeded one or more limits.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/monitoring-2010-08-01/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # The quota for alarms for this customer has already been reached.
     #

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
@@ -185,6 +185,8 @@ module Aws::CloudWatchEvents
     BatchRetryStrategy.add_member(:attempts, Shapes::ShapeRef.new(shape: Integer, location_name: "Attempts"))
     BatchRetryStrategy.struct_class = Types::BatchRetryStrategy
 
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
+
     Condition.add_member(:type, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Type"))
     Condition.add_member(:key, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Key"))
     Condition.add_member(:value, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Value"))
@@ -300,8 +302,16 @@ module Aws::CloudWatchEvents
     InputTransformer.add_member(:input_template, Shapes::ShapeRef.new(shape: TransformerInput, required: true, location_name: "InputTemplate"))
     InputTransformer.struct_class = Types::InputTransformer
 
+    InternalException.struct_class = Types::InternalException
+
+    InvalidEventPatternException.struct_class = Types::InvalidEventPatternException
+
+    InvalidStateException.struct_class = Types::InvalidStateException
+
     KinesisParameters.add_member(:partition_key_path, Shapes::ShapeRef.new(shape: TargetPartitionKeyPath, required: true, location_name: "PartitionKeyPath"))
     KinesisParameters.struct_class = Types::KinesisParameters
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListEventBusesRequest.add_member(:name_prefix, Shapes::ShapeRef.new(shape: EventBusName, location_name: "NamePrefix"))
     ListEventBusesRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
@@ -375,6 +385,8 @@ module Aws::CloudWatchEvents
     ListTargetsByRuleResponse.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListTargetsByRuleResponse.struct_class = Types::ListTargetsByRuleResponse
 
+    ManagedRuleException.struct_class = Types::ManagedRuleException
+
     NetworkConfiguration.add_member(:awsvpc_configuration, Shapes::ShapeRef.new(shape: AwsVpcConfiguration, location_name: "awsvpcConfiguration"))
     NetworkConfiguration.struct_class = Types::NetworkConfiguration
 
@@ -391,6 +403,8 @@ module Aws::CloudWatchEvents
     PartnerEventSourceAccountList.member = Shapes::ShapeRef.new(shape: PartnerEventSourceAccount)
 
     PartnerEventSourceList.member = Shapes::ShapeRef.new(shape: PartnerEventSource)
+
+    PolicyLengthExceededException.struct_class = Types::PolicyLengthExceededException
 
     PutEventsRequest.add_member(:entries, Shapes::ShapeRef.new(shape: PutEventsRequestEntryList, required: true, location_name: "Entries"))
     PutEventsRequest.struct_class = Types::PutEventsRequest
@@ -495,6 +509,10 @@ module Aws::CloudWatchEvents
     RemoveTargetsResultEntry.struct_class = Types::RemoveTargetsResultEntry
 
     RemoveTargetsResultEntryList.member = Shapes::ShapeRef.new(shape: RemoveTargetsResultEntry)
+
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
 
     Rule.add_member(:name, Shapes::ShapeRef.new(shape: RuleName, location_name: "Name"))
     Rule.add_member(:arn, Shapes::ShapeRef.new(shape: RuleArn, location_name: "Arn"))

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
@@ -10,5 +10,104 @@ module Aws::CloudWatchEvents
 
     extend Aws::Errors::DynamicErrors
 
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::InternalException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventPatternException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::InvalidEventPatternException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::InvalidStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ManagedRuleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::ManagedRuleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PolicyLengthExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::PolicyLengthExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchEvents::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
@@ -164,6 +164,12 @@ module Aws::CloudWatchEvents
       include Aws::Structure
     end
 
+    # There is concurrent modification on a rule or target.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
+
     # A JSON string which you can use to limit the event bus permissions you
     # are granting to only accounts that fulfill the condition. Currently,
     # the only supported condition is membership in a certain AWS
@@ -907,6 +913,24 @@ module Aws::CloudWatchEvents
       include Aws::Structure
     end
 
+    # This exception occurs due to unexpected causes.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/InternalException AWS API Documentation
+    #
+    class InternalException < Aws::EmptyStructure; end
+
+    # The event pattern is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/InvalidEventPatternException AWS API Documentation
+    #
+    class InvalidEventPatternException < Aws::EmptyStructure; end
+
+    # The specified state is not a valid state for an event source.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/InvalidStateException AWS API Documentation
+    #
+    class InvalidStateException < Aws::EmptyStructure; end
+
     # This object enables you to specify a JSON path to extract from the
     # event and use as the partition key for the Amazon Kinesis data stream,
     # so that you can control the shard to which the event goes. If you do
@@ -936,6 +960,13 @@ module Aws::CloudWatchEvents
       :partition_key_path)
       include Aws::Structure
     end
+
+    # You tried to create more rules or add more targets to a rule than is
+    # allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListEventBusesRequest
     #   data as a hash:
@@ -1336,6 +1367,18 @@ module Aws::CloudWatchEvents
       include Aws::Structure
     end
 
+    # This rule was created by an AWS service on behalf of your account. It
+    # is managed by that service. If you see this error in response to
+    # `DeleteRule` or `RemoveTargets`, you can use the `Force` parameter in
+    # those calls to delete the rule or remove targets from the rule. You
+    # cannot modify these managed rules by using `DisableRule`,
+    # `EnableRule`, `PutTargets`, `PutRule`, `TagResource`, or
+    # `UntagResource`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/ManagedRuleException AWS API Documentation
+    #
+    class ManagedRuleException < Aws::EmptyStructure; end
+
     # This structure specifies the network configuration for an ECS task.
     #
     # @note When making an API call, you may pass NetworkConfiguration
@@ -1417,6 +1460,13 @@ module Aws::CloudWatchEvents
       :state)
       include Aws::Structure
     end
+
+    # The event bus policy is too long. For more information, see the
+    # limits.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/PolicyLengthExceededException AWS API Documentation
+    #
+    class PolicyLengthExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PutEventsRequest
     #   data as a hash:
@@ -2053,6 +2103,18 @@ module Aws::CloudWatchEvents
       :error_message)
       include Aws::Structure
     end
+
+    # The resource you are trying to create already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/ResourceAlreadyExistsException AWS API Documentation
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    # An entity that you specified does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/events-2015-10-07/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # Contains information about a rule in Amazon EventBridge.
     #

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
@@ -425,8 +425,14 @@ module Aws::CloudWatchLogs
 
     InputLogStreamNames.member = Shapes::ShapeRef.new(shape: LogStreamName)
 
+    InvalidOperationException.struct_class = Types::InvalidOperationException
+
+    InvalidParameterException.struct_class = Types::InvalidParameterException
+
     InvalidSequenceTokenException.add_member(:expected_sequence_token, Shapes::ShapeRef.new(shape: SequenceToken, location_name: "expectedSequenceToken"))
     InvalidSequenceTokenException.struct_class = Types::InvalidSequenceTokenException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListTagsLogGroupRequest.add_member(:log_group_name, Shapes::ShapeRef.new(shape: LogGroupName, required: true, location_name: "logGroupName"))
     ListTagsLogGroupRequest.struct_class = Types::ListTagsLogGroupRequest
@@ -494,6 +500,8 @@ module Aws::CloudWatchLogs
     MetricTransformation.struct_class = Types::MetricTransformation
 
     MetricTransformations.member = Shapes::ShapeRef.new(shape: MetricTransformation)
+
+    OperationAbortedException.struct_class = Types::OperationAbortedException
 
     OutputLogEvent.add_member(:timestamp, Shapes::ShapeRef.new(shape: Timestamp, location_name: "timestamp"))
     OutputLogEvent.add_member(:message, Shapes::ShapeRef.new(shape: EventMessage, location_name: "message"))
@@ -578,6 +586,10 @@ module Aws::CloudWatchLogs
     RejectedLogEventsInfo.add_member(:expired_log_event_end_index, Shapes::ShapeRef.new(shape: LogEventIndex, location_name: "expiredLogEventEndIndex"))
     RejectedLogEventsInfo.struct_class = Types::RejectedLogEventsInfo
 
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ResourcePolicies.member = Shapes::ShapeRef.new(shape: ResourcePolicy)
 
     ResourcePolicy.add_member(:policy_name, Shapes::ShapeRef.new(shape: PolicyName, location_name: "policyName"))
@@ -596,6 +608,8 @@ module Aws::CloudWatchLogs
     SearchedLogStream.struct_class = Types::SearchedLogStream
 
     SearchedLogStreams.member = Shapes::ShapeRef.new(shape: SearchedLogStream)
+
+    ServiceUnavailableException.struct_class = Types::ServiceUnavailableException
 
     StartQueryRequest.add_member(:log_group_name, Shapes::ShapeRef.new(shape: LogGroupName, location_name: "logGroupName"))
     StartQueryRequest.add_member(:log_group_names, Shapes::ShapeRef.new(shape: LogGroupNames, location_name: "logGroupNames"))
@@ -642,6 +656,8 @@ module Aws::CloudWatchLogs
 
     TestMetricFilterResponse.add_member(:matches, Shapes::ShapeRef.new(shape: MetricFilterMatches, location_name: "matches"))
     TestMetricFilterResponse.struct_class = Types::TestMetricFilterResponse
+
+    UnrecognizedClientException.struct_class = Types::UnrecognizedClientException
 
     UntagLogGroupRequest.add_member(:log_group_name, Shapes::ShapeRef.new(shape: LogGroupName, required: true, location_name: "logGroupName"))
     UntagLogGroupRequest.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, required: true, location_name: "tags"))

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
@@ -26,6 +26,28 @@ module Aws::CloudWatchLogs
 
     end
 
+    class InvalidOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::InvalidOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::InvalidParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidSequenceTokenException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -42,6 +64,17 @@ module Aws::CloudWatchLogs
 
     end
 
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class MalformedQueryException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -54,6 +87,61 @@ module Aws::CloudWatchLogs
       # @return [String]
       def query_compile_error
         @data[:query_compile_error]
+      end
+
+    end
+
+    class OperationAbortedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::OperationAbortedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ServiceUnavailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::ServiceUnavailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnrecognizedClientException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CloudWatchLogs::Types::UnrecognizedClientException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
@@ -1379,6 +1379,18 @@ module Aws::CloudWatchLogs
       include Aws::Structure
     end
 
+    # The operation is not valid on the specified resource.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/InvalidOperationException AWS API Documentation
+    #
+    class InvalidOperationException < Aws::EmptyStructure; end
+
+    # A parameter is specified incorrectly.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/InvalidParameterException AWS API Documentation
+    #
+    class InvalidParameterException < Aws::EmptyStructure; end
+
     # The sequence token is not valid. You can get the correct sequence
     # token in the `expectedSequenceToken` field in the
     # `InvalidSequenceTokenException` message.
@@ -1392,6 +1404,12 @@ module Aws::CloudWatchLogs
       :expected_sequence_token)
       include Aws::Structure
     end
+
+    # You have reached the maximum number of resources that can be created.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListTagsLogGroupRequest
     #   data as a hash:
@@ -1674,6 +1692,12 @@ module Aws::CloudWatchLogs
       :default_value)
       include Aws::Structure
     end
+
+    # Multiple requests to update the same resource were in conflict.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/OperationAbortedException AWS API Documentation
+    #
+    class OperationAbortedException < Aws::EmptyStructure; end
 
     # Represents a log event.
     #
@@ -2140,6 +2164,18 @@ module Aws::CloudWatchLogs
       include Aws::Structure
     end
 
+    # The specified resource already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/ResourceAlreadyExistsException AWS API Documentation
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The specified resource does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # A policy enabling one or more entities to put logs to a log group in
     # this account.
     #
@@ -2201,6 +2237,12 @@ module Aws::CloudWatchLogs
       :searched_completely)
       include Aws::Structure
     end
+
+    # The service cannot complete the request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/ServiceUnavailableException AWS API Documentation
+    #
+    class ServiceUnavailableException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass StartQueryRequest
     #   data as a hash:
@@ -2420,6 +2462,12 @@ module Aws::CloudWatchLogs
       :matches)
       include Aws::Structure
     end
+
+    # The most likely cause is an invalid AWS access key ID or secret key.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/UnrecognizedClientException AWS API Documentation
+    #
+    class UnrecognizedClientException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagLogGroupRequest
     #   data as a hash:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
@@ -202,6 +202,8 @@ module Aws::CodeBuild
     WrapperInt = Shapes::IntegerShape.new(name: 'WrapperInt')
     WrapperLong = Shapes::IntegerShape.new(name: 'WrapperLong')
 
+    AccountLimitExceededException.struct_class = Types::AccountLimitExceededException
+
     BatchDeleteBuildsInput.add_member(:ids, Shapes::ShapeRef.new(shape: BuildIds, required: true, location_name: "ids"))
     BatchDeleteBuildsInput.struct_class = Types::BatchDeleteBuildsInput
 
@@ -444,6 +446,8 @@ module Aws::CodeBuild
     ImportSourceCredentialsOutput.add_member(:arn, Shapes::ShapeRef.new(shape: NonEmptyString, location_name: "arn"))
     ImportSourceCredentialsOutput.struct_class = Types::ImportSourceCredentialsOutput
 
+    InvalidInputException.struct_class = Types::InvalidInputException
+
     InvalidateProjectCacheInput.add_member(:project_name, Shapes::ShapeRef.new(shape: NonEmptyString, required: true, location_name: "projectName"))
     InvalidateProjectCacheInput.struct_class = Types::InvalidateProjectCacheInput
 
@@ -553,6 +557,8 @@ module Aws::CodeBuild
     NetworkInterface.add_member(:subnet_id, Shapes::ShapeRef.new(shape: NonEmptyString, location_name: "subnetId"))
     NetworkInterface.add_member(:network_interface_id, Shapes::ShapeRef.new(shape: NonEmptyString, location_name: "networkInterfaceId"))
     NetworkInterface.struct_class = Types::NetworkInterface
+
+    OAuthProviderException.struct_class = Types::OAuthProviderException
 
     PhaseContext.add_member(:status_code, Shapes::ShapeRef.new(shape: String, location_name: "statusCode"))
     PhaseContext.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "message"))
@@ -702,6 +708,10 @@ module Aws::CodeBuild
     ReportStatusCounts.value = Shapes::ShapeRef.new(shape: WrapperInt)
 
     Reports.member = Shapes::ShapeRef.new(shape: Report)
+
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
 
     S3LogsConfig.add_member(:status, Shapes::ShapeRef.new(shape: LogsConfigStatusType, required: true, location_name: "status"))
     S3LogsConfig.add_member(:location, Shapes::ShapeRef.new(shape: String, location_name: "location"))

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
@@ -10,5 +10,60 @@ module Aws::CodeBuild
 
     extend Aws::Errors::DynamicErrors
 
+    class AccountLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeBuild::Types::AccountLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInputException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeBuild::Types::InvalidInputException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OAuthProviderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeBuild::Types::OAuthProviderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeBuild::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeBuild::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
@@ -8,6 +8,12 @@
 module Aws::CodeBuild
   module Types
 
+    # An AWS service limit was exceeded for the calling AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/AccountLimitExceededException AWS API Documentation
+    #
+    class AccountLimitExceededException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass BatchDeleteBuildsInput
     #   data as a hash:
     #
@@ -1514,6 +1520,12 @@ module Aws::CodeBuild
       include Aws::Structure
     end
 
+    # The input value that was provided is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/InvalidInputException AWS API Documentation
+    #
+    class InvalidInputException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass InvalidateProjectCacheInput
     #   data as a hash:
     #
@@ -2260,6 +2272,12 @@ module Aws::CodeBuild
       :network_interface_id)
       include Aws::Structure
     end
+
+    # There was a problem with the underlying OAuth provider.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/OAuthProviderException AWS API Documentation
+    #
+    class OAuthProviderException < Aws::EmptyStructure; end
 
     # Additional information about a build phase that has an error. You can
     # use this information for troubleshooting.
@@ -3470,6 +3488,19 @@ module Aws::CodeBuild
       :last_modified)
       include Aws::Structure
     end
+
+    # The specified AWS resource cannot be created, because an AWS resource
+    # with the same settings already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/ResourceAlreadyExistsException AWS API Documentation
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The specified AWS resource cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # Information about S3 logs for a build project.
     #

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
@@ -517,6 +517,8 @@ module Aws::CodeCommit
     UserInfo = Shapes::StructureShape.new(name: 'UserInfo')
     blob = Shapes::BlobShape.new(name: 'blob')
 
+    ActorDoesNotExistException.struct_class = Types::ActorDoesNotExistException
+
     Approval.add_member(:user_arn, Shapes::ShapeRef.new(shape: Arn, location_name: "userArn"))
     Approval.add_member(:approval_state, Shapes::ShapeRef.new(shape: ApprovalState, location_name: "approvalState"))
     Approval.struct_class = Types::Approval
@@ -533,10 +535,18 @@ module Aws::CodeCommit
     ApprovalRule.add_member(:origin_approval_rule_template, Shapes::ShapeRef.new(shape: OriginApprovalRuleTemplate, location_name: "originApprovalRuleTemplate"))
     ApprovalRule.struct_class = Types::ApprovalRule
 
+    ApprovalRuleContentRequiredException.struct_class = Types::ApprovalRuleContentRequiredException
+
+    ApprovalRuleDoesNotExistException.struct_class = Types::ApprovalRuleDoesNotExistException
+
     ApprovalRuleEventMetadata.add_member(:approval_rule_name, Shapes::ShapeRef.new(shape: ApprovalRuleName, location_name: "approvalRuleName"))
     ApprovalRuleEventMetadata.add_member(:approval_rule_id, Shapes::ShapeRef.new(shape: ApprovalRuleId, location_name: "approvalRuleId"))
     ApprovalRuleEventMetadata.add_member(:approval_rule_content, Shapes::ShapeRef.new(shape: ApprovalRuleContent, location_name: "approvalRuleContent"))
     ApprovalRuleEventMetadata.struct_class = Types::ApprovalRuleEventMetadata
+
+    ApprovalRuleNameAlreadyExistsException.struct_class = Types::ApprovalRuleNameAlreadyExistsException
+
+    ApprovalRuleNameRequiredException.struct_class = Types::ApprovalRuleNameRequiredException
 
     ApprovalRuleOverriddenEventMetadata.add_member(:revision_id, Shapes::ShapeRef.new(shape: RevisionId, location_name: "revisionId"))
     ApprovalRuleOverriddenEventMetadata.add_member(:override_status, Shapes::ShapeRef.new(shape: OverrideStatus, location_name: "overrideStatus"))
@@ -552,7 +562,17 @@ module Aws::CodeCommit
     ApprovalRuleTemplate.add_member(:last_modified_user, Shapes::ShapeRef.new(shape: Arn, location_name: "lastModifiedUser"))
     ApprovalRuleTemplate.struct_class = Types::ApprovalRuleTemplate
 
+    ApprovalRuleTemplateContentRequiredException.struct_class = Types::ApprovalRuleTemplateContentRequiredException
+
+    ApprovalRuleTemplateDoesNotExistException.struct_class = Types::ApprovalRuleTemplateDoesNotExistException
+
+    ApprovalRuleTemplateInUseException.struct_class = Types::ApprovalRuleTemplateInUseException
+
+    ApprovalRuleTemplateNameAlreadyExistsException.struct_class = Types::ApprovalRuleTemplateNameAlreadyExistsException
+
     ApprovalRuleTemplateNameList.member = Shapes::ShapeRef.new(shape: ApprovalRuleTemplateName)
+
+    ApprovalRuleTemplateNameRequiredException.struct_class = Types::ApprovalRuleTemplateNameRequiredException
 
     ApprovalRulesList.member = Shapes::ShapeRef.new(shape: ApprovalRule)
 
@@ -564,9 +584,13 @@ module Aws::CodeCommit
     ApprovalStateChangedEventMetadata.add_member(:approval_status, Shapes::ShapeRef.new(shape: ApprovalState, location_name: "approvalStatus"))
     ApprovalStateChangedEventMetadata.struct_class = Types::ApprovalStateChangedEventMetadata
 
+    ApprovalStateRequiredException.struct_class = Types::ApprovalStateRequiredException
+
     AssociateApprovalRuleTemplateWithRepositoryInput.add_member(:approval_rule_template_name, Shapes::ShapeRef.new(shape: ApprovalRuleTemplateName, required: true, location_name: "approvalRuleTemplateName"))
     AssociateApprovalRuleTemplateWithRepositoryInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     AssociateApprovalRuleTemplateWithRepositoryInput.struct_class = Types::AssociateApprovalRuleTemplateWithRepositoryInput
+
+    AuthorDoesNotExistException.struct_class = Types::AuthorDoesNotExistException
 
     BatchAssociateApprovalRuleTemplateWithRepositoriesError.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, location_name: "repositoryName"))
     BatchAssociateApprovalRuleTemplateWithRepositoriesError.add_member(:error_code, Shapes::ShapeRef.new(shape: ErrorCode, location_name: "errorCode"))
@@ -647,16 +671,36 @@ module Aws::CodeCommit
     BatchGetRepositoriesOutput.add_member(:repositories_not_found, Shapes::ShapeRef.new(shape: RepositoryNotFoundList, location_name: "repositoriesNotFound"))
     BatchGetRepositoriesOutput.struct_class = Types::BatchGetRepositoriesOutput
 
+    BeforeCommitIdAndAfterCommitIdAreSameException.struct_class = Types::BeforeCommitIdAndAfterCommitIdAreSameException
+
+    BlobIdDoesNotExistException.struct_class = Types::BlobIdDoesNotExistException
+
+    BlobIdRequiredException.struct_class = Types::BlobIdRequiredException
+
     BlobMetadata.add_member(:blob_id, Shapes::ShapeRef.new(shape: ObjectId, location_name: "blobId"))
     BlobMetadata.add_member(:path, Shapes::ShapeRef.new(shape: Path, location_name: "path"))
     BlobMetadata.add_member(:mode, Shapes::ShapeRef.new(shape: Mode, location_name: "mode"))
     BlobMetadata.struct_class = Types::BlobMetadata
 
+    BranchDoesNotExistException.struct_class = Types::BranchDoesNotExistException
+
     BranchInfo.add_member(:branch_name, Shapes::ShapeRef.new(shape: BranchName, location_name: "branchName"))
     BranchInfo.add_member(:commit_id, Shapes::ShapeRef.new(shape: CommitId, location_name: "commitId"))
     BranchInfo.struct_class = Types::BranchInfo
 
+    BranchNameExistsException.struct_class = Types::BranchNameExistsException
+
+    BranchNameIsTagNameException.struct_class = Types::BranchNameIsTagNameException
+
     BranchNameList.member = Shapes::ShapeRef.new(shape: BranchName)
+
+    BranchNameRequiredException.struct_class = Types::BranchNameRequiredException
+
+    CannotDeleteApprovalRuleFromTemplateException.struct_class = Types::CannotDeleteApprovalRuleFromTemplateException
+
+    CannotModifyApprovalRuleFromTemplateException.struct_class = Types::CannotModifyApprovalRuleFromTemplateException
+
+    ClientRequestTokenRequiredException.struct_class = Types::ClientRequestTokenRequiredException
 
     Comment.add_member(:comment_id, Shapes::ShapeRef.new(shape: CommentId, location_name: "commentId"))
     Comment.add_member(:content, Shapes::ShapeRef.new(shape: Content, location_name: "content"))
@@ -667,6 +711,18 @@ module Aws::CodeCommit
     Comment.add_member(:deleted, Shapes::ShapeRef.new(shape: IsCommentDeleted, location_name: "deleted"))
     Comment.add_member(:client_request_token, Shapes::ShapeRef.new(shape: ClientRequestToken, location_name: "clientRequestToken"))
     Comment.struct_class = Types::Comment
+
+    CommentContentRequiredException.struct_class = Types::CommentContentRequiredException
+
+    CommentContentSizeLimitExceededException.struct_class = Types::CommentContentSizeLimitExceededException
+
+    CommentDeletedException.struct_class = Types::CommentDeletedException
+
+    CommentDoesNotExistException.struct_class = Types::CommentDoesNotExistException
+
+    CommentIdRequiredException.struct_class = Types::CommentIdRequiredException
+
+    CommentNotCreatedByCallerException.struct_class = Types::CommentNotCreatedByCallerException
 
     Comments.member = Shapes::ShapeRef.new(shape: Comment)
 
@@ -702,9 +758,25 @@ module Aws::CodeCommit
     Commit.add_member(:additional_data, Shapes::ShapeRef.new(shape: AdditionalData, location_name: "additionalData"))
     Commit.struct_class = Types::Commit
 
+    CommitDoesNotExistException.struct_class = Types::CommitDoesNotExistException
+
+    CommitIdDoesNotExistException.struct_class = Types::CommitIdDoesNotExistException
+
+    CommitIdRequiredException.struct_class = Types::CommitIdRequiredException
+
     CommitIdsInputList.member = Shapes::ShapeRef.new(shape: ObjectId)
 
+    CommitIdsLimitExceededException.struct_class = Types::CommitIdsLimitExceededException
+
+    CommitIdsListRequiredException.struct_class = Types::CommitIdsListRequiredException
+
+    CommitMessageLengthExceededException.struct_class = Types::CommitMessageLengthExceededException
+
     CommitObjectsList.member = Shapes::ShapeRef.new(shape: Commit)
+
+    CommitRequiredException.struct_class = Types::CommitRequiredException
+
+    ConcurrentReferenceUpdateException.struct_class = Types::ConcurrentReferenceUpdateException
 
     Conflict.add_member(:conflict_metadata, Shapes::ShapeRef.new(shape: ConflictMetadata, location_name: "conflictMetadata"))
     Conflict.add_member(:merge_hunks, Shapes::ShapeRef.new(shape: MergeHunks, location_name: "mergeHunks"))
@@ -805,6 +877,8 @@ module Aws::CodeCommit
     CreateUnreferencedMergeCommitOutput.add_member(:tree_id, Shapes::ShapeRef.new(shape: ObjectId, location_name: "treeId"))
     CreateUnreferencedMergeCommitOutput.struct_class = Types::CreateUnreferencedMergeCommitOutput
 
+    DefaultBranchCannotBeDeletedException.struct_class = Types::DefaultBranchCannotBeDeletedException
+
     DeleteApprovalRuleTemplateInput.add_member(:approval_rule_template_name, Shapes::ShapeRef.new(shape: ApprovalRuleTemplateName, required: true, location_name: "approvalRuleTemplateName"))
     DeleteApprovalRuleTemplateInput.struct_class = Types::DeleteApprovalRuleTemplateInput
 
@@ -895,9 +969,21 @@ module Aws::CodeCommit
 
     DifferenceList.member = Shapes::ShapeRef.new(shape: Difference)
 
+    DirectoryNameConflictsWithFileNameException.struct_class = Types::DirectoryNameConflictsWithFileNameException
+
     DisassociateApprovalRuleTemplateFromRepositoryInput.add_member(:approval_rule_template_name, Shapes::ShapeRef.new(shape: ApprovalRuleTemplateName, required: true, location_name: "approvalRuleTemplateName"))
     DisassociateApprovalRuleTemplateFromRepositoryInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     DisassociateApprovalRuleTemplateFromRepositoryInput.struct_class = Types::DisassociateApprovalRuleTemplateFromRepositoryInput
+
+    EncryptionIntegrityChecksFailedException.struct_class = Types::EncryptionIntegrityChecksFailedException
+
+    EncryptionKeyAccessDeniedException.struct_class = Types::EncryptionKeyAccessDeniedException
+
+    EncryptionKeyDisabledException.struct_class = Types::EncryptionKeyDisabledException
+
+    EncryptionKeyNotFoundException.struct_class = Types::EncryptionKeyNotFoundException
+
+    EncryptionKeyUnavailableException.struct_class = Types::EncryptionKeyUnavailableException
 
     EvaluatePullRequestApprovalRulesInput.add_member(:pull_request_id, Shapes::ShapeRef.new(shape: PullRequestId, required: true, location_name: "pullRequestId"))
     EvaluatePullRequestApprovalRulesInput.add_member(:revision_id, Shapes::ShapeRef.new(shape: RevisionId, required: true, location_name: "revisionId"))
@@ -918,6 +1004,16 @@ module Aws::CodeCommit
     File.add_member(:file_mode, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "fileMode"))
     File.struct_class = Types::File
 
+    FileContentAndSourceFileSpecifiedException.struct_class = Types::FileContentAndSourceFileSpecifiedException
+
+    FileContentRequiredException.struct_class = Types::FileContentRequiredException
+
+    FileContentSizeLimitExceededException.struct_class = Types::FileContentSizeLimitExceededException
+
+    FileDoesNotExistException.struct_class = Types::FileDoesNotExistException
+
+    FileEntryRequiredException.struct_class = Types::FileEntryRequiredException
+
     FileList.member = Shapes::ShapeRef.new(shape: File)
 
     FileMetadata.add_member(:absolute_path, Shapes::ShapeRef.new(shape: Path, location_name: "absolutePath"))
@@ -925,10 +1021,16 @@ module Aws::CodeCommit
     FileMetadata.add_member(:file_mode, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "fileMode"))
     FileMetadata.struct_class = Types::FileMetadata
 
+    FileModeRequiredException.struct_class = Types::FileModeRequiredException
+
     FileModes.add_member(:source, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "source"))
     FileModes.add_member(:destination, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "destination"))
     FileModes.add_member(:base, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "base"))
     FileModes.struct_class = Types::FileModes
+
+    FileNameConflictsWithDirectoryNameException.struct_class = Types::FileNameConflictsWithDirectoryNameException
+
+    FilePathConflictsWithSubmodulePathException.struct_class = Types::FilePathConflictsWithSubmodulePathException
 
     FilePaths.member = Shapes::ShapeRef.new(shape: Path)
 
@@ -937,12 +1039,18 @@ module Aws::CodeCommit
     FileSizes.add_member(:base, Shapes::ShapeRef.new(shape: FileSize, location_name: "base"))
     FileSizes.struct_class = Types::FileSizes
 
+    FileTooLargeException.struct_class = Types::FileTooLargeException
+
     FilesMetadata.member = Shapes::ShapeRef.new(shape: FileMetadata)
 
     Folder.add_member(:tree_id, Shapes::ShapeRef.new(shape: ObjectId, location_name: "treeId"))
     Folder.add_member(:absolute_path, Shapes::ShapeRef.new(shape: Path, location_name: "absolutePath"))
     Folder.add_member(:relative_path, Shapes::ShapeRef.new(shape: Path, location_name: "relativePath"))
     Folder.struct_class = Types::Folder
+
+    FolderContentSizeLimitExceededException.struct_class = Types::FolderContentSizeLimitExceededException
+
+    FolderDoesNotExistException.struct_class = Types::FolderDoesNotExistException
 
     FolderList.member = Shapes::ShapeRef.new(shape: Folder)
 
@@ -1120,6 +1228,130 @@ module Aws::CodeCommit
     GetRepositoryTriggersOutput.add_member(:triggers, Shapes::ShapeRef.new(shape: RepositoryTriggersList, location_name: "triggers"))
     GetRepositoryTriggersOutput.struct_class = Types::GetRepositoryTriggersOutput
 
+    IdempotencyParameterMismatchException.struct_class = Types::IdempotencyParameterMismatchException
+
+    InvalidActorArnException.struct_class = Types::InvalidActorArnException
+
+    InvalidApprovalRuleContentException.struct_class = Types::InvalidApprovalRuleContentException
+
+    InvalidApprovalRuleNameException.struct_class = Types::InvalidApprovalRuleNameException
+
+    InvalidApprovalRuleTemplateContentException.struct_class = Types::InvalidApprovalRuleTemplateContentException
+
+    InvalidApprovalRuleTemplateDescriptionException.struct_class = Types::InvalidApprovalRuleTemplateDescriptionException
+
+    InvalidApprovalRuleTemplateNameException.struct_class = Types::InvalidApprovalRuleTemplateNameException
+
+    InvalidApprovalStateException.struct_class = Types::InvalidApprovalStateException
+
+    InvalidAuthorArnException.struct_class = Types::InvalidAuthorArnException
+
+    InvalidBlobIdException.struct_class = Types::InvalidBlobIdException
+
+    InvalidBranchNameException.struct_class = Types::InvalidBranchNameException
+
+    InvalidClientRequestTokenException.struct_class = Types::InvalidClientRequestTokenException
+
+    InvalidCommentIdException.struct_class = Types::InvalidCommentIdException
+
+    InvalidCommitException.struct_class = Types::InvalidCommitException
+
+    InvalidCommitIdException.struct_class = Types::InvalidCommitIdException
+
+    InvalidConflictDetailLevelException.struct_class = Types::InvalidConflictDetailLevelException
+
+    InvalidConflictResolutionException.struct_class = Types::InvalidConflictResolutionException
+
+    InvalidConflictResolutionStrategyException.struct_class = Types::InvalidConflictResolutionStrategyException
+
+    InvalidContinuationTokenException.struct_class = Types::InvalidContinuationTokenException
+
+    InvalidDeletionParameterException.struct_class = Types::InvalidDeletionParameterException
+
+    InvalidDescriptionException.struct_class = Types::InvalidDescriptionException
+
+    InvalidDestinationCommitSpecifierException.struct_class = Types::InvalidDestinationCommitSpecifierException
+
+    InvalidEmailException.struct_class = Types::InvalidEmailException
+
+    InvalidFileLocationException.struct_class = Types::InvalidFileLocationException
+
+    InvalidFileModeException.struct_class = Types::InvalidFileModeException
+
+    InvalidFilePositionException.struct_class = Types::InvalidFilePositionException
+
+    InvalidMaxConflictFilesException.struct_class = Types::InvalidMaxConflictFilesException
+
+    InvalidMaxMergeHunksException.struct_class = Types::InvalidMaxMergeHunksException
+
+    InvalidMaxResultsException.struct_class = Types::InvalidMaxResultsException
+
+    InvalidMergeOptionException.struct_class = Types::InvalidMergeOptionException
+
+    InvalidOrderException.struct_class = Types::InvalidOrderException
+
+    InvalidOverrideStatusException.struct_class = Types::InvalidOverrideStatusException
+
+    InvalidParentCommitIdException.struct_class = Types::InvalidParentCommitIdException
+
+    InvalidPathException.struct_class = Types::InvalidPathException
+
+    InvalidPullRequestEventTypeException.struct_class = Types::InvalidPullRequestEventTypeException
+
+    InvalidPullRequestIdException.struct_class = Types::InvalidPullRequestIdException
+
+    InvalidPullRequestStatusException.struct_class = Types::InvalidPullRequestStatusException
+
+    InvalidPullRequestStatusUpdateException.struct_class = Types::InvalidPullRequestStatusUpdateException
+
+    InvalidReferenceNameException.struct_class = Types::InvalidReferenceNameException
+
+    InvalidRelativeFileVersionEnumException.struct_class = Types::InvalidRelativeFileVersionEnumException
+
+    InvalidReplacementContentException.struct_class = Types::InvalidReplacementContentException
+
+    InvalidReplacementTypeException.struct_class = Types::InvalidReplacementTypeException
+
+    InvalidRepositoryDescriptionException.struct_class = Types::InvalidRepositoryDescriptionException
+
+    InvalidRepositoryNameException.struct_class = Types::InvalidRepositoryNameException
+
+    InvalidRepositoryTriggerBranchNameException.struct_class = Types::InvalidRepositoryTriggerBranchNameException
+
+    InvalidRepositoryTriggerCustomDataException.struct_class = Types::InvalidRepositoryTriggerCustomDataException
+
+    InvalidRepositoryTriggerDestinationArnException.struct_class = Types::InvalidRepositoryTriggerDestinationArnException
+
+    InvalidRepositoryTriggerEventsException.struct_class = Types::InvalidRepositoryTriggerEventsException
+
+    InvalidRepositoryTriggerNameException.struct_class = Types::InvalidRepositoryTriggerNameException
+
+    InvalidRepositoryTriggerRegionException.struct_class = Types::InvalidRepositoryTriggerRegionException
+
+    InvalidResourceArnException.struct_class = Types::InvalidResourceArnException
+
+    InvalidRevisionIdException.struct_class = Types::InvalidRevisionIdException
+
+    InvalidRuleContentSha256Exception.struct_class = Types::InvalidRuleContentSha256Exception
+
+    InvalidSortByException.struct_class = Types::InvalidSortByException
+
+    InvalidSourceCommitSpecifierException.struct_class = Types::InvalidSourceCommitSpecifierException
+
+    InvalidSystemTagUsageException.struct_class = Types::InvalidSystemTagUsageException
+
+    InvalidTagKeysListException.struct_class = Types::InvalidTagKeysListException
+
+    InvalidTagsMapException.struct_class = Types::InvalidTagsMapException
+
+    InvalidTargetBranchException.struct_class = Types::InvalidTargetBranchException
+
+    InvalidTargetException.struct_class = Types::InvalidTargetException
+
+    InvalidTargetsException.struct_class = Types::InvalidTargetsException
+
+    InvalidTitleException.struct_class = Types::InvalidTitleException
+
     IsBinaryFile.add_member(:source, Shapes::ShapeRef.new(shape: CapitalBoolean, location_name: "source"))
     IsBinaryFile.add_member(:destination, Shapes::ShapeRef.new(shape: CapitalBoolean, location_name: "destination"))
     IsBinaryFile.add_member(:base, Shapes::ShapeRef.new(shape: CapitalBoolean, location_name: "base"))
@@ -1192,6 +1424,28 @@ module Aws::CodeCommit
     Location.add_member(:relative_file_version, Shapes::ShapeRef.new(shape: RelativeFileVersionEnum, location_name: "relativeFileVersion"))
     Location.struct_class = Types::Location
 
+    ManualMergeRequiredException.struct_class = Types::ManualMergeRequiredException
+
+    MaximumBranchesExceededException.struct_class = Types::MaximumBranchesExceededException
+
+    MaximumConflictResolutionEntriesExceededException.struct_class = Types::MaximumConflictResolutionEntriesExceededException
+
+    MaximumFileContentToLoadExceededException.struct_class = Types::MaximumFileContentToLoadExceededException
+
+    MaximumFileEntriesExceededException.struct_class = Types::MaximumFileEntriesExceededException
+
+    MaximumItemsToCompareExceededException.struct_class = Types::MaximumItemsToCompareExceededException
+
+    MaximumNumberOfApprovalsExceededException.struct_class = Types::MaximumNumberOfApprovalsExceededException
+
+    MaximumOpenPullRequestsExceededException.struct_class = Types::MaximumOpenPullRequestsExceededException
+
+    MaximumRepositoryNamesExceededException.struct_class = Types::MaximumRepositoryNamesExceededException
+
+    MaximumRepositoryTriggersExceededException.struct_class = Types::MaximumRepositoryTriggersExceededException
+
+    MaximumRuleTemplatesAssociatedWithRepositoryException.struct_class = Types::MaximumRuleTemplatesAssociatedWithRepositoryException
+
     MergeBranchesByFastForwardInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     MergeBranchesByFastForwardInput.add_member(:source_commit_specifier, Shapes::ShapeRef.new(shape: CommitName, required: true, location_name: "sourceCommitSpecifier"))
     MergeBranchesByFastForwardInput.add_member(:destination_commit_specifier, Shapes::ShapeRef.new(shape: CommitName, required: true, location_name: "destinationCommitSpecifier"))
@@ -1259,6 +1513,8 @@ module Aws::CodeCommit
     MergeOperations.add_member(:destination, Shapes::ShapeRef.new(shape: ChangeTypeEnum, location_name: "destination"))
     MergeOperations.struct_class = Types::MergeOperations
 
+    MergeOptionRequiredException.struct_class = Types::MergeOptionRequiredException
+
     MergeOptions.member = Shapes::ShapeRef.new(shape: MergeOptionTypeEnum)
 
     MergePullRequestByFastForwardInput.add_member(:pull_request_id, Shapes::ShapeRef.new(shape: PullRequestId, required: true, location_name: "pullRequestId"))
@@ -1299,6 +1555,18 @@ module Aws::CodeCommit
     MergePullRequestByThreeWayOutput.add_member(:pull_request, Shapes::ShapeRef.new(shape: PullRequest, location_name: "pullRequest"))
     MergePullRequestByThreeWayOutput.struct_class = Types::MergePullRequestByThreeWayOutput
 
+    MultipleConflictResolutionEntriesException.struct_class = Types::MultipleConflictResolutionEntriesException
+
+    MultipleRepositoriesInPullRequestException.struct_class = Types::MultipleRepositoriesInPullRequestException
+
+    NameLengthExceededException.struct_class = Types::NameLengthExceededException
+
+    NoChangeException.struct_class = Types::NoChangeException
+
+    NumberOfRuleTemplatesExceededException.struct_class = Types::NumberOfRuleTemplatesExceededException
+
+    NumberOfRulesExceededException.struct_class = Types::NumberOfRulesExceededException
+
     ObjectTypes.add_member(:source, Shapes::ShapeRef.new(shape: ObjectTypeEnum, location_name: "source"))
     ObjectTypes.add_member(:destination, Shapes::ShapeRef.new(shape: ObjectTypeEnum, location_name: "destination"))
     ObjectTypes.add_member(:base, Shapes::ShapeRef.new(shape: ObjectTypeEnum, location_name: "base"))
@@ -1308,12 +1576,26 @@ module Aws::CodeCommit
     OriginApprovalRuleTemplate.add_member(:approval_rule_template_name, Shapes::ShapeRef.new(shape: ApprovalRuleTemplateName, location_name: "approvalRuleTemplateName"))
     OriginApprovalRuleTemplate.struct_class = Types::OriginApprovalRuleTemplate
 
+    OverrideAlreadySetException.struct_class = Types::OverrideAlreadySetException
+
     OverridePullRequestApprovalRulesInput.add_member(:pull_request_id, Shapes::ShapeRef.new(shape: PullRequestId, required: true, location_name: "pullRequestId"))
     OverridePullRequestApprovalRulesInput.add_member(:revision_id, Shapes::ShapeRef.new(shape: RevisionId, required: true, location_name: "revisionId"))
     OverridePullRequestApprovalRulesInput.add_member(:override_status, Shapes::ShapeRef.new(shape: OverrideStatus, required: true, location_name: "overrideStatus"))
     OverridePullRequestApprovalRulesInput.struct_class = Types::OverridePullRequestApprovalRulesInput
 
+    OverrideStatusRequiredException.struct_class = Types::OverrideStatusRequiredException
+
+    ParentCommitDoesNotExistException.struct_class = Types::ParentCommitDoesNotExistException
+
+    ParentCommitIdOutdatedException.struct_class = Types::ParentCommitIdOutdatedException
+
+    ParentCommitIdRequiredException.struct_class = Types::ParentCommitIdRequiredException
+
     ParentList.member = Shapes::ShapeRef.new(shape: ObjectId)
+
+    PathDoesNotExistException.struct_class = Types::PathDoesNotExistException
+
+    PathRequiredException.struct_class = Types::PathRequiredException
 
     PostCommentForComparedCommitInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     PostCommentForComparedCommitInput.add_member(:before_commit_id, Shapes::ShapeRef.new(shape: CommitId, location_name: "beforeCommitId"))
@@ -1372,11 +1654,19 @@ module Aws::CodeCommit
     PullRequest.add_member(:approval_rules, Shapes::ShapeRef.new(shape: ApprovalRulesList, location_name: "approvalRules"))
     PullRequest.struct_class = Types::PullRequest
 
+    PullRequestAlreadyClosedException.struct_class = Types::PullRequestAlreadyClosedException
+
+    PullRequestApprovalRulesNotSatisfiedException.struct_class = Types::PullRequestApprovalRulesNotSatisfiedException
+
+    PullRequestCannotBeApprovedByAuthorException.struct_class = Types::PullRequestCannotBeApprovedByAuthorException
+
     PullRequestCreatedEventMetadata.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, location_name: "repositoryName"))
     PullRequestCreatedEventMetadata.add_member(:source_commit_id, Shapes::ShapeRef.new(shape: CommitId, location_name: "sourceCommitId"))
     PullRequestCreatedEventMetadata.add_member(:destination_commit_id, Shapes::ShapeRef.new(shape: CommitId, location_name: "destinationCommitId"))
     PullRequestCreatedEventMetadata.add_member(:merge_base, Shapes::ShapeRef.new(shape: CommitId, location_name: "mergeBase"))
     PullRequestCreatedEventMetadata.struct_class = Types::PullRequestCreatedEventMetadata
+
+    PullRequestDoesNotExistException.struct_class = Types::PullRequestDoesNotExistException
 
     PullRequestEvent.add_member(:pull_request_id, Shapes::ShapeRef.new(shape: PullRequestId, location_name: "pullRequestId"))
     PullRequestEvent.add_member(:event_date, Shapes::ShapeRef.new(shape: EventDate, location_name: "eventDate"))
@@ -1395,6 +1685,8 @@ module Aws::CodeCommit
 
     PullRequestIdList.member = Shapes::ShapeRef.new(shape: PullRequestId)
 
+    PullRequestIdRequiredException.struct_class = Types::PullRequestIdRequiredException
+
     PullRequestMergedStateChangedEventMetadata.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, location_name: "repositoryName"))
     PullRequestMergedStateChangedEventMetadata.add_member(:destination_reference, Shapes::ShapeRef.new(shape: ReferenceName, location_name: "destinationReference"))
     PullRequestMergedStateChangedEventMetadata.add_member(:merge_metadata, Shapes::ShapeRef.new(shape: MergeMetadata, location_name: "mergeMetadata"))
@@ -1408,6 +1700,8 @@ module Aws::CodeCommit
 
     PullRequestStatusChangedEventMetadata.add_member(:pull_request_status, Shapes::ShapeRef.new(shape: PullRequestStatusEnum, location_name: "pullRequestStatus"))
     PullRequestStatusChangedEventMetadata.struct_class = Types::PullRequestStatusChangedEventMetadata
+
+    PullRequestStatusRequiredException.struct_class = Types::PullRequestStatusRequiredException
 
     PullRequestTarget.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, location_name: "repositoryName"))
     PullRequestTarget.add_member(:source_reference, Shapes::ShapeRef.new(shape: ReferenceName, location_name: "sourceReference"))
@@ -1427,6 +1721,8 @@ module Aws::CodeCommit
     PutFileEntry.add_member(:file_content, Shapes::ShapeRef.new(shape: FileContent, location_name: "fileContent"))
     PutFileEntry.add_member(:source_file, Shapes::ShapeRef.new(shape: SourceFileSpecifier, location_name: "sourceFile"))
     PutFileEntry.struct_class = Types::PutFileEntry
+
+    PutFileEntryConflictException.struct_class = Types::PutFileEntryConflictException
 
     PutFileInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     PutFileInput.add_member(:branch_name, Shapes::ShapeRef.new(shape: BranchName, required: true, location_name: "branchName"))
@@ -1451,6 +1747,12 @@ module Aws::CodeCommit
     PutRepositoryTriggersOutput.add_member(:configuration_id, Shapes::ShapeRef.new(shape: RepositoryTriggersConfigurationId, location_name: "configurationId"))
     PutRepositoryTriggersOutput.struct_class = Types::PutRepositoryTriggersOutput
 
+    ReferenceDoesNotExistException.struct_class = Types::ReferenceDoesNotExistException
+
+    ReferenceNameRequiredException.struct_class = Types::ReferenceNameRequiredException
+
+    ReferenceTypeNotSupportedException.struct_class = Types::ReferenceTypeNotSupportedException
+
     ReplaceContentEntries.member = Shapes::ShapeRef.new(shape: ReplaceContentEntry)
 
     ReplaceContentEntry.add_member(:file_path, Shapes::ShapeRef.new(shape: Path, required: true, location_name: "filePath"))
@@ -1458,6 +1760,14 @@ module Aws::CodeCommit
     ReplaceContentEntry.add_member(:content, Shapes::ShapeRef.new(shape: FileContent, location_name: "content"))
     ReplaceContentEntry.add_member(:file_mode, Shapes::ShapeRef.new(shape: FileModeTypeEnum, location_name: "fileMode"))
     ReplaceContentEntry.struct_class = Types::ReplaceContentEntry
+
+    ReplacementContentRequiredException.struct_class = Types::ReplacementContentRequiredException
+
+    ReplacementTypeRequiredException.struct_class = Types::ReplacementTypeRequiredException
+
+    RepositoryDoesNotExistException.struct_class = Types::RepositoryDoesNotExistException
+
+    RepositoryLimitExceededException.struct_class = Types::RepositoryLimitExceededException
 
     RepositoryMetadata.add_member(:account_id, Shapes::ShapeRef.new(shape: AccountId, location_name: "accountId"))
     RepositoryMetadata.add_member(:repository_id, Shapes::ShapeRef.new(shape: RepositoryId, location_name: "repositoryId"))
@@ -1473,6 +1783,8 @@ module Aws::CodeCommit
 
     RepositoryMetadataList.member = Shapes::ShapeRef.new(shape: RepositoryMetadata)
 
+    RepositoryNameExistsException.struct_class = Types::RepositoryNameExistsException
+
     RepositoryNameIdPair.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, location_name: "repositoryName"))
     RepositoryNameIdPair.add_member(:repository_id, Shapes::ShapeRef.new(shape: RepositoryId, location_name: "repositoryId"))
     RepositoryNameIdPair.struct_class = Types::RepositoryNameIdPair
@@ -1480,6 +1792,12 @@ module Aws::CodeCommit
     RepositoryNameIdPairList.member = Shapes::ShapeRef.new(shape: RepositoryNameIdPair)
 
     RepositoryNameList.member = Shapes::ShapeRef.new(shape: RepositoryName)
+
+    RepositoryNameRequiredException.struct_class = Types::RepositoryNameRequiredException
+
+    RepositoryNamesRequiredException.struct_class = Types::RepositoryNamesRequiredException
+
+    RepositoryNotAssociatedWithPullRequestException.struct_class = Types::RepositoryNotAssociatedWithPullRequestException
 
     RepositoryNotFoundList.member = Shapes::ShapeRef.new(shape: RepositoryName)
 
@@ -1490,7 +1808,13 @@ module Aws::CodeCommit
     RepositoryTrigger.add_member(:events, Shapes::ShapeRef.new(shape: RepositoryTriggerEventList, required: true, location_name: "events"))
     RepositoryTrigger.struct_class = Types::RepositoryTrigger
 
+    RepositoryTriggerBranchNameListRequiredException.struct_class = Types::RepositoryTriggerBranchNameListRequiredException
+
+    RepositoryTriggerDestinationArnRequiredException.struct_class = Types::RepositoryTriggerDestinationArnRequiredException
+
     RepositoryTriggerEventList.member = Shapes::ShapeRef.new(shape: RepositoryTriggerEventEnum)
+
+    RepositoryTriggerEventsListRequiredException.struct_class = Types::RepositoryTriggerEventsListRequiredException
 
     RepositoryTriggerExecutionFailure.add_member(:trigger, Shapes::ShapeRef.new(shape: RepositoryTriggerName, location_name: "trigger"))
     RepositoryTriggerExecutionFailure.add_member(:failure_message, Shapes::ShapeRef.new(shape: RepositoryTriggerExecutionFailureMessage, location_name: "failureMessage"))
@@ -1500,13 +1824,33 @@ module Aws::CodeCommit
 
     RepositoryTriggerNameList.member = Shapes::ShapeRef.new(shape: RepositoryTriggerName)
 
+    RepositoryTriggerNameRequiredException.struct_class = Types::RepositoryTriggerNameRequiredException
+
     RepositoryTriggersList.member = Shapes::ShapeRef.new(shape: RepositoryTrigger)
+
+    RepositoryTriggersListRequiredException.struct_class = Types::RepositoryTriggersListRequiredException
+
+    ResourceArnRequiredException.struct_class = Types::ResourceArnRequiredException
+
+    RestrictedSourceFileException.struct_class = Types::RestrictedSourceFileException
+
+    RevisionIdRequiredException.struct_class = Types::RevisionIdRequiredException
+
+    RevisionNotCurrentException.struct_class = Types::RevisionNotCurrentException
+
+    SameFileContentException.struct_class = Types::SameFileContentException
+
+    SamePathRequestException.struct_class = Types::SamePathRequestException
 
     SetFileModeEntries.member = Shapes::ShapeRef.new(shape: SetFileModeEntry)
 
     SetFileModeEntry.add_member(:file_path, Shapes::ShapeRef.new(shape: Path, required: true, location_name: "filePath"))
     SetFileModeEntry.add_member(:file_mode, Shapes::ShapeRef.new(shape: FileModeTypeEnum, required: true, location_name: "fileMode"))
     SetFileModeEntry.struct_class = Types::SetFileModeEntry
+
+    SourceAndDestinationAreSameException.struct_class = Types::SourceAndDestinationAreSameException
+
+    SourceFileOrContentRequiredException.struct_class = Types::SourceFileOrContentRequiredException
 
     SourceFileSpecifier.add_member(:file_path, Shapes::ShapeRef.new(shape: Path, required: true, location_name: "filePath"))
     SourceFileSpecifier.add_member(:is_move, Shapes::ShapeRef.new(shape: IsMove, location_name: "isMove"))
@@ -1529,12 +1873,18 @@ module Aws::CodeCommit
 
     TagKeysList.member = Shapes::ShapeRef.new(shape: TagKey)
 
+    TagKeysListRequiredException.struct_class = Types::TagKeysListRequiredException
+
+    TagPolicyException.struct_class = Types::TagPolicyException
+
     TagResourceInput.add_member(:resource_arn, Shapes::ShapeRef.new(shape: ResourceArn, required: true, location_name: "resourceArn"))
     TagResourceInput.add_member(:tags, Shapes::ShapeRef.new(shape: TagsMap, required: true, location_name: "tags"))
     TagResourceInput.struct_class = Types::TagResourceInput
 
     TagsMap.key = Shapes::ShapeRef.new(shape: TagKey)
     TagsMap.value = Shapes::ShapeRef.new(shape: TagValue)
+
+    TagsMapRequiredException.struct_class = Types::TagsMapRequiredException
 
     Target.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     Target.add_member(:source_reference, Shapes::ShapeRef.new(shape: ReferenceName, required: true, location_name: "sourceReference"))
@@ -1543,6 +1893,10 @@ module Aws::CodeCommit
 
     TargetList.member = Shapes::ShapeRef.new(shape: Target)
 
+    TargetRequiredException.struct_class = Types::TargetRequiredException
+
+    TargetsRequiredException.struct_class = Types::TargetsRequiredException
+
     TestRepositoryTriggersInput.add_member(:repository_name, Shapes::ShapeRef.new(shape: RepositoryName, required: true, location_name: "repositoryName"))
     TestRepositoryTriggersInput.add_member(:triggers, Shapes::ShapeRef.new(shape: RepositoryTriggersList, required: true, location_name: "triggers"))
     TestRepositoryTriggersInput.struct_class = Types::TestRepositoryTriggersInput
@@ -1550,6 +1904,14 @@ module Aws::CodeCommit
     TestRepositoryTriggersOutput.add_member(:successful_executions, Shapes::ShapeRef.new(shape: RepositoryTriggerNameList, location_name: "successfulExecutions"))
     TestRepositoryTriggersOutput.add_member(:failed_executions, Shapes::ShapeRef.new(shape: RepositoryTriggerExecutionFailureList, location_name: "failedExecutions"))
     TestRepositoryTriggersOutput.struct_class = Types::TestRepositoryTriggersOutput
+
+    TipOfSourceReferenceIsDifferentException.struct_class = Types::TipOfSourceReferenceIsDifferentException
+
+    TipsDivergenceExceededException.struct_class = Types::TipsDivergenceExceededException
+
+    TitleRequiredException.struct_class = Types::TitleRequiredException
+
+    TooManyTagsException.struct_class = Types::TooManyTagsException
 
     UntagResourceInput.add_member(:resource_arn, Shapes::ShapeRef.new(shape: ResourceArn, required: true, location_name: "resourceArn"))
     UntagResourceInput.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeysList, required: true, location_name: "tagKeys"))

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
@@ -10,5 +10,1996 @@ module Aws::CodeCommit
 
     extend Aws::Errors::DynamicErrors
 
+    class ActorDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ActorDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleNameAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleNameAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleTemplateContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleTemplateContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleTemplateDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleTemplateDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleTemplateInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleTemplateInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleTemplateNameAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleTemplateNameAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalRuleTemplateNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalRuleTemplateNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalStateRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ApprovalStateRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::AuthorDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BeforeCommitIdAndAfterCommitIdAreSameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BeforeCommitIdAndAfterCommitIdAreSameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BlobIdDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BlobIdDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BlobIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BlobIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BranchDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BranchDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BranchNameExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BranchNameExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BranchNameIsTagNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BranchNameIsTagNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BranchNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::BranchNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CannotDeleteApprovalRuleFromTemplateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CannotDeleteApprovalRuleFromTemplateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CannotModifyApprovalRuleFromTemplateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CannotModifyApprovalRuleFromTemplateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClientRequestTokenRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ClientRequestTokenRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentContentSizeLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentContentSizeLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentDeletedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentDeletedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommentNotCreatedByCallerException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommentNotCreatedByCallerException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitIdDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitIdDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitIdsLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitIdsLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitIdsListRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitIdsListRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitMessageLengthExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitMessageLengthExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CommitRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::CommitRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ConcurrentReferenceUpdateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ConcurrentReferenceUpdateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DefaultBranchCannotBeDeletedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::DefaultBranchCannotBeDeletedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DirectoryNameConflictsWithFileNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::DirectoryNameConflictsWithFileNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EncryptionIntegrityChecksFailedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::EncryptionIntegrityChecksFailedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EncryptionKeyAccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::EncryptionKeyAccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EncryptionKeyDisabledException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::EncryptionKeyDisabledException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EncryptionKeyNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::EncryptionKeyNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EncryptionKeyUnavailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::EncryptionKeyUnavailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileContentAndSourceFileSpecifiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileContentAndSourceFileSpecifiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileContentSizeLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileContentSizeLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileEntryRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileEntryRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileModeRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileModeRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileNameConflictsWithDirectoryNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileNameConflictsWithDirectoryNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FilePathConflictsWithSubmodulePathException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FilePathConflictsWithSubmodulePathException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FileTooLargeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FileTooLargeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FolderContentSizeLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FolderContentSizeLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class FolderDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::FolderDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IdempotencyParameterMismatchException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::IdempotencyParameterMismatchException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidActorArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidActorArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalRuleContentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalRuleContentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalRuleNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalRuleNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalRuleTemplateContentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalRuleTemplateContentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalRuleTemplateDescriptionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalRuleTemplateDescriptionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalRuleTemplateNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalRuleTemplateNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidApprovalStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidAuthorArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidAuthorArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidBlobIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidBlobIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidBranchNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidBranchNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClientRequestTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidClientRequestTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCommentIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidCommentIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCommitException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidCommitException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCommitIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidCommitIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConflictDetailLevelException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidConflictDetailLevelException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConflictResolutionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidConflictResolutionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConflictResolutionStrategyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidConflictResolutionStrategyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidContinuationTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidContinuationTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeletionParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidDeletionParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDescriptionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidDescriptionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDestinationCommitSpecifierException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidDestinationCommitSpecifierException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEmailException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidEmailException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidFileLocationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidFileLocationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidFileModeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidFileModeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidFilePositionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidFilePositionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMaxConflictFilesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidMaxConflictFilesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMaxMergeHunksException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidMaxMergeHunksException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMaxResultsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidMaxResultsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMergeOptionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidMergeOptionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOrderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidOrderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOverrideStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidOverrideStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParentCommitIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidParentCommitIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPathException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidPathException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPullRequestEventTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidPullRequestEventTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPullRequestIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidPullRequestIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPullRequestStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidPullRequestStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPullRequestStatusUpdateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidPullRequestStatusUpdateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidReferenceNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidReferenceNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRelativeFileVersionEnumException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRelativeFileVersionEnumException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidReplacementContentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidReplacementContentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidReplacementTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidReplacementTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryDescriptionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryDescriptionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerBranchNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerBranchNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerCustomDataException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerCustomDataException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerDestinationArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerDestinationArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerEventsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerEventsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRepositoryTriggerRegionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRepositoryTriggerRegionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidResourceArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidResourceArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRevisionIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRevisionIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRuleContentSha256Exception < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidRuleContentSha256Exception] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSortByException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidSortByException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSourceCommitSpecifierException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidSourceCommitSpecifierException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSystemTagUsageException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidSystemTagUsageException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagKeysListException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTagKeysListException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagsMapException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTagsMapException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetBranchException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTargetBranchException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTargetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTargetsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTitleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::InvalidTitleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ManualMergeRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ManualMergeRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumBranchesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumBranchesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumConflictResolutionEntriesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumConflictResolutionEntriesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumFileContentToLoadExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumFileContentToLoadExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumFileEntriesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumFileEntriesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumItemsToCompareExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumItemsToCompareExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumNumberOfApprovalsExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumNumberOfApprovalsExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumOpenPullRequestsExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumOpenPullRequestsExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumRepositoryNamesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumRepositoryNamesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumRepositoryTriggersExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumRepositoryTriggersExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaximumRuleTemplatesAssociatedWithRepositoryException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MaximumRuleTemplatesAssociatedWithRepositoryException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MergeOptionRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MergeOptionRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MultipleConflictResolutionEntriesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MultipleConflictResolutionEntriesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MultipleRepositoriesInPullRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::MultipleRepositoriesInPullRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NameLengthExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::NameLengthExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoChangeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::NoChangeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NumberOfRuleTemplatesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::NumberOfRuleTemplatesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NumberOfRulesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::NumberOfRulesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OverrideAlreadySetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::OverrideAlreadySetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OverrideStatusRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::OverrideStatusRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParentCommitDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ParentCommitDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParentCommitIdOutdatedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ParentCommitIdOutdatedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParentCommitIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ParentCommitIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PathDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PathDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PathRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PathRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestAlreadyClosedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestAlreadyClosedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestApprovalRulesNotSatisfiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestApprovalRulesNotSatisfiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestCannotBeApprovedByAuthorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestCannotBeApprovedByAuthorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PullRequestStatusRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PullRequestStatusRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PutFileEntryConflictException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::PutFileEntryConflictException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReferenceDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ReferenceDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReferenceNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ReferenceNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReferenceTypeNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ReferenceTypeNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplacementContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ReplacementContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplacementTypeRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ReplacementTypeRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryNameExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryNameExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryNamesRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryNamesRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryNotAssociatedWithPullRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryNotAssociatedWithPullRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryTriggerBranchNameListRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryTriggerBranchNameListRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryTriggerDestinationArnRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryTriggerDestinationArnRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryTriggerEventsListRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryTriggerEventsListRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryTriggerNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryTriggerNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RepositoryTriggersListRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RepositoryTriggersListRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceArnRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::ResourceArnRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RestrictedSourceFileException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RestrictedSourceFileException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RevisionIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RevisionIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RevisionNotCurrentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::RevisionNotCurrentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SameFileContentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::SameFileContentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SamePathRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::SamePathRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceAndDestinationAreSameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::SourceAndDestinationAreSameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceFileOrContentRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::SourceFileOrContentRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagKeysListRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TagKeysListRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TagPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagsMapRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TagsMapRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TargetRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TargetRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TargetsRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TargetsRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TipOfSourceReferenceIsDifferentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TipOfSourceReferenceIsDifferentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TipsDivergenceExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TipsDivergenceExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TitleRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TitleRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeCommit::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
@@ -8,6 +8,13 @@
 module Aws::CodeCommit
   module Types
 
+    # The specified Amazon Resource Name (ARN) does not exist in the AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ActorDoesNotExistException AWS API Documentation
+    #
+    class ActorDoesNotExistException < Aws::EmptyStructure; end
+
     # Returns information about a specific approval on a pull request.
     #
     # @!attribute [rw] user_arn
@@ -77,6 +84,19 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The content for the approval rule is empty. You must provide some
+    # content for an approval rule. The content cannot be null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleContentRequiredException AWS API Documentation
+    #
+    class ApprovalRuleContentRequiredException < Aws::EmptyStructure; end
+
+    # The specified approval rule does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleDoesNotExistException AWS API Documentation
+    #
+    class ApprovalRuleDoesNotExistException < Aws::EmptyStructure; end
+
     # Returns information about an event for an approval rule.
     #
     # @!attribute [rw] approval_rule_name
@@ -99,6 +119,19 @@ module Aws::CodeCommit
       :approval_rule_content)
       include Aws::Structure
     end
+
+    # An approval rule with that name already exists. Approval rule names
+    # must be unique within the scope of a pull request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleNameAlreadyExistsException AWS API Documentation
+    #
+    class ApprovalRuleNameAlreadyExistsException < Aws::EmptyStructure; end
+
+    # An approval rule name is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleNameRequiredException AWS API Documentation
+    #
+    class ApprovalRuleNameRequiredException < Aws::EmptyStructure; end
 
     # Returns information about an override event for approval rules for a
     # pull request.
@@ -172,6 +205,44 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The content for the approval rule template is empty. You must provide
+    # some content for an approval rule template. The content cannot be
+    # null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleTemplateContentRequiredException AWS API Documentation
+    #
+    class ApprovalRuleTemplateContentRequiredException < Aws::EmptyStructure; end
+
+    # The specified approval rule template does not exist. Verify that the
+    # name is correct and that you are signed in to the AWS Region where the
+    # template was created, and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleTemplateDoesNotExistException AWS API Documentation
+    #
+    class ApprovalRuleTemplateDoesNotExistException < Aws::EmptyStructure; end
+
+    # The approval rule template is associated with one or more
+    # repositories. You cannot delete a template that is associated with a
+    # repository. Remove all associations, and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleTemplateInUseException AWS API Documentation
+    #
+    class ApprovalRuleTemplateInUseException < Aws::EmptyStructure; end
+
+    # You cannot create an approval rule template with that name because a
+    # template with that name already exists in this AWS Region for your AWS
+    # account. Approval rule template names must be unique.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleTemplateNameAlreadyExistsException AWS API Documentation
+    #
+    class ApprovalRuleTemplateNameAlreadyExistsException < Aws::EmptyStructure; end
+
+    # An approval rule template name is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalRuleTemplateNameRequiredException AWS API Documentation
+    #
+    class ApprovalRuleTemplateNameRequiredException < Aws::EmptyStructure; end
+
     # Returns information about a change in the approval state for a pull
     # request.
     #
@@ -190,6 +261,12 @@ module Aws::CodeCommit
       :approval_status)
       include Aws::Structure
     end
+
+    # An approval state is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ApprovalStateRequiredException AWS API Documentation
+    #
+    class ApprovalStateRequiredException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass AssociateApprovalRuleTemplateWithRepositoryInput
     #   data as a hash:
@@ -215,6 +292,13 @@ module Aws::CodeCommit
       :repository_name)
       include Aws::Structure
     end
+
+    # The specified Amazon Resource Name (ARN) does not exist in the AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/AuthorDoesNotExistException AWS API Documentation
+    #
+    class AuthorDoesNotExistException < Aws::EmptyStructure; end
 
     # Returns information about errors in a
     # BatchAssociateApprovalRuleTemplateWithRepositories operation.
@@ -636,6 +720,26 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The before commit ID and the after commit ID are the same, which is
+    # not valid. The before commit ID and the after commit ID must be
+    # different commit IDs.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BeforeCommitIdAndAfterCommitIdAreSameException AWS API Documentation
+    #
+    class BeforeCommitIdAndAfterCommitIdAreSameException < Aws::EmptyStructure; end
+
+    # The specified blob does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BlobIdDoesNotExistException AWS API Documentation
+    #
+    class BlobIdDoesNotExistException < Aws::EmptyStructure; end
+
+    # A blob ID is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BlobIdRequiredException AWS API Documentation
+    #
+    class BlobIdRequiredException < Aws::EmptyStructure; end
+
     # Returns information about a specific Git blob object.
     #
     # @!attribute [rw] blob_id
@@ -668,6 +772,12 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The specified branch does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BranchDoesNotExistException AWS API Documentation
+    #
+    class BranchDoesNotExistException < Aws::EmptyStructure; end
+
     # Returns information about a branch.
     #
     # @!attribute [rw] branch_name
@@ -685,6 +795,53 @@ module Aws::CodeCommit
       :commit_id)
       include Aws::Structure
     end
+
+    # The specified branch name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BranchNameExistsException AWS API Documentation
+    #
+    class BranchNameExistsException < Aws::EmptyStructure; end
+
+    # The specified branch name is not valid because it is a tag name. Enter
+    # the name of a branch in the repository. For a list of valid branch
+    # names, use ListBranches.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BranchNameIsTagNameException AWS API Documentation
+    #
+    class BranchNameIsTagNameException < Aws::EmptyStructure; end
+
+    # A branch name is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/BranchNameRequiredException AWS API Documentation
+    #
+    class BranchNameRequiredException < Aws::EmptyStructure; end
+
+    # The approval rule cannot be deleted from the pull request because it
+    # was created by an approval rule template and applied to the pull
+    # request automatically.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CannotDeleteApprovalRuleFromTemplateException AWS API Documentation
+    #
+    class CannotDeleteApprovalRuleFromTemplateException < Aws::EmptyStructure; end
+
+    # The approval rule cannot be modified for the pull request because it
+    # was created by an approval rule template and applied to the pull
+    # request automatically.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CannotModifyApprovalRuleFromTemplateException AWS API Documentation
+    #
+    class CannotModifyApprovalRuleFromTemplateException < Aws::EmptyStructure; end
+
+    # A client request token is required. A client request token is an
+    # unique, client-generated idempotency token that, when provided in a
+    # request, ensures the request cannot be repeated with a changed
+    # parameter. If a request is received with the same parameters and a
+    # token is included, the request returns information about the initial
+    # request that used that token.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ClientRequestTokenRequiredException AWS API Documentation
+    #
+    class ClientRequestTokenRequiredException < Aws::EmptyStructure; end
 
     # Returns information about a specific comment.
     #
@@ -738,6 +895,46 @@ module Aws::CodeCommit
       :client_request_token)
       include Aws::Structure
     end
+
+    # The comment is empty. You must provide some content for a comment. The
+    # content cannot be null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentContentRequiredException AWS API Documentation
+    #
+    class CommentContentRequiredException < Aws::EmptyStructure; end
+
+    # The comment is too large. Comments are limited to 1,000 characters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentContentSizeLimitExceededException AWS API Documentation
+    #
+    class CommentContentSizeLimitExceededException < Aws::EmptyStructure; end
+
+    # This comment has already been deleted. You cannot edit or delete a
+    # deleted comment.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentDeletedException AWS API Documentation
+    #
+    class CommentDeletedException < Aws::EmptyStructure; end
+
+    # No comment exists with the provided ID. Verify that you have used the
+    # correct ID, and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentDoesNotExistException AWS API Documentation
+    #
+    class CommentDoesNotExistException < Aws::EmptyStructure; end
+
+    # The comment ID is missing or null. A comment ID is required.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentIdRequiredException AWS API Documentation
+    #
+    class CommentIdRequiredException < Aws::EmptyStructure; end
+
+    # You cannot modify or delete this comment. Only comment authors can
+    # modify or delete their comments.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentNotCreatedByCallerException AWS API Documentation
+    #
+    class CommentNotCreatedByCallerException < Aws::EmptyStructure; end
 
     # Returns information about comments on the comparison between two
     # commits.
@@ -905,6 +1102,60 @@ module Aws::CodeCommit
       :additional_data)
       include Aws::Structure
     end
+
+    # The specified commit does not exist or no commit was specified, and
+    # the specified repository has no default branch.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitDoesNotExistException AWS API Documentation
+    #
+    class CommitDoesNotExistException < Aws::EmptyStructure; end
+
+    # The specified commit ID does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitIdDoesNotExistException AWS API Documentation
+    #
+    class CommitIdDoesNotExistException < Aws::EmptyStructure; end
+
+    # A commit ID was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitIdRequiredException AWS API Documentation
+    #
+    class CommitIdRequiredException < Aws::EmptyStructure; end
+
+    # The maximum number of allowed commit IDs in a batch request is 100.
+    # Verify that your batch requests contains no more than 100 commit IDs,
+    # and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitIdsLimitExceededException AWS API Documentation
+    #
+    class CommitIdsLimitExceededException < Aws::EmptyStructure; end
+
+    # A list of commit IDs is required, but was either not specified or the
+    # list was empty.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitIdsListRequiredException AWS API Documentation
+    #
+    class CommitIdsListRequiredException < Aws::EmptyStructure; end
+
+    # The commit message is too long. Provide a shorter string.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitMessageLengthExceededException AWS API Documentation
+    #
+    class CommitMessageLengthExceededException < Aws::EmptyStructure; end
+
+    # A commit was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommitRequiredException AWS API Documentation
+    #
+    class CommitRequiredException < Aws::EmptyStructure; end
+
+    # The merge cannot be completed because the target branch has been
+    # modified. Another user might have modified the target branch while the
+    # merge was in progress. Wait a few minutes, and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ConcurrentReferenceUpdateException AWS API Documentation
+    #
+    class ConcurrentReferenceUpdateException < Aws::EmptyStructure; end
 
     # Information about conflicts in a merge operation.
     #
@@ -1641,6 +1892,14 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The specified branch is the default branch for the repository, and
+    # cannot be deleted. To delete this branch, you must first set another
+    # branch as the default branch.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DefaultBranchCannotBeDeletedException AWS API Documentation
+    #
+    class DefaultBranchCannotBeDeletedException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass DeleteApprovalRuleTemplateInput
     #   data as a hash:
     #
@@ -2152,6 +2411,15 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # A file cannot be added to the repository because the specified path
+    # name has the same name as a file that already exists in this
+    # repository. Either provide a different name for the file, or specify a
+    # different path for the file.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DirectoryNameConflictsWithFileNameException AWS API Documentation
+    #
+    class DirectoryNameConflictsWithFileNameException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass DisassociateApprovalRuleTemplateFromRepositoryInput
     #   data as a hash:
     #
@@ -2177,6 +2445,36 @@ module Aws::CodeCommit
       :repository_name)
       include Aws::Structure
     end
+
+    # An encryption integrity check failed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/EncryptionIntegrityChecksFailedException AWS API Documentation
+    #
+    class EncryptionIntegrityChecksFailedException < Aws::EmptyStructure; end
+
+    # An encryption key could not be accessed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/EncryptionKeyAccessDeniedException AWS API Documentation
+    #
+    class EncryptionKeyAccessDeniedException < Aws::EmptyStructure; end
+
+    # The encryption key is disabled.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/EncryptionKeyDisabledException AWS API Documentation
+    #
+    class EncryptionKeyDisabledException < Aws::EmptyStructure; end
+
+    # No encryption key was found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/EncryptionKeyNotFoundException AWS API Documentation
+    #
+    class EncryptionKeyNotFoundException < Aws::EmptyStructure; end
+
+    # The encryption key is not available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/EncryptionKeyUnavailableException AWS API Documentation
+    #
+    class EncryptionKeyUnavailableException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass EvaluatePullRequestApprovalRulesInput
     #   data as a hash:
@@ -2279,6 +2577,44 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The commit cannot be created because both a source file and file
+    # content have been specified for the same file. You cannot provide
+    # both. Either specify a source file or provide the file content
+    # directly.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileContentAndSourceFileSpecifiedException AWS API Documentation
+    #
+    class FileContentAndSourceFileSpecifiedException < Aws::EmptyStructure; end
+
+    # The file cannot be added because it is empty. Empty files cannot be
+    # added to the repository with this API.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileContentRequiredException AWS API Documentation
+    #
+    class FileContentRequiredException < Aws::EmptyStructure; end
+
+    # The file cannot be added because it is too large. The maximum file
+    # size is 6 MB, and the combined file content change size is 7 MB.
+    # Consider making these changes using a Git client.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileContentSizeLimitExceededException AWS API Documentation
+    #
+    class FileContentSizeLimitExceededException < Aws::EmptyStructure; end
+
+    # The specified file does not exist. Verify that you have used the
+    # correct file name, full path, and extension.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileDoesNotExistException AWS API Documentation
+    #
+    class FileDoesNotExistException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because no files have been specified as
+    # added, updated, or changed (PutFile or DeleteFile) for the commit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileEntryRequiredException AWS API Documentation
+    #
+    class FileEntryRequiredException < Aws::EmptyStructure; end
+
     # A file to be added, updated, or deleted as part of a commit.
     #
     # @!attribute [rw] absolute_path
@@ -2304,6 +2640,13 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The commit cannot be created because no file mode has been specified.
+    # A file mode is required to update mode permissions for a file.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileModeRequiredException AWS API Documentation
+    #
+    class FileModeRequiredException < Aws::EmptyStructure; end
+
     # Information about file modes in a merge or pull request.
     #
     # @!attribute [rw] source
@@ -2328,6 +2671,23 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # A file cannot be added to the repository because the specified file
+    # name has the same name as a directory in this repository. Either
+    # provide another name for the file, or add the file in a directory that
+    # does not match the file name.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileNameConflictsWithDirectoryNameException AWS API Documentation
+    #
+    class FileNameConflictsWithDirectoryNameException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because a specified file path points to a
+    # submodule. Verify that the destination files have valid file paths
+    # that do not point to a submodule.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FilePathConflictsWithSubmodulePathException AWS API Documentation
+    #
+    class FilePathConflictsWithSubmodulePathException < Aws::EmptyStructure; end
+
     # Information about the size of files in a merge or pull request.
     #
     # @!attribute [rw] source
@@ -2350,6 +2710,18 @@ module Aws::CodeCommit
       :base)
       include Aws::Structure
     end
+
+    # The specified file exceeds the file size limit for AWS CodeCommit. For
+    # more information about limits in AWS CodeCommit, see [AWS CodeCommit
+    # User Guide][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FileTooLargeException AWS API Documentation
+    #
+    class FileTooLargeException < Aws::EmptyStructure; end
 
     # Returns information about a folder in a repository.
     #
@@ -2375,6 +2747,22 @@ module Aws::CodeCommit
       :relative_path)
       include Aws::Structure
     end
+
+    # The commit cannot be created because at least one of the overall
+    # changes in the commit results in a folder whose contents exceed the
+    # limit of 6 MB. Either reduce the number and size of your changes, or
+    # split the changes across multiple folders.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FolderContentSizeLimitExceededException AWS API Documentation
+    #
+    class FolderContentSizeLimitExceededException < Aws::EmptyStructure; end
+
+    # The specified folder does not exist. Either the folder name is not
+    # correct, or you did not enter the full path to the folder.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/FolderDoesNotExistException AWS API Documentation
+    #
+    class FolderDoesNotExistException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass GetApprovalRuleTemplateInput
     #   data as a hash:
@@ -3392,6 +3780,454 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The client request token is not valid. Either the token is not in a
+    # valid format, or the token has been used in a previous request and
+    # cannot be reused.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/IdempotencyParameterMismatchException AWS API Documentation
+    #
+    class IdempotencyParameterMismatchException < Aws::EmptyStructure; end
+
+    # The Amazon Resource Name (ARN) is not valid. Make sure that you have
+    # provided the full ARN for the user who initiated the change for the
+    # pull request, and then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidActorArnException AWS API Documentation
+    #
+    class InvalidActorArnException < Aws::EmptyStructure; end
+
+    # The content for the approval rule is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalRuleContentException AWS API Documentation
+    #
+    class InvalidApprovalRuleContentException < Aws::EmptyStructure; end
+
+    # The name for the approval rule is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalRuleNameException AWS API Documentation
+    #
+    class InvalidApprovalRuleNameException < Aws::EmptyStructure; end
+
+    # The content of the approval rule template is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalRuleTemplateContentException AWS API Documentation
+    #
+    class InvalidApprovalRuleTemplateContentException < Aws::EmptyStructure; end
+
+    # The description for the approval rule template is not valid because it
+    # exceeds the maximum characters allowed for a description. For more
+    # information about limits in AWS CodeCommit, see [AWS CodeCommit User
+    # Guide][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalRuleTemplateDescriptionException AWS API Documentation
+    #
+    class InvalidApprovalRuleTemplateDescriptionException < Aws::EmptyStructure; end
+
+    # The name of the approval rule template is not valid. Template names
+    # must be between 1 and 100 valid characters in length. For more
+    # information about limits in AWS CodeCommit, see [AWS CodeCommit User
+    # Guide][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalRuleTemplateNameException AWS API Documentation
+    #
+    class InvalidApprovalRuleTemplateNameException < Aws::EmptyStructure; end
+
+    # The state for the approval is not valid. Valid values include APPROVE
+    # and REVOKE.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidApprovalStateException AWS API Documentation
+    #
+    class InvalidApprovalStateException < Aws::EmptyStructure; end
+
+    # The Amazon Resource Name (ARN) is not valid. Make sure that you have
+    # provided the full ARN for the author of the pull request, and then try
+    # again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidAuthorArnException AWS API Documentation
+    #
+    class InvalidAuthorArnException < Aws::EmptyStructure; end
+
+    # The specified blob is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidBlobIdException AWS API Documentation
+    #
+    class InvalidBlobIdException < Aws::EmptyStructure; end
+
+    # The specified reference name is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidBranchNameException AWS API Documentation
+    #
+    class InvalidBranchNameException < Aws::EmptyStructure; end
+
+    # The client request token is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidClientRequestTokenException AWS API Documentation
+    #
+    class InvalidClientRequestTokenException < Aws::EmptyStructure; end
+
+    # The comment ID is not in a valid format. Make sure that you have
+    # provided the full comment ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidCommentIdException AWS API Documentation
+    #
+    class InvalidCommentIdException < Aws::EmptyStructure; end
+
+    # The specified commit is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidCommitException AWS API Documentation
+    #
+    class InvalidCommitException < Aws::EmptyStructure; end
+
+    # The specified commit ID is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidCommitIdException AWS API Documentation
+    #
+    class InvalidCommitIdException < Aws::EmptyStructure; end
+
+    # The specified conflict detail level is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidConflictDetailLevelException AWS API Documentation
+    #
+    class InvalidConflictDetailLevelException < Aws::EmptyStructure; end
+
+    # The specified conflict resolution list is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidConflictResolutionException AWS API Documentation
+    #
+    class InvalidConflictResolutionException < Aws::EmptyStructure; end
+
+    # The specified conflict resolution strategy is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidConflictResolutionStrategyException AWS API Documentation
+    #
+    class InvalidConflictResolutionStrategyException < Aws::EmptyStructure; end
+
+    # The specified continuation token is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidContinuationTokenException AWS API Documentation
+    #
+    class InvalidContinuationTokenException < Aws::EmptyStructure; end
+
+    # The specified deletion parameter is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidDeletionParameterException AWS API Documentation
+    #
+    class InvalidDeletionParameterException < Aws::EmptyStructure; end
+
+    # The pull request description is not valid. Descriptions cannot be more
+    # than 1,000 characters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidDescriptionException AWS API Documentation
+    #
+    class InvalidDescriptionException < Aws::EmptyStructure; end
+
+    # The destination commit specifier is not valid. You must provide a
+    # valid branch name, tag, or full commit ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidDestinationCommitSpecifierException AWS API Documentation
+    #
+    class InvalidDestinationCommitSpecifierException < Aws::EmptyStructure; end
+
+    # The specified email address either contains one or more characters
+    # that are not allowed, or it exceeds the maximum number of characters
+    # allowed for an email address.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidEmailException AWS API Documentation
+    #
+    class InvalidEmailException < Aws::EmptyStructure; end
+
+    # The location of the file is not valid. Make sure that you include the
+    # file name and extension.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidFileLocationException AWS API Documentation
+    #
+    class InvalidFileLocationException < Aws::EmptyStructure; end
+
+    # The specified file mode permission is not valid. For a list of valid
+    # file mode permissions, see PutFile.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidFileModeException AWS API Documentation
+    #
+    class InvalidFileModeException < Aws::EmptyStructure; end
+
+    # The position is not valid. Make sure that the line number exists in
+    # the version of the file you want to comment on.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidFilePositionException AWS API Documentation
+    #
+    class InvalidFilePositionException < Aws::EmptyStructure; end
+
+    # The specified value for the number of conflict files to return is not
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidMaxConflictFilesException AWS API Documentation
+    #
+    class InvalidMaxConflictFilesException < Aws::EmptyStructure; end
+
+    # The specified value for the number of merge hunks to return is not
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidMaxMergeHunksException AWS API Documentation
+    #
+    class InvalidMaxMergeHunksException < Aws::EmptyStructure; end
+
+    # The specified number of maximum results is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidMaxResultsException AWS API Documentation
+    #
+    class InvalidMaxResultsException < Aws::EmptyStructure; end
+
+    # The specified merge option is not valid for this operation. Not all
+    # merge strategies are supported for all operations.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidMergeOptionException AWS API Documentation
+    #
+    class InvalidMergeOptionException < Aws::EmptyStructure; end
+
+    # The specified sort order is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidOrderException AWS API Documentation
+    #
+    class InvalidOrderException < Aws::EmptyStructure; end
+
+    # The override status is not valid. Valid statuses are OVERRIDE and
+    # REVOKE.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidOverrideStatusException AWS API Documentation
+    #
+    class InvalidOverrideStatusException < Aws::EmptyStructure; end
+
+    # The parent commit ID is not valid. The commit ID cannot be empty, and
+    # must match the head commit ID for the branch of the repository where
+    # you want to add or update a file.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidParentCommitIdException AWS API Documentation
+    #
+    class InvalidParentCommitIdException < Aws::EmptyStructure; end
+
+    # The specified path is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidPathException AWS API Documentation
+    #
+    class InvalidPathException < Aws::EmptyStructure; end
+
+    # The pull request event type is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidPullRequestEventTypeException AWS API Documentation
+    #
+    class InvalidPullRequestEventTypeException < Aws::EmptyStructure; end
+
+    # The pull request ID is not valid. Make sure that you have provided the
+    # full ID and that the pull request is in the specified repository, and
+    # then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidPullRequestIdException AWS API Documentation
+    #
+    class InvalidPullRequestIdException < Aws::EmptyStructure; end
+
+    # The pull request status is not valid. The only valid values are `OPEN`
+    # and `CLOSED`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidPullRequestStatusException AWS API Documentation
+    #
+    class InvalidPullRequestStatusException < Aws::EmptyStructure; end
+
+    # The pull request status update is not valid. The only valid update is
+    # from `OPEN` to `CLOSED`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidPullRequestStatusUpdateException AWS API Documentation
+    #
+    class InvalidPullRequestStatusUpdateException < Aws::EmptyStructure; end
+
+    # The specified reference name format is not valid. Reference names must
+    # conform to the Git references format (for example, refs/heads/master).
+    # For more information, see [Git Internals - Git References][1] or
+    # consult your Git documentation.
+    #
+    #
+    #
+    # [1]: https://git-scm.com/book/en/v2/Git-Internals-Git-References
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidReferenceNameException AWS API Documentation
+    #
+    class InvalidReferenceNameException < Aws::EmptyStructure; end
+
+    # Either the enum is not in a valid format, or the specified file
+    # version enum is not valid in respect to the current file version.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRelativeFileVersionEnumException AWS API Documentation
+    #
+    class InvalidRelativeFileVersionEnumException < Aws::EmptyStructure; end
+
+    # Automerge was specified for resolving the conflict, but the
+    # replacement type is not valid or content is missing.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidReplacementContentException AWS API Documentation
+    #
+    class InvalidReplacementContentException < Aws::EmptyStructure; end
+
+    # Automerge was specified for resolving the conflict, but the specified
+    # replacement type is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidReplacementTypeException AWS API Documentation
+    #
+    class InvalidReplacementTypeException < Aws::EmptyStructure; end
+
+    # The specified repository description is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryDescriptionException AWS API Documentation
+    #
+    class InvalidRepositoryDescriptionException < Aws::EmptyStructure; end
+
+    # A specified repository name is not valid.
+    #
+    # <note markdown="1"> This exception occurs only when a specified repository name is not
+    # valid. Other exceptions occur when a required repository parameter is
+    # missing, or when a specified repository does not exist.
+    #
+    #  </note>
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryNameException AWS API Documentation
+    #
+    class InvalidRepositoryNameException < Aws::EmptyStructure; end
+
+    # One or more branch names specified for the trigger is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerBranchNameException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerBranchNameException < Aws::EmptyStructure; end
+
+    # The custom data provided for the trigger is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerCustomDataException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerCustomDataException < Aws::EmptyStructure; end
+
+    # The Amazon Resource Name (ARN) for the trigger is not valid for the
+    # specified destination. The most common reason for this error is that
+    # the ARN does not meet the requirements for the service type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerDestinationArnException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerDestinationArnException < Aws::EmptyStructure; end
+
+    # One or more events specified for the trigger is not valid. Check to
+    # make sure that all events specified match the requirements for allowed
+    # events.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerEventsException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerEventsException < Aws::EmptyStructure; end
+
+    # The name of the trigger is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerNameException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerNameException < Aws::EmptyStructure; end
+
+    # The AWS Region for the trigger target does not match the AWS Region
+    # for the repository. Triggers must be created in the same Region as the
+    # target for the trigger.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRepositoryTriggerRegionException AWS API Documentation
+    #
+    class InvalidRepositoryTriggerRegionException < Aws::EmptyStructure; end
+
+    # The value for the resource ARN is not valid. For more information
+    # about resources in AWS CodeCommit, see [CodeCommit Resources and
+    # Operations][1] in the AWS CodeCommit User Guide.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-access-control-identity-based.html#arn-formats
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidResourceArnException AWS API Documentation
+    #
+    class InvalidResourceArnException < Aws::EmptyStructure; end
+
+    # The revision ID is not valid. Use GetPullRequest to determine the
+    # value.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRevisionIdException AWS API Documentation
+    #
+    class InvalidRevisionIdException < Aws::EmptyStructure; end
+
+    # The SHA-256 hash signature for the rule content is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidRuleContentSha256Exception AWS API Documentation
+    #
+    class InvalidRuleContentSha256Exception < Aws::EmptyStructure; end
+
+    # The specified sort by value is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidSortByException AWS API Documentation
+    #
+    class InvalidSortByException < Aws::EmptyStructure; end
+
+    # The source commit specifier is not valid. You must provide a valid
+    # branch name, tag, or full commit ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidSourceCommitSpecifierException AWS API Documentation
+    #
+    class InvalidSourceCommitSpecifierException < Aws::EmptyStructure; end
+
+    # The specified tag is not valid. Key names cannot be prefixed with
+    # aws:.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidSystemTagUsageException AWS API Documentation
+    #
+    class InvalidSystemTagUsageException < Aws::EmptyStructure; end
+
+    # The list of tags is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTagKeysListException AWS API Documentation
+    #
+    class InvalidTagKeysListException < Aws::EmptyStructure; end
+
+    # The map of tags is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTagsMapException AWS API Documentation
+    #
+    class InvalidTagsMapException < Aws::EmptyStructure; end
+
+    # The specified target branch is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTargetBranchException AWS API Documentation
+    #
+    class InvalidTargetBranchException < Aws::EmptyStructure; end
+
+    # The target for the pull request is not valid. A target must contain
+    # the full values for the repository name, source branch, and
+    # destination branch for the pull request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTargetException AWS API Documentation
+    #
+    class InvalidTargetException < Aws::EmptyStructure; end
+
+    # The targets for the pull request is not valid or not in a valid
+    # format. Targets are a list of target objects. Each target object must
+    # contain the full values for the repository name, source branch, and
+    # destination branch for a pull request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTargetsException AWS API Documentation
+    #
+    class InvalidTargetsException < Aws::EmptyStructure; end
+
+    # The title of the pull request is not valid. Pull request titles cannot
+    # exceed 100 characters in length.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/InvalidTitleException AWS API Documentation
+    #
+    class InvalidTitleException < Aws::EmptyStructure; end
+
     # Information about whether a file is binary or textual in a merge or
     # pull request operation.
     #
@@ -3809,6 +4645,84 @@ module Aws::CodeCommit
       :relative_file_version)
       include Aws::Structure
     end
+
+    # The pull request cannot be merged automatically into the destination
+    # branch. You must manually merge the branches and resolve any
+    # conflicts.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ManualMergeRequiredException AWS API Documentation
+    #
+    class ManualMergeRequiredException < Aws::EmptyStructure; end
+
+    # The number of branches for the trigger was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumBranchesExceededException AWS API Documentation
+    #
+    class MaximumBranchesExceededException < Aws::EmptyStructure; end
+
+    # The number of allowed conflict resolution entries was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumConflictResolutionEntriesExceededException AWS API Documentation
+    #
+    class MaximumConflictResolutionEntriesExceededException < Aws::EmptyStructure; end
+
+    # The number of files to load exceeds the allowed limit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumFileContentToLoadExceededException AWS API Documentation
+    #
+    class MaximumFileContentToLoadExceededException < Aws::EmptyStructure; end
+
+    # The number of specified files to change as part of this commit exceeds
+    # the maximum number of files that can be changed in a single commit.
+    # Consider using a Git client for these changes.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumFileEntriesExceededException AWS API Documentation
+    #
+    class MaximumFileEntriesExceededException < Aws::EmptyStructure; end
+
+    # The number of items to compare between the source or destination
+    # branches and the merge base has exceeded the maximum allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumItemsToCompareExceededException AWS API Documentation
+    #
+    class MaximumItemsToCompareExceededException < Aws::EmptyStructure; end
+
+    # The number of approvals required for the approval rule exceeds the
+    # maximum number allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumNumberOfApprovalsExceededException AWS API Documentation
+    #
+    class MaximumNumberOfApprovalsExceededException < Aws::EmptyStructure; end
+
+    # You cannot create the pull request because the repository has too many
+    # open pull requests. The maximum number of open pull requests for a
+    # repository is 1,000. Close one or more open pull requests, and then
+    # try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumOpenPullRequestsExceededException AWS API Documentation
+    #
+    class MaximumOpenPullRequestsExceededException < Aws::EmptyStructure; end
+
+    # The maximum number of allowed repository names was exceeded.
+    # Currently, this number is 100.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumRepositoryNamesExceededException AWS API Documentation
+    #
+    class MaximumRepositoryNamesExceededException < Aws::EmptyStructure; end
+
+    # The number of triggers allowed for the repository was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumRepositoryTriggersExceededException AWS API Documentation
+    #
+    class MaximumRepositoryTriggersExceededException < Aws::EmptyStructure; end
+
+    # The maximum number of approval rule templates for a repository has
+    # been exceeded. You cannot associate more than 25 approval rule
+    # templates with a repository.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MaximumRuleTemplatesAssociatedWithRepositoryException AWS API Documentation
+    #
+    class MaximumRuleTemplatesAssociatedWithRepositoryException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass MergeBranchesByFastForwardInput
     #   data as a hash:
@@ -4232,6 +5146,12 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # A merge option or stategy is required, and none was provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergeOptionRequiredException AWS API Documentation
+    #
+    class MergeOptionRequiredException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass MergePullRequestByFastForwardInput
     #   data as a hash:
     #
@@ -4517,6 +5437,50 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # More than one conflict resolution entries exists for the conflict. A
+    # conflict can have only one conflict resolution entry.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MultipleConflictResolutionEntriesException AWS API Documentation
+    #
+    class MultipleConflictResolutionEntriesException < Aws::EmptyStructure; end
+
+    # You cannot include more than one repository in a pull request. Make
+    # sure you have specified only one repository name in your request, and
+    # then try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MultipleRepositoriesInPullRequestException AWS API Documentation
+    #
+    class MultipleRepositoriesInPullRequestException < Aws::EmptyStructure; end
+
+    # The user name is not valid because it has exceeded the character limit
+    # for author names.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/NameLengthExceededException AWS API Documentation
+    #
+    class NameLengthExceededException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because no changes will be made to the
+    # repository as a result of this commit. A commit must contain at least
+    # one change.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/NoChangeException AWS API Documentation
+    #
+    class NoChangeException < Aws::EmptyStructure; end
+
+    # The maximum number of approval rule templates has been exceeded for
+    # this AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/NumberOfRuleTemplatesExceededException AWS API Documentation
+    #
+    class NumberOfRuleTemplatesExceededException < Aws::EmptyStructure; end
+
+    # The approval rule cannot be added. The pull request has the maximum
+    # number of approval rules associated with it.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/NumberOfRulesExceededException AWS API Documentation
+    #
+    class NumberOfRulesExceededException < Aws::EmptyStructure; end
+
     # Information about the type of an object in a merge operation.
     #
     # @!attribute [rw] source
@@ -4559,6 +5523,12 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The pull request has already had its approval rules set to override.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/OverrideAlreadySetException AWS API Documentation
+    #
+    class OverrideAlreadySetException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass OverridePullRequestApprovalRulesInput
     #   data as a hash:
     #
@@ -4595,6 +5565,49 @@ module Aws::CodeCommit
       :override_status)
       include Aws::Structure
     end
+
+    # An override status is required, but no value was provided. Valid
+    # values include OVERRIDE and REVOKE.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/OverrideStatusRequiredException AWS API Documentation
+    #
+    class OverrideStatusRequiredException < Aws::EmptyStructure; end
+
+    # The parent commit ID is not valid because it does not exist. The
+    # specified parent commit ID does not exist in the specified branch of
+    # the repository.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ParentCommitDoesNotExistException AWS API Documentation
+    #
+    class ParentCommitDoesNotExistException < Aws::EmptyStructure; end
+
+    # The file could not be added because the provided parent commit ID is
+    # not the current tip of the specified branch. To view the full commit
+    # ID of the current head of the branch, use GetBranch.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ParentCommitIdOutdatedException AWS API Documentation
+    #
+    class ParentCommitIdOutdatedException < Aws::EmptyStructure; end
+
+    # A parent commit ID is required. To view the full commit ID of a branch
+    # in a repository, use GetBranch or a Git command (for example, git pull
+    # or git log).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ParentCommitIdRequiredException AWS API Documentation
+    #
+    class ParentCommitIdRequiredException < Aws::EmptyStructure; end
+
+    # The specified path does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PathDoesNotExistException AWS API Documentation
+    #
+    class PathDoesNotExistException < Aws::EmptyStructure; end
+
+    # The folderPath for a location cannot be null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PathRequiredException AWS API Documentation
+    #
+    class PathRequiredException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PostCommentForComparedCommitInput
     #   data as a hash:
@@ -4956,6 +5969,28 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The pull request status cannot be updated because it is already
+    # closed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestAlreadyClosedException AWS API Documentation
+    #
+    class PullRequestAlreadyClosedException < Aws::EmptyStructure; end
+
+    # The pull request cannot be merged because one or more approval rules
+    # applied to the pull request have conditions that have not been met.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestApprovalRulesNotSatisfiedException AWS API Documentation
+    #
+    class PullRequestApprovalRulesNotSatisfiedException < Aws::EmptyStructure; end
+
+    # The approval cannot be applied because the user approving the pull
+    # request matches the user who created the pull request. You cannot
+    # approve a pull request that you created.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestCannotBeApprovedByAuthorException AWS API Documentation
+    #
+    class PullRequestCannotBeApprovedByAuthorException < Aws::EmptyStructure; end
+
     # Metadata about the pull request that is used when comparing the pull
     # request source with its destination.
     #
@@ -4987,6 +6022,14 @@ module Aws::CodeCommit
       :merge_base)
       include Aws::Structure
     end
+
+    # The pull request ID could not be found. Make sure that you have
+    # specified the correct repository name and pull request ID, and then
+    # try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestDoesNotExistException AWS API Documentation
+    #
+    class PullRequestDoesNotExistException < Aws::EmptyStructure; end
 
     # Returns information about a pull request event.
     #
@@ -5059,6 +6102,12 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # A pull request ID is required, but none was provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestIdRequiredException AWS API Documentation
+    #
+    class PullRequestIdRequiredException < Aws::EmptyStructure; end
+
     # Returns information about the change in the merge state for a pull
     # request event.
     #
@@ -5126,6 +6175,12 @@ module Aws::CodeCommit
       :pull_request_status)
       include Aws::Structure
     end
+
+    # A pull request status is required, but none was provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestStatusRequiredException AWS API Documentation
+    #
+    class PullRequestStatusRequiredException < Aws::EmptyStructure; end
 
     # Returns information about a pull request target.
     #
@@ -5223,6 +6278,13 @@ module Aws::CodeCommit
       :source_file)
       include Aws::Structure
     end
+
+    # The commit cannot be created because one or more files specified in
+    # the commit reference both a file and a folder.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PutFileEntryConflictException AWS API Documentation
+    #
+    class PutFileEntryConflictException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PutFileInput
     #   data as a hash:
@@ -5379,6 +6441,25 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The specified reference does not exist. You must provide a full commit
+    # ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ReferenceDoesNotExistException AWS API Documentation
+    #
+    class ReferenceDoesNotExistException < Aws::EmptyStructure; end
+
+    # A reference name is required, but none was provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ReferenceNameRequiredException AWS API Documentation
+    #
+    class ReferenceNameRequiredException < Aws::EmptyStructure; end
+
+    # The specified reference is not a supported type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ReferenceTypeNotSupportedException AWS API Documentation
+    #
+    class ReferenceTypeNotSupportedException < Aws::EmptyStructure; end
+
     # Information about a replacement content entry in the conflict of a
     # merge or pull request operation.
     #
@@ -5419,6 +6500,31 @@ module Aws::CodeCommit
       :file_mode)
       include Aws::Structure
     end
+
+    # USE\_NEW\_CONTENT was specified, but no replacement content has been
+    # provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ReplacementContentRequiredException AWS API Documentation
+    #
+    class ReplacementContentRequiredException < Aws::EmptyStructure; end
+
+    # A replacement type is required.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ReplacementTypeRequiredException AWS API Documentation
+    #
+    class ReplacementTypeRequiredException < Aws::EmptyStructure; end
+
+    # The specified repository does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryDoesNotExistException AWS API Documentation
+    #
+    class RepositoryDoesNotExistException < Aws::EmptyStructure; end
+
+    # A repository resource limit was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryLimitExceededException AWS API Documentation
+    #
+    class RepositoryLimitExceededException < Aws::EmptyStructure; end
 
     # Information about a repository.
     #
@@ -5479,6 +6585,12 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # The specified repository name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryNameExistsException AWS API Documentation
+    #
+    class RepositoryNameExistsException < Aws::EmptyStructure; end
+
     # Information about a repository name and ID.
     #
     # @!attribute [rw] repository_name
@@ -5496,6 +6608,27 @@ module Aws::CodeCommit
       :repository_id)
       include Aws::Structure
     end
+
+    # A repository name is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryNameRequiredException AWS API Documentation
+    #
+    class RepositoryNameRequiredException < Aws::EmptyStructure; end
+
+    # At least one repository name object is required, but was not
+    # specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryNamesRequiredException AWS API Documentation
+    #
+    class RepositoryNamesRequiredException < Aws::EmptyStructure; end
+
+    # The repository does not contain any pull requests with that pull
+    # request ID. Use GetPullRequest to verify the correct repository name
+    # for the pull request ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryNotAssociatedWithPullRequestException AWS API Documentation
+    #
+    class RepositoryNotAssociatedWithPullRequestException < Aws::EmptyStructure; end
 
     # Information about a trigger for a repository.
     #
@@ -5554,6 +6687,26 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # At least one branch name is required, but was not specified in the
+    # trigger configuration.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryTriggerBranchNameListRequiredException AWS API Documentation
+    #
+    class RepositoryTriggerBranchNameListRequiredException < Aws::EmptyStructure; end
+
+    # A destination ARN for the target service for the trigger is required,
+    # but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryTriggerDestinationArnRequiredException AWS API Documentation
+    #
+    class RepositoryTriggerDestinationArnRequiredException < Aws::EmptyStructure; end
+
+    # At least one event for the trigger is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryTriggerEventsListRequiredException AWS API Documentation
+    #
+    class RepositoryTriggerEventsListRequiredException < Aws::EmptyStructure; end
+
     # A trigger failed to run.
     #
     # @!attribute [rw] trigger
@@ -5571,6 +6724,70 @@ module Aws::CodeCommit
       :failure_message)
       include Aws::Structure
     end
+
+    # A name for the trigger is required, but was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryTriggerNameRequiredException AWS API Documentation
+    #
+    class RepositoryTriggerNameRequiredException < Aws::EmptyStructure; end
+
+    # The list of triggers for the repository is required, but was not
+    # specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RepositoryTriggersListRequiredException AWS API Documentation
+    #
+    class RepositoryTriggersListRequiredException < Aws::EmptyStructure; end
+
+    # A valid Amazon Resource Name (ARN) for an AWS CodeCommit resource is
+    # required. For a list of valid resources in AWS CodeCommit, see
+    # [CodeCommit Resources and Operations][1] in the AWS CodeCommit User
+    # Guide.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-access-control-identity-based.html#arn-formats
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ResourceArnRequiredException AWS API Documentation
+    #
+    class ResourceArnRequiredException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because one of the changes specifies
+    # copying or moving a .gitkeep file.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RestrictedSourceFileException AWS API Documentation
+    #
+    class RestrictedSourceFileException < Aws::EmptyStructure; end
+
+    # A revision ID is required, but was not provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RevisionIdRequiredException AWS API Documentation
+    #
+    class RevisionIdRequiredException < Aws::EmptyStructure; end
+
+    # The revision ID provided in the request does not match the current
+    # revision ID. Use GetPullRequest to retrieve the current revision ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/RevisionNotCurrentException AWS API Documentation
+    #
+    class RevisionNotCurrentException < Aws::EmptyStructure; end
+
+    # The file was not added or updated because the content of the file is
+    # exactly the same as the content of that file in the repository and
+    # branch that you specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/SameFileContentException AWS API Documentation
+    #
+    class SameFileContentException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because one or more changes in this
+    # commit duplicate actions in the same file path. For example, you
+    # cannot make the same delete request to the same file in the same file
+    # path twice, or make a delete request and a move request to the same
+    # file as part of the same commit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/SamePathRequestException AWS API Documentation
+    #
+    class SamePathRequestException < Aws::EmptyStructure; end
 
     # Information about the file mode changes.
     #
@@ -5597,6 +6814,21 @@ module Aws::CodeCommit
       :file_mode)
       include Aws::Structure
     end
+
+    # The source branch and destination branch for the pull request are the
+    # same. You must specify different branches for the source and
+    # destination.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/SourceAndDestinationAreSameException AWS API Documentation
+    #
+    class SourceAndDestinationAreSameException < Aws::EmptyStructure; end
+
+    # The commit cannot be created because no source files or file content
+    # have been specified for the commit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/SourceFileOrContentRequiredException AWS API Documentation
+    #
+    class SourceFileOrContentRequiredException < Aws::EmptyStructure; end
 
     # Information about a source file that is part of changes made in a
     # commit.
@@ -5682,6 +6914,18 @@ module Aws::CodeCommit
       include Aws::Structure
     end
 
+    # A list of tag keys is required. The list cannot be empty or null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TagKeysListRequiredException AWS API Documentation
+    #
+    class TagKeysListRequiredException < Aws::EmptyStructure; end
+
+    # The tag policy is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TagPolicyException AWS API Documentation
+    #
+    class TagPolicyException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass TagResourceInput
     #   data as a hash:
     #
@@ -5708,6 +6952,12 @@ module Aws::CodeCommit
       :tags)
       include Aws::Structure
     end
+
+    # A map of tags is required.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TagsMapRequiredException AWS API Documentation
+    #
+    class TagsMapRequiredException < Aws::EmptyStructure; end
 
     # Returns information about a target for a pull request.
     #
@@ -5742,6 +6992,20 @@ module Aws::CodeCommit
       :destination_reference)
       include Aws::Structure
     end
+
+    # A pull request target is required. It cannot be empty or null. A pull
+    # request target must contain the full values for the repository name,
+    # source branch, and destination branch for the pull request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TargetRequiredException AWS API Documentation
+    #
+    class TargetRequiredException < Aws::EmptyStructure; end
+
+    # An array of target objects is required. It cannot be empty or null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TargetsRequiredException AWS API Documentation
+    #
+    class TargetsRequiredException < Aws::EmptyStructure; end
 
     # Represents the input of a test repository triggers operation.
     #
@@ -5797,6 +7061,36 @@ module Aws::CodeCommit
       :failed_executions)
       include Aws::Structure
     end
+
+    # The tip of the source branch in the destination repository does not
+    # match the tip of the source branch specified in your request. The pull
+    # request might have been updated. Make sure that you have the latest
+    # changes.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TipOfSourceReferenceIsDifferentException AWS API Documentation
+    #
+    class TipOfSourceReferenceIsDifferentException < Aws::EmptyStructure; end
+
+    # The divergence between the tips of the provided commit specifiers is
+    # too great to determine whether there might be any merge conflicts.
+    # Locally compare the specifiers using `git diff` or a diff tool.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TipsDivergenceExceededException AWS API Documentation
+    #
+    class TipsDivergenceExceededException < Aws::EmptyStructure; end
+
+    # A pull request title is required. It cannot be empty or null.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TitleRequiredException AWS API Documentation
+    #
+    class TitleRequiredException < Aws::EmptyStructure; end
+
+    # The maximum number of tags for an AWS CodeCommit resource has been
+    # exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagResourceInput
     #   data as a hash:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
@@ -409,9 +409,15 @@ module Aws::CodeDeploy
 
     AlarmList.member = Shapes::ShapeRef.new(shape: Alarm)
 
+    AlarmsLimitExceededException.struct_class = Types::AlarmsLimitExceededException
+
     AppSpecContent.add_member(:content, Shapes::ShapeRef.new(shape: RawStringContent, location_name: "content"))
     AppSpecContent.add_member(:sha256, Shapes::ShapeRef.new(shape: RawStringSha256, location_name: "sha256"))
     AppSpecContent.struct_class = Types::AppSpecContent
+
+    ApplicationAlreadyExistsException.struct_class = Types::ApplicationAlreadyExistsException
+
+    ApplicationDoesNotExistException.struct_class = Types::ApplicationDoesNotExistException
 
     ApplicationInfo.add_member(:application_id, Shapes::ShapeRef.new(shape: ApplicationId, location_name: "applicationId"))
     ApplicationInfo.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, location_name: "applicationName"))
@@ -421,9 +427,15 @@ module Aws::CodeDeploy
     ApplicationInfo.add_member(:compute_platform, Shapes::ShapeRef.new(shape: ComputePlatform, location_name: "computePlatform"))
     ApplicationInfo.struct_class = Types::ApplicationInfo
 
+    ApplicationLimitExceededException.struct_class = Types::ApplicationLimitExceededException
+
+    ApplicationNameRequiredException.struct_class = Types::ApplicationNameRequiredException
+
     ApplicationsInfoList.member = Shapes::ShapeRef.new(shape: ApplicationInfo)
 
     ApplicationsList.member = Shapes::ShapeRef.new(shape: ApplicationName)
+
+    ArnNotSupportedException.struct_class = Types::ArnNotSupportedException
 
     AutoRollbackConfiguration.add_member(:enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "enabled"))
     AutoRollbackConfiguration.add_member(:events, Shapes::ShapeRef.new(shape: AutoRollbackEventsList, location_name: "events"))
@@ -489,6 +501,8 @@ module Aws::CodeDeploy
     BatchGetOnPremisesInstancesOutput.add_member(:instance_infos, Shapes::ShapeRef.new(shape: InstanceInfoList, location_name: "instanceInfos"))
     BatchGetOnPremisesInstancesOutput.struct_class = Types::BatchGetOnPremisesInstancesOutput
 
+    BatchLimitExceededException.struct_class = Types::BatchLimitExceededException
+
     BlueGreenDeploymentConfiguration.add_member(:terminate_blue_instances_on_deployment_success, Shapes::ShapeRef.new(shape: BlueInstanceTerminationOption, location_name: "terminateBlueInstancesOnDeploymentSuccess"))
     BlueGreenDeploymentConfiguration.add_member(:deployment_ready_option, Shapes::ShapeRef.new(shape: DeploymentReadyOption, location_name: "deploymentReadyOption"))
     BlueGreenDeploymentConfiguration.add_member(:green_fleet_provisioning_option, Shapes::ShapeRef.new(shape: GreenFleetProvisioningOption, location_name: "greenFleetProvisioningOption"))
@@ -497,6 +511,8 @@ module Aws::CodeDeploy
     BlueInstanceTerminationOption.add_member(:action, Shapes::ShapeRef.new(shape: InstanceAction, location_name: "action"))
     BlueInstanceTerminationOption.add_member(:termination_wait_time_in_minutes, Shapes::ShapeRef.new(shape: Duration, location_name: "terminationWaitTimeInMinutes"))
     BlueInstanceTerminationOption.struct_class = Types::BlueInstanceTerminationOption
+
+    BucketNameFilterRequiredException.struct_class = Types::BucketNameFilterRequiredException
 
     ContinueDeploymentInput.add_member(:deployment_id, Shapes::ShapeRef.new(shape: DeploymentId, location_name: "deploymentId"))
     ContinueDeploymentInput.add_member(:deployment_wait_type, Shapes::ShapeRef.new(shape: DeploymentWaitType, location_name: "deploymentWaitType"))
@@ -575,6 +591,16 @@ module Aws::CodeDeploy
     DeleteGitHubAccountTokenOutput.add_member(:token_name, Shapes::ShapeRef.new(shape: GitHubAccountTokenName, location_name: "tokenName"))
     DeleteGitHubAccountTokenOutput.struct_class = Types::DeleteGitHubAccountTokenOutput
 
+    DeploymentAlreadyCompletedException.struct_class = Types::DeploymentAlreadyCompletedException
+
+    DeploymentAlreadyStartedException.struct_class = Types::DeploymentAlreadyStartedException
+
+    DeploymentConfigAlreadyExistsException.struct_class = Types::DeploymentConfigAlreadyExistsException
+
+    DeploymentConfigDoesNotExistException.struct_class = Types::DeploymentConfigDoesNotExistException
+
+    DeploymentConfigInUseException.struct_class = Types::DeploymentConfigInUseException
+
     DeploymentConfigInfo.add_member(:deployment_config_id, Shapes::ShapeRef.new(shape: DeploymentConfigId, location_name: "deploymentConfigId"))
     DeploymentConfigInfo.add_member(:deployment_config_name, Shapes::ShapeRef.new(shape: DeploymentConfigName, location_name: "deploymentConfigName"))
     DeploymentConfigInfo.add_member(:minimum_healthy_hosts, Shapes::ShapeRef.new(shape: MinimumHealthyHosts, location_name: "minimumHealthyHosts"))
@@ -583,7 +609,17 @@ module Aws::CodeDeploy
     DeploymentConfigInfo.add_member(:traffic_routing_config, Shapes::ShapeRef.new(shape: TrafficRoutingConfig, location_name: "trafficRoutingConfig"))
     DeploymentConfigInfo.struct_class = Types::DeploymentConfigInfo
 
+    DeploymentConfigLimitExceededException.struct_class = Types::DeploymentConfigLimitExceededException
+
+    DeploymentConfigNameRequiredException.struct_class = Types::DeploymentConfigNameRequiredException
+
     DeploymentConfigsList.member = Shapes::ShapeRef.new(shape: DeploymentConfigName)
+
+    DeploymentDoesNotExistException.struct_class = Types::DeploymentDoesNotExistException
+
+    DeploymentGroupAlreadyExistsException.struct_class = Types::DeploymentGroupAlreadyExistsException
+
+    DeploymentGroupDoesNotExistException.struct_class = Types::DeploymentGroupDoesNotExistException
 
     DeploymentGroupInfo.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, location_name: "applicationName"))
     DeploymentGroupInfo.add_member(:deployment_group_id, Shapes::ShapeRef.new(shape: DeploymentGroupId, location_name: "deploymentGroupId"))
@@ -610,7 +646,13 @@ module Aws::CodeDeploy
 
     DeploymentGroupInfoList.member = Shapes::ShapeRef.new(shape: DeploymentGroupInfo)
 
+    DeploymentGroupLimitExceededException.struct_class = Types::DeploymentGroupLimitExceededException
+
+    DeploymentGroupNameRequiredException.struct_class = Types::DeploymentGroupNameRequiredException
+
     DeploymentGroupsList.member = Shapes::ShapeRef.new(shape: DeploymentGroupName)
+
+    DeploymentIdRequiredException.struct_class = Types::DeploymentIdRequiredException
 
     DeploymentInfo.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, location_name: "applicationName"))
     DeploymentInfo.add_member(:deployment_group_name, Shapes::ShapeRef.new(shape: DeploymentGroupName, location_name: "deploymentGroupName"))
@@ -641,6 +683,12 @@ module Aws::CodeDeploy
     DeploymentInfo.add_member(:compute_platform, Shapes::ShapeRef.new(shape: ComputePlatform, location_name: "computePlatform"))
     DeploymentInfo.struct_class = Types::DeploymentInfo
 
+    DeploymentIsNotInReadyStateException.struct_class = Types::DeploymentIsNotInReadyStateException
+
+    DeploymentLimitExceededException.struct_class = Types::DeploymentLimitExceededException
+
+    DeploymentNotStartedException.struct_class = Types::DeploymentNotStartedException
+
     DeploymentOverview.add_member(:pending, Shapes::ShapeRef.new(shape: InstanceCount, location_name: "Pending"))
     DeploymentOverview.add_member(:in_progress, Shapes::ShapeRef.new(shape: InstanceCount, location_name: "InProgress"))
     DeploymentOverview.add_member(:succeeded, Shapes::ShapeRef.new(shape: InstanceCount, location_name: "Succeeded"))
@@ -667,7 +715,13 @@ module Aws::CodeDeploy
     DeploymentTarget.add_member(:ecs_target, Shapes::ShapeRef.new(shape: ECSTarget, location_name: "ecsTarget"))
     DeploymentTarget.struct_class = Types::DeploymentTarget
 
+    DeploymentTargetDoesNotExistException.struct_class = Types::DeploymentTargetDoesNotExistException
+
+    DeploymentTargetIdRequiredException.struct_class = Types::DeploymentTargetIdRequiredException
+
     DeploymentTargetList.member = Shapes::ShapeRef.new(shape: DeploymentTarget)
+
+    DeploymentTargetListSizeExceededException.struct_class = Types::DeploymentTargetListSizeExceededException
 
     DeploymentsInfoList.member = Shapes::ShapeRef.new(shape: DeploymentInfo)
 
@@ -675,6 +729,8 @@ module Aws::CodeDeploy
 
     DeregisterOnPremisesInstanceInput.add_member(:instance_name, Shapes::ShapeRef.new(shape: InstanceName, required: true, location_name: "instanceName"))
     DeregisterOnPremisesInstanceInput.struct_class = Types::DeregisterOnPremisesInstanceInput
+
+    DescriptionTooLongException.struct_class = Types::DescriptionTooLongException
 
     Diagnostics.add_member(:error_code, Shapes::ShapeRef.new(shape: LifecycleErrorCode, location_name: "errorCode"))
     Diagnostics.add_member(:script_name, Shapes::ShapeRef.new(shape: ScriptName, location_name: "scriptName"))
@@ -699,6 +755,8 @@ module Aws::CodeDeploy
     ECSService.struct_class = Types::ECSService
 
     ECSServiceList.member = Shapes::ShapeRef.new(shape: ECSService)
+
+    ECSServiceMappingLimitExceededException.struct_class = Types::ECSServiceMappingLimitExceededException
 
     ECSTarget.add_member(:deployment_id, Shapes::ShapeRef.new(shape: DeploymentId, location_name: "deploymentId"))
     ECSTarget.add_member(:target_id, Shapes::ShapeRef.new(shape: TargetId, location_name: "targetId"))
@@ -793,7 +851,11 @@ module Aws::CodeDeploy
     GetOnPremisesInstanceOutput.add_member(:instance_info, Shapes::ShapeRef.new(shape: InstanceInfo, location_name: "instanceInfo"))
     GetOnPremisesInstanceOutput.struct_class = Types::GetOnPremisesInstanceOutput
 
+    GitHubAccountTokenDoesNotExistException.struct_class = Types::GitHubAccountTokenDoesNotExistException
+
     GitHubAccountTokenNameList.member = Shapes::ShapeRef.new(shape: GitHubAccountTokenName)
+
+    GitHubAccountTokenNameRequiredException.struct_class = Types::GitHubAccountTokenNameRequiredException
 
     GitHubLocation.add_member(:repository, Shapes::ShapeRef.new(shape: Repository, location_name: "repository"))
     GitHubLocation.add_member(:commit_id, Shapes::ShapeRef.new(shape: CommitId, location_name: "commitId"))
@@ -801,6 +863,18 @@ module Aws::CodeDeploy
 
     GreenFleetProvisioningOption.add_member(:action, Shapes::ShapeRef.new(shape: GreenFleetProvisioningAction, location_name: "action"))
     GreenFleetProvisioningOption.struct_class = Types::GreenFleetProvisioningOption
+
+    IamArnRequiredException.struct_class = Types::IamArnRequiredException
+
+    IamSessionArnAlreadyRegisteredException.struct_class = Types::IamSessionArnAlreadyRegisteredException
+
+    IamUserArnAlreadyRegisteredException.struct_class = Types::IamUserArnAlreadyRegisteredException
+
+    IamUserArnRequiredException.struct_class = Types::IamUserArnRequiredException
+
+    InstanceDoesNotExistException.struct_class = Types::InstanceDoesNotExistException
+
+    InstanceIdRequiredException.struct_class = Types::InstanceIdRequiredException
 
     InstanceInfo.add_member(:instance_name, Shapes::ShapeRef.new(shape: InstanceName, location_name: "instanceName"))
     InstanceInfo.add_member(:iam_session_arn, Shapes::ShapeRef.new(shape: IamSessionArn, location_name: "iamSessionArn"))
@@ -813,7 +887,15 @@ module Aws::CodeDeploy
 
     InstanceInfoList.member = Shapes::ShapeRef.new(shape: InstanceInfo)
 
+    InstanceLimitExceededException.struct_class = Types::InstanceLimitExceededException
+
+    InstanceNameAlreadyRegisteredException.struct_class = Types::InstanceNameAlreadyRegisteredException
+
     InstanceNameList.member = Shapes::ShapeRef.new(shape: InstanceName)
+
+    InstanceNameRequiredException.struct_class = Types::InstanceNameRequiredException
+
+    InstanceNotRegisteredException.struct_class = Types::InstanceNotRegisteredException
 
     InstanceStatusList.member = Shapes::ShapeRef.new(shape: InstanceStatus, deprecated: true)
 
@@ -839,6 +921,118 @@ module Aws::CodeDeploy
     InstanceTypeList.member = Shapes::ShapeRef.new(shape: InstanceType)
 
     InstancesList.member = Shapes::ShapeRef.new(shape: InstanceId)
+
+    InvalidAlarmConfigException.struct_class = Types::InvalidAlarmConfigException
+
+    InvalidApplicationNameException.struct_class = Types::InvalidApplicationNameException
+
+    InvalidArnException.struct_class = Types::InvalidArnException
+
+    InvalidAutoRollbackConfigException.struct_class = Types::InvalidAutoRollbackConfigException
+
+    InvalidAutoScalingGroupException.struct_class = Types::InvalidAutoScalingGroupException
+
+    InvalidBlueGreenDeploymentConfigurationException.struct_class = Types::InvalidBlueGreenDeploymentConfigurationException
+
+    InvalidBucketNameFilterException.struct_class = Types::InvalidBucketNameFilterException
+
+    InvalidComputePlatformException.struct_class = Types::InvalidComputePlatformException
+
+    InvalidDeployedStateFilterException.struct_class = Types::InvalidDeployedStateFilterException
+
+    InvalidDeploymentConfigIdException.struct_class = Types::InvalidDeploymentConfigIdException
+
+    InvalidDeploymentConfigNameException.struct_class = Types::InvalidDeploymentConfigNameException
+
+    InvalidDeploymentGroupNameException.struct_class = Types::InvalidDeploymentGroupNameException
+
+    InvalidDeploymentIdException.struct_class = Types::InvalidDeploymentIdException
+
+    InvalidDeploymentInstanceTypeException.struct_class = Types::InvalidDeploymentInstanceTypeException
+
+    InvalidDeploymentStatusException.struct_class = Types::InvalidDeploymentStatusException
+
+    InvalidDeploymentStyleException.struct_class = Types::InvalidDeploymentStyleException
+
+    InvalidDeploymentTargetIdException.struct_class = Types::InvalidDeploymentTargetIdException
+
+    InvalidDeploymentWaitTypeException.struct_class = Types::InvalidDeploymentWaitTypeException
+
+    InvalidEC2TagCombinationException.struct_class = Types::InvalidEC2TagCombinationException
+
+    InvalidEC2TagException.struct_class = Types::InvalidEC2TagException
+
+    InvalidECSServiceException.struct_class = Types::InvalidECSServiceException
+
+    InvalidFileExistsBehaviorException.struct_class = Types::InvalidFileExistsBehaviorException
+
+    InvalidGitHubAccountTokenException.struct_class = Types::InvalidGitHubAccountTokenException
+
+    InvalidGitHubAccountTokenNameException.struct_class = Types::InvalidGitHubAccountTokenNameException
+
+    InvalidIamSessionArnException.struct_class = Types::InvalidIamSessionArnException
+
+    InvalidIamUserArnException.struct_class = Types::InvalidIamUserArnException
+
+    InvalidIgnoreApplicationStopFailuresValueException.struct_class = Types::InvalidIgnoreApplicationStopFailuresValueException
+
+    InvalidInputException.struct_class = Types::InvalidInputException
+
+    InvalidInstanceIdException.struct_class = Types::InvalidInstanceIdException
+
+    InvalidInstanceNameException.struct_class = Types::InvalidInstanceNameException
+
+    InvalidInstanceStatusException.struct_class = Types::InvalidInstanceStatusException
+
+    InvalidInstanceTypeException.struct_class = Types::InvalidInstanceTypeException
+
+    InvalidKeyPrefixFilterException.struct_class = Types::InvalidKeyPrefixFilterException
+
+    InvalidLifecycleEventHookExecutionIdException.struct_class = Types::InvalidLifecycleEventHookExecutionIdException
+
+    InvalidLifecycleEventHookExecutionStatusException.struct_class = Types::InvalidLifecycleEventHookExecutionStatusException
+
+    InvalidLoadBalancerInfoException.struct_class = Types::InvalidLoadBalancerInfoException
+
+    InvalidMinimumHealthyHostValueException.struct_class = Types::InvalidMinimumHealthyHostValueException
+
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
+    InvalidOnPremisesTagCombinationException.struct_class = Types::InvalidOnPremisesTagCombinationException
+
+    InvalidOperationException.struct_class = Types::InvalidOperationException
+
+    InvalidRegistrationStatusException.struct_class = Types::InvalidRegistrationStatusException
+
+    InvalidRevisionException.struct_class = Types::InvalidRevisionException
+
+    InvalidRoleException.struct_class = Types::InvalidRoleException
+
+    InvalidSortByException.struct_class = Types::InvalidSortByException
+
+    InvalidSortOrderException.struct_class = Types::InvalidSortOrderException
+
+    InvalidTagException.struct_class = Types::InvalidTagException
+
+    InvalidTagFilterException.struct_class = Types::InvalidTagFilterException
+
+    InvalidTagsToAddException.struct_class = Types::InvalidTagsToAddException
+
+    InvalidTargetException.struct_class = Types::InvalidTargetException
+
+    InvalidTargetFilterNameException.struct_class = Types::InvalidTargetFilterNameException
+
+    InvalidTargetGroupPairException.struct_class = Types::InvalidTargetGroupPairException
+
+    InvalidTargetInstancesException.struct_class = Types::InvalidTargetInstancesException
+
+    InvalidTimeRangeException.struct_class = Types::InvalidTimeRangeException
+
+    InvalidTrafficRoutingConfigurationException.struct_class = Types::InvalidTrafficRoutingConfigurationException
+
+    InvalidTriggerConfigException.struct_class = Types::InvalidTriggerConfigException
+
+    InvalidUpdateOutdatedInstancesOnlyValueException.struct_class = Types::InvalidUpdateOutdatedInstancesOnlyValueException
 
     LambdaFunctionInfo.add_member(:function_name, Shapes::ShapeRef.new(shape: LambdaFunctionName, location_name: "functionName"))
     LambdaFunctionInfo.add_member(:function_alias, Shapes::ShapeRef.new(shape: LambdaFunctionAlias, location_name: "functionAlias"))
@@ -869,7 +1063,11 @@ module Aws::CodeDeploy
     LifecycleEvent.add_member(:status, Shapes::ShapeRef.new(shape: LifecycleEventStatus, location_name: "status"))
     LifecycleEvent.struct_class = Types::LifecycleEvent
 
+    LifecycleEventAlreadyCompletedException.struct_class = Types::LifecycleEventAlreadyCompletedException
+
     LifecycleEventList.member = Shapes::ShapeRef.new(shape: LifecycleEvent)
+
+    LifecycleHookLimitExceededException.struct_class = Types::LifecycleHookLimitExceededException
 
     ListApplicationRevisionsInput.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, required: true, location_name: "applicationName"))
     ListApplicationRevisionsInput.add_member(:sort_by, Shapes::ShapeRef.new(shape: ApplicationRevisionSortBy, location_name: "sortBy"))
@@ -972,10 +1170,14 @@ module Aws::CodeDeploy
     MinimumHealthyHosts.add_member(:type, Shapes::ShapeRef.new(shape: MinimumHealthyHostsType, location_name: "type"))
     MinimumHealthyHosts.struct_class = Types::MinimumHealthyHosts
 
+    MultipleIamArnsProvidedException.struct_class = Types::MultipleIamArnsProvidedException
+
     OnPremisesTagSet.add_member(:on_premises_tag_set_list, Shapes::ShapeRef.new(shape: OnPremisesTagSetList, location_name: "onPremisesTagSetList"))
     OnPremisesTagSet.struct_class = Types::OnPremisesTagSet
 
     OnPremisesTagSetList.member = Shapes::ShapeRef.new(shape: TagFilterList)
+
+    OperationNotSupportedException.struct_class = Types::OperationNotSupportedException
 
     PutLifecycleEventHookExecutionStatusInput.add_member(:deployment_id, Shapes::ShapeRef.new(shape: DeploymentId, location_name: "deploymentId"))
     PutLifecycleEventHookExecutionStatusInput.add_member(:lifecycle_event_hook_execution_id, Shapes::ShapeRef.new(shape: LifecycleEventHookExecutionId, location_name: "lifecycleEventHookExecutionId"))
@@ -1003,6 +1205,12 @@ module Aws::CodeDeploy
     RemoveTagsFromOnPremisesInstancesInput.add_member(:instance_names, Shapes::ShapeRef.new(shape: InstanceNameList, required: true, location_name: "instanceNames"))
     RemoveTagsFromOnPremisesInstancesInput.struct_class = Types::RemoveTagsFromOnPremisesInstancesInput
 
+    ResourceArnRequiredException.struct_class = Types::ResourceArnRequiredException
+
+    ResourceValidationException.struct_class = Types::ResourceValidationException
+
+    RevisionDoesNotExistException.struct_class = Types::RevisionDoesNotExistException
+
     RevisionInfo.add_member(:revision_location, Shapes::ShapeRef.new(shape: RevisionLocation, location_name: "revisionLocation"))
     RevisionInfo.add_member(:generic_revision_info, Shapes::ShapeRef.new(shape: GenericRevisionInfo, location_name: "genericRevisionInfo"))
     RevisionInfo.struct_class = Types::RevisionInfo
@@ -1017,6 +1225,10 @@ module Aws::CodeDeploy
     RevisionLocation.struct_class = Types::RevisionLocation
 
     RevisionLocationList.member = Shapes::ShapeRef.new(shape: RevisionLocation)
+
+    RevisionRequiredException.struct_class = Types::RevisionRequiredException
+
+    RoleRequiredException.struct_class = Types::RoleRequiredException
 
     RollbackInfo.add_member(:rollback_deployment_id, Shapes::ShapeRef.new(shape: DeploymentId, location_name: "rollbackDeploymentId"))
     RollbackInfo.add_member(:rollback_triggering_deployment_id, Shapes::ShapeRef.new(shape: DeploymentId, location_name: "rollbackTriggeringDeploymentId"))
@@ -1054,13 +1266,19 @@ module Aws::CodeDeploy
 
     TagKeyList.member = Shapes::ShapeRef.new(shape: Key)
 
+    TagLimitExceededException.struct_class = Types::TagLimitExceededException
+
     TagList.member = Shapes::ShapeRef.new(shape: Tag)
+
+    TagRequiredException.struct_class = Types::TagRequiredException
 
     TagResourceInput.add_member(:resource_arn, Shapes::ShapeRef.new(shape: Arn, required: true, location_name: "ResourceArn"))
     TagResourceInput.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, required: true, location_name: "Tags"))
     TagResourceInput.struct_class = Types::TagResourceInput
 
     TagResourceOutput.struct_class = Types::TagResourceOutput
+
+    TagSetListLimitExceededException.struct_class = Types::TagSetListLimitExceededException
 
     TargetFilters.key = Shapes::ShapeRef.new(shape: TargetFilterName)
     TargetFilters.value = Shapes::ShapeRef.new(shape: FilterValueList)
@@ -1083,6 +1301,8 @@ module Aws::CodeDeploy
     TargetInstances.add_member(:auto_scaling_groups, Shapes::ShapeRef.new(shape: AutoScalingGroupNameList, location_name: "autoScalingGroups"))
     TargetInstances.add_member(:ec2_tag_set, Shapes::ShapeRef.new(shape: EC2TagSet, location_name: "ec2TagSet"))
     TargetInstances.struct_class = Types::TargetInstances
+
+    ThrottlingException.struct_class = Types::ThrottlingException
 
     TimeBasedCanary.add_member(:canary_percentage, Shapes::ShapeRef.new(shape: Percentage, location_name: "canaryPercentage"))
     TimeBasedCanary.add_member(:canary_interval, Shapes::ShapeRef.new(shape: WaitTimeInMins, location_name: "canaryInterval"))
@@ -1112,6 +1332,10 @@ module Aws::CodeDeploy
     TriggerConfigList.member = Shapes::ShapeRef.new(shape: TriggerConfig)
 
     TriggerEventTypeList.member = Shapes::ShapeRef.new(shape: TriggerEventType)
+
+    TriggerTargetsLimitExceededException.struct_class = Types::TriggerTargetsLimitExceededException
+
+    UnsupportedActionForDeploymentTypeException.struct_class = Types::UnsupportedActionForDeploymentTypeException
 
     UntagResourceInput.add_member(:resource_arn, Shapes::ShapeRef.new(shape: Arn, required: true, location_name: "ResourceArn"))
     UntagResourceInput.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "TagKeys"))

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
@@ -10,5 +10,1237 @@ module Aws::CodeDeploy
 
     extend Aws::Errors::DynamicErrors
 
+    class AlarmsLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::AlarmsLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApplicationAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ApplicationAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApplicationDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ApplicationDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApplicationLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ApplicationLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApplicationNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ApplicationNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ArnNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ArnNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BatchLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::BatchLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BucketNameFilterRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::BucketNameFilterRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentAlreadyCompletedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentAlreadyCompletedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentAlreadyStartedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentAlreadyStartedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentConfigAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentConfigAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentConfigDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentConfigDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentConfigInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentConfigInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentConfigLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentConfigLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentConfigNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentConfigNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentGroupAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentGroupAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentGroupDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentGroupDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentGroupLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentGroupLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentGroupNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentGroupNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentIsNotInReadyStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentIsNotInReadyStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentNotStartedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentNotStartedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentTargetDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentTargetDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentTargetIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentTargetIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DeploymentTargetListSizeExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DeploymentTargetListSizeExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DescriptionTooLongException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::DescriptionTooLongException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ECSServiceMappingLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ECSServiceMappingLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GitHubAccountTokenDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::GitHubAccountTokenDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GitHubAccountTokenNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::GitHubAccountTokenNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamArnRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::IamArnRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamSessionArnAlreadyRegisteredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::IamSessionArnAlreadyRegisteredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamUserArnAlreadyRegisteredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::IamUserArnAlreadyRegisteredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamUserArnRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::IamUserArnRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceIdRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceIdRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceNameAlreadyRegisteredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceNameAlreadyRegisteredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceNameRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceNameRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceNotRegisteredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InstanceNotRegisteredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidAlarmConfigException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidAlarmConfigException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApplicationNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidApplicationNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidAutoRollbackConfigException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidAutoRollbackConfigException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidAutoScalingGroupException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidAutoScalingGroupException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidBlueGreenDeploymentConfigurationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidBlueGreenDeploymentConfigurationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidBucketNameFilterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidBucketNameFilterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidComputePlatformException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidComputePlatformException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeployedStateFilterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeployedStateFilterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentConfigIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentConfigIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentConfigNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentConfigNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentGroupNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentGroupNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentInstanceTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentInstanceTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentStyleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentStyleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentTargetIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentTargetIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeploymentWaitTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidDeploymentWaitTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEC2TagCombinationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidEC2TagCombinationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEC2TagException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidEC2TagException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidECSServiceException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidECSServiceException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidFileExistsBehaviorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidFileExistsBehaviorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidGitHubAccountTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidGitHubAccountTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidGitHubAccountTokenNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidGitHubAccountTokenNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidIamSessionArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidIamSessionArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidIamUserArnException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidIamUserArnException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidIgnoreApplicationStopFailuresValueException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidIgnoreApplicationStopFailuresValueException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInputException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidInputException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInstanceIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidInstanceIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInstanceNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidInstanceNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInstanceStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidInstanceStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidInstanceTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidInstanceTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidKeyPrefixFilterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidKeyPrefixFilterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLifecycleEventHookExecutionIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidLifecycleEventHookExecutionIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLifecycleEventHookExecutionStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidLifecycleEventHookExecutionStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLoadBalancerInfoException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidLoadBalancerInfoException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMinimumHealthyHostValueException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidMinimumHealthyHostValueException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOnPremisesTagCombinationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidOnPremisesTagCombinationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRegistrationStatusException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidRegistrationStatusException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRevisionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidRevisionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRoleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidRoleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSortByException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidSortByException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSortOrderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidSortOrderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTagException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagFilterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTagFilterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagsToAddException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTagsToAddException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTargetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetFilterNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTargetFilterNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetGroupPairException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTargetGroupPairException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetInstancesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTargetInstancesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTimeRangeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTimeRangeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTrafficRoutingConfigurationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTrafficRoutingConfigurationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTriggerConfigException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidTriggerConfigException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidUpdateOutdatedInstancesOnlyValueException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::InvalidUpdateOutdatedInstancesOnlyValueException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LifecycleEventAlreadyCompletedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::LifecycleEventAlreadyCompletedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LifecycleHookLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::LifecycleHookLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MultipleIamArnsProvidedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::MultipleIamArnsProvidedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::OperationNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceArnRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ResourceArnRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ResourceValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RevisionDoesNotExistException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::RevisionDoesNotExistException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RevisionRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::RevisionRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RoleRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::RoleRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::TagLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::TagRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagSetListLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::TagSetListLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ThrottlingException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::ThrottlingException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TriggerTargetsLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::TriggerTargetsLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedActionForDeploymentTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeDeploy::Types::UnsupportedActionForDeploymentTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
@@ -109,6 +109,12 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The maximum number of alarms for a deployment group (10) was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/AlarmsLimitExceededException AWS API Documentation
+    #
+    class AlarmsLimitExceededException < Aws::EmptyStructure; end
+
     # A revision for an AWS Lambda or Amazon ECS deployment that is a
     # YAML-formatted or JSON-formatted string. For AWS Lambda and Amazon ECS
     # deployments, the revision is the same as the AppSpec file. This method
@@ -151,6 +157,19 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # An application with the specified name with the IAM user or AWS
+    # account already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ApplicationAlreadyExistsException AWS API Documentation
+    #
+    class ApplicationAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The application does not exist with the IAM user or AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ApplicationDoesNotExistException AWS API Documentation
+    #
+    class ApplicationDoesNotExistException < Aws::EmptyStructure; end
+
     # Information about an application.
     #
     # @!attribute [rw] application_id
@@ -190,6 +209,25 @@ module Aws::CodeDeploy
       :compute_platform)
       include Aws::Structure
     end
+
+    # More applications were attempted to be created than are allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ApplicationLimitExceededException AWS API Documentation
+    #
+    class ApplicationLimitExceededException < Aws::EmptyStructure; end
+
+    # The minimum number of required application names was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ApplicationNameRequiredException AWS API Documentation
+    #
+    class ApplicationNameRequiredException < Aws::EmptyStructure; end
+
+    # The specified ARN is not supported. For example, it might be an ARN
+    # for a resource that is not expected.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ArnNotSupportedException AWS API Documentation
+    #
+    class ArnNotSupportedException < Aws::EmptyStructure; end
 
     # Information about a configuration for automatically rolling back to a
     # previous version of an application revision when a deployment is not
@@ -572,6 +610,13 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The maximum number of names or IDs allowed for this request (100) was
+    # exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/BatchLimitExceededException AWS API Documentation
+    #
+    class BatchLimitExceededException < Aws::EmptyStructure; end
+
     # Information about blue/green deployment options for a deployment
     # group.
     #
@@ -659,6 +704,12 @@ module Aws::CodeDeploy
       :termination_wait_time_in_minutes)
       include Aws::Structure
     end
+
+    # A bucket name is required, but was not provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/BucketNameFilterRequiredException AWS API Documentation
+    #
+    class BucketNameFilterRequiredException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ContinueDeploymentInput
     #   data as a hash:
@@ -1400,6 +1451,39 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The deployment is already complete.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentAlreadyCompletedException AWS API Documentation
+    #
+    class DeploymentAlreadyCompletedException < Aws::EmptyStructure; end
+
+    # A deployment to a target was attempted while another deployment was in
+    # progress.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentAlreadyStartedException AWS API Documentation
+    #
+    class DeploymentAlreadyStartedException < Aws::EmptyStructure; end
+
+    # A deployment configuration with the specified name with the IAM user
+    # or AWS account already exists .
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentConfigAlreadyExistsException AWS API Documentation
+    #
+    class DeploymentConfigAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The deployment configuration does not exist with the IAM user or AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentConfigDoesNotExistException AWS API Documentation
+    #
+    class DeploymentConfigDoesNotExistException < Aws::EmptyStructure; end
+
+    # The deployment configuration is still in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentConfigInUseException AWS API Documentation
+    #
+    class DeploymentConfigInUseException < Aws::EmptyStructure; end
+
     # Information about a deployment configuration.
     #
     # @!attribute [rw] deployment_config_id
@@ -1441,6 +1525,38 @@ module Aws::CodeDeploy
       :traffic_routing_config)
       include Aws::Structure
     end
+
+    # The deployment configurations limit was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentConfigLimitExceededException AWS API Documentation
+    #
+    class DeploymentConfigLimitExceededException < Aws::EmptyStructure; end
+
+    # The deployment configuration name was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentConfigNameRequiredException AWS API Documentation
+    #
+    class DeploymentConfigNameRequiredException < Aws::EmptyStructure; end
+
+    # The deployment with the IAM user or AWS account does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentDoesNotExistException AWS API Documentation
+    #
+    class DeploymentDoesNotExistException < Aws::EmptyStructure; end
+
+    # A deployment group with the specified name with the IAM user or AWS
+    # account already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentGroupAlreadyExistsException AWS API Documentation
+    #
+    class DeploymentGroupAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The named deployment group with the IAM user or AWS account does not
+    # exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentGroupDoesNotExistException AWS API Documentation
+    #
+    class DeploymentGroupDoesNotExistException < Aws::EmptyStructure; end
 
     # Information about a deployment group.
     #
@@ -1580,6 +1696,24 @@ module Aws::CodeDeploy
       :ecs_services)
       include Aws::Structure
     end
+
+    # The deployment groups limit was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentGroupLimitExceededException AWS API Documentation
+    #
+    class DeploymentGroupLimitExceededException < Aws::EmptyStructure; end
+
+    # The deployment group name was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentGroupNameRequiredException AWS API Documentation
+    #
+    class DeploymentGroupNameRequiredException < Aws::EmptyStructure; end
+
+    # At least one deployment ID must be specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentIdRequiredException AWS API Documentation
+    #
+    class DeploymentIdRequiredException < Aws::EmptyStructure; end
 
     # Information about a deployment.
     #
@@ -1787,6 +1921,25 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The deployment does not have a status of Ready and can't continue
+    # yet.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentIsNotInReadyStateException AWS API Documentation
+    #
+    class DeploymentIsNotInReadyStateException < Aws::EmptyStructure; end
+
+    # The number of allowed deployments was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentLimitExceededException AWS API Documentation
+    #
+    class DeploymentLimitExceededException < Aws::EmptyStructure; end
+
+    # The specified deployment has not started.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentNotStartedException AWS API Documentation
+    #
+    class DeploymentNotStartedException < Aws::EmptyStructure; end
+
     # Information about the deployment status of the instances in the
     # deployment.
     #
@@ -1931,6 +2084,27 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The provided target ID does not belong to the attempted deployment.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentTargetDoesNotExistException AWS API Documentation
+    #
+    class DeploymentTargetDoesNotExistException < Aws::EmptyStructure; end
+
+    # A deployment target ID was not provided.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentTargetIdRequiredException AWS API Documentation
+    #
+    class DeploymentTargetIdRequiredException < Aws::EmptyStructure; end
+
+    # The maximum number of targets that can be associated with an Amazon
+    # ECS or AWS Lambda deployment was exceeded. The target list of both
+    # types of deployments must have exactly one item. This exception does
+    # not apply to EC2/On-premises deployments.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentTargetListSizeExceededException AWS API Documentation
+    #
+    class DeploymentTargetListSizeExceededException < Aws::EmptyStructure; end
+
     # Represents the input of a DeregisterOnPremisesInstance operation.
     #
     # @note When making an API call, you may pass DeregisterOnPremisesInstanceInput
@@ -1950,6 +2124,12 @@ module Aws::CodeDeploy
       :instance_name)
       include Aws::Structure
     end
+
+    # The description is too long.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DescriptionTooLongException AWS API Documentation
+    #
+    class DescriptionTooLongException < Aws::EmptyStructure; end
 
     # Diagnostic information about executable scripts that are part of a
     # deployment.
@@ -2094,6 +2274,14 @@ module Aws::CodeDeploy
       :cluster_name)
       include Aws::Structure
     end
+
+    # The Amazon ECS service is associated with more than one deployment
+    # groups. An Amazon ECS service can be associated with only one
+    # deployment group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ECSServiceMappingLimitExceededException AWS API Documentation
+    #
+    class ECSServiceMappingLimitExceededException < Aws::EmptyStructure; end
 
     # Information about the target of an Amazon ECS deployment.
     #
@@ -2665,6 +2853,19 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # No GitHub account connection exists with the named specified in the
+    # call.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/GitHubAccountTokenDoesNotExistException AWS API Documentation
+    #
+    class GitHubAccountTokenDoesNotExistException < Aws::EmptyStructure; end
+
+    # The call is missing a required GitHub account connection name.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/GitHubAccountTokenNameRequiredException AWS API Documentation
+    #
+    class GitHubAccountTokenNameRequiredException < Aws::EmptyStructure; end
+
     # Information about the location of application artifacts stored in
     # GitHub.
     #
@@ -2725,6 +2926,45 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # No IAM ARN was included in the request. You must use an IAM session
+    # ARN or IAM user ARN in the request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/IamArnRequiredException AWS API Documentation
+    #
+    class IamArnRequiredException < Aws::EmptyStructure; end
+
+    # The request included an IAM session ARN that has already been used to
+    # register a different instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/IamSessionArnAlreadyRegisteredException AWS API Documentation
+    #
+    class IamSessionArnAlreadyRegisteredException < Aws::EmptyStructure; end
+
+    # The specified IAM user ARN is already registered with an on-premises
+    # instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/IamUserArnAlreadyRegisteredException AWS API Documentation
+    #
+    class IamUserArnAlreadyRegisteredException < Aws::EmptyStructure; end
+
+    # An IAM user ARN was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/IamUserArnRequiredException AWS API Documentation
+    #
+    class IamUserArnRequiredException < Aws::EmptyStructure; end
+
+    # The specified instance does not exist in the deployment group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceDoesNotExistException AWS API Documentation
+    #
+    class InstanceDoesNotExistException < Aws::EmptyStructure; end
+
+    # The instance ID was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceIdRequiredException AWS API Documentation
+    #
+    class InstanceIdRequiredException < Aws::EmptyStructure; end
+
     # Information about an on-premises instance.
     #
     # @!attribute [rw] instance_name
@@ -2768,6 +3008,31 @@ module Aws::CodeDeploy
       :tags)
       include Aws::Structure
     end
+
+    # The maximum number of allowed on-premises instances in a single call
+    # was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceLimitExceededException AWS API Documentation
+    #
+    class InstanceLimitExceededException < Aws::EmptyStructure; end
+
+    # The specified on-premises instance name is already registered.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceNameAlreadyRegisteredException AWS API Documentation
+    #
+    class InstanceNameAlreadyRegisteredException < Aws::EmptyStructure; end
+
+    # An on-premises instance name was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceNameRequiredException AWS API Documentation
+    #
+    class InstanceNameRequiredException < Aws::EmptyStructure; end
+
+    # The specified on-premises instance is not registered.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InstanceNotRegisteredException AWS API Documentation
+    #
+    class InstanceNotRegisteredException < Aws::EmptyStructure; end
 
     # Information about an instance in a deployment.
     #
@@ -2871,6 +3136,393 @@ module Aws::CodeDeploy
       :instance_label)
       include Aws::Structure
     end
+
+    # The format of the alarm configuration is invalid. Possible causes
+    # include:
+    #
+    # * The alarm list is null.
+    #
+    # * The alarm object is null.
+    #
+    # * The alarm name is empty or null or exceeds the limit of 255
+    #   characters.
+    #
+    # * Two alarms with the same name have been specified.
+    #
+    # * The alarm configuration is enabled, but the alarm list is empty.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidAlarmConfigException AWS API Documentation
+    #
+    class InvalidAlarmConfigException < Aws::EmptyStructure; end
+
+    # The application name was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidApplicationNameException AWS API Documentation
+    #
+    class InvalidApplicationNameException < Aws::EmptyStructure; end
+
+    # The specified ARN is not in a valid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidArnException AWS API Documentation
+    #
+    class InvalidArnException < Aws::EmptyStructure; end
+
+    # The automatic rollback configuration was specified in an invalid
+    # format. For example, automatic rollback is enabled, but an invalid
+    # triggering event type or no event types were listed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidAutoRollbackConfigException AWS API Documentation
+    #
+    class InvalidAutoRollbackConfigException < Aws::EmptyStructure; end
+
+    # The Auto Scaling group was specified in an invalid format or does not
+    # exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidAutoScalingGroupException AWS API Documentation
+    #
+    class InvalidAutoScalingGroupException < Aws::EmptyStructure; end
+
+    # The configuration for the blue/green deployment group was provided in
+    # an invalid format. For information about deployment configuration
+    # format, see CreateDeploymentConfig.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidBlueGreenDeploymentConfigurationException AWS API Documentation
+    #
+    class InvalidBlueGreenDeploymentConfigurationException < Aws::EmptyStructure; end
+
+    # The bucket name either doesn't exist or was specified in an invalid
+    # format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidBucketNameFilterException AWS API Documentation
+    #
+    class InvalidBucketNameFilterException < Aws::EmptyStructure; end
+
+    # The computePlatform is invalid. The computePlatform should be `Lambda`
+    # or `Server`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidComputePlatformException AWS API Documentation
+    #
+    class InvalidComputePlatformException < Aws::EmptyStructure; end
+
+    # The deployed state filter was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeployedStateFilterException AWS API Documentation
+    #
+    class InvalidDeployedStateFilterException < Aws::EmptyStructure; end
+
+    # The ID of the deployment configuration is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentConfigIdException AWS API Documentation
+    #
+    class InvalidDeploymentConfigIdException < Aws::EmptyStructure; end
+
+    # The deployment configuration name was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentConfigNameException AWS API Documentation
+    #
+    class InvalidDeploymentConfigNameException < Aws::EmptyStructure; end
+
+    # The deployment group name was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentGroupNameException AWS API Documentation
+    #
+    class InvalidDeploymentGroupNameException < Aws::EmptyStructure; end
+
+    # At least one of the deployment IDs was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentIdException AWS API Documentation
+    #
+    class InvalidDeploymentIdException < Aws::EmptyStructure; end
+
+    # An instance type was specified for an in-place deployment. Instance
+    # types are supported for blue/green deployments only.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentInstanceTypeException AWS API Documentation
+    #
+    class InvalidDeploymentInstanceTypeException < Aws::EmptyStructure; end
+
+    # The specified deployment status doesn't exist or cannot be
+    # determined.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentStatusException AWS API Documentation
+    #
+    class InvalidDeploymentStatusException < Aws::EmptyStructure; end
+
+    # An invalid deployment style was specified. Valid deployment types
+    # include "IN\_PLACE" and "BLUE\_GREEN." Valid deployment options
+    # include "WITH\_TRAFFIC\_CONTROL" and "WITHOUT\_TRAFFIC\_CONTROL."
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentStyleException AWS API Documentation
+    #
+    class InvalidDeploymentStyleException < Aws::EmptyStructure; end
+
+    # The target ID provided was not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentTargetIdException AWS API Documentation
+    #
+    class InvalidDeploymentTargetIdException < Aws::EmptyStructure; end
+
+    # The wait type is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidDeploymentWaitTypeException AWS API Documentation
+    #
+    class InvalidDeploymentWaitTypeException < Aws::EmptyStructure; end
+
+    # A call was submitted that specified both Ec2TagFilters and Ec2TagSet,
+    # but only one of these data types can be used in a single call.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidEC2TagCombinationException AWS API Documentation
+    #
+    class InvalidEC2TagCombinationException < Aws::EmptyStructure; end
+
+    # The tag was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidEC2TagException AWS API Documentation
+    #
+    class InvalidEC2TagException < Aws::EmptyStructure; end
+
+    # The Amazon ECS service identifier is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidECSServiceException AWS API Documentation
+    #
+    class InvalidECSServiceException < Aws::EmptyStructure; end
+
+    # An invalid fileExistsBehavior option was specified to determine how
+    # AWS CodeDeploy handles files or directories that already exist in a
+    # deployment target location, but weren't part of the previous
+    # successful deployment. Valid values include "DISALLOW,"
+    # "OVERWRITE," and "RETAIN."
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidFileExistsBehaviorException AWS API Documentation
+    #
+    class InvalidFileExistsBehaviorException < Aws::EmptyStructure; end
+
+    # The GitHub token is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidGitHubAccountTokenException AWS API Documentation
+    #
+    class InvalidGitHubAccountTokenException < Aws::EmptyStructure; end
+
+    # The format of the specified GitHub account connection name is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidGitHubAccountTokenNameException AWS API Documentation
+    #
+    class InvalidGitHubAccountTokenNameException < Aws::EmptyStructure; end
+
+    # The IAM session ARN was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidIamSessionArnException AWS API Documentation
+    #
+    class InvalidIamSessionArnException < Aws::EmptyStructure; end
+
+    # The IAM user ARN was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidIamUserArnException AWS API Documentation
+    #
+    class InvalidIamUserArnException < Aws::EmptyStructure; end
+
+    # The IgnoreApplicationStopFailures value is invalid. For AWS Lambda
+    # deployments, `false` is expected. For EC2/On-premises deployments,
+    # `true` or `false` is expected.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidIgnoreApplicationStopFailuresValueException AWS API Documentation
+    #
+    class InvalidIgnoreApplicationStopFailuresValueException < Aws::EmptyStructure; end
+
+    # The input was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidInputException AWS API Documentation
+    #
+    class InvalidInputException < Aws::EmptyStructure; end
+
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidInstanceIdException AWS API Documentation
+    #
+    class InvalidInstanceIdException < Aws::EmptyStructure; end
+
+    # The on-premises instance name was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidInstanceNameException AWS API Documentation
+    #
+    class InvalidInstanceNameException < Aws::EmptyStructure; end
+
+    # The specified instance status does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidInstanceStatusException AWS API Documentation
+    #
+    class InvalidInstanceStatusException < Aws::EmptyStructure; end
+
+    # An invalid instance type was specified for instances in a blue/green
+    # deployment. Valid values include "Blue" for an original environment
+    # and "Green" for a replacement environment.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidInstanceTypeException AWS API Documentation
+    #
+    class InvalidInstanceTypeException < Aws::EmptyStructure; end
+
+    # The specified key prefix filter was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidKeyPrefixFilterException AWS API Documentation
+    #
+    class InvalidKeyPrefixFilterException < Aws::EmptyStructure; end
+
+    # A lifecycle event hook is invalid. Review the `hooks` section in your
+    # AppSpec file to ensure the lifecycle events and `hooks` functions are
+    # valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidLifecycleEventHookExecutionIdException AWS API Documentation
+    #
+    class InvalidLifecycleEventHookExecutionIdException < Aws::EmptyStructure; end
+
+    # The result of a Lambda validation function that verifies a lifecycle
+    # event is invalid. It should return `Succeeded` or `Failed`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidLifecycleEventHookExecutionStatusException AWS API Documentation
+    #
+    class InvalidLifecycleEventHookExecutionStatusException < Aws::EmptyStructure; end
+
+    # An invalid load balancer name, or no load balancer name, was
+    # specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidLoadBalancerInfoException AWS API Documentation
+    #
+    class InvalidLoadBalancerInfoException < Aws::EmptyStructure; end
+
+    # The minimum healthy instance value was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidMinimumHealthyHostValueException AWS API Documentation
+    #
+    class InvalidMinimumHealthyHostValueException < Aws::EmptyStructure; end
+
+    # The next token was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
+    # A call was submitted that specified both OnPremisesTagFilters and
+    # OnPremisesTagSet, but only one of these data types can be used in a
+    # single call.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidOnPremisesTagCombinationException AWS API Documentation
+    #
+    class InvalidOnPremisesTagCombinationException < Aws::EmptyStructure; end
+
+    # An invalid operation was detected.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidOperationException AWS API Documentation
+    #
+    class InvalidOperationException < Aws::EmptyStructure; end
+
+    # The registration status was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidRegistrationStatusException AWS API Documentation
+    #
+    class InvalidRegistrationStatusException < Aws::EmptyStructure; end
+
+    # The revision was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidRevisionException AWS API Documentation
+    #
+    class InvalidRevisionException < Aws::EmptyStructure; end
+
+    # The service role ARN was specified in an invalid format. Or, if an
+    # Auto Scaling group was specified, the specified service role does not
+    # grant the appropriate permissions to Amazon EC2 Auto Scaling.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidRoleException AWS API Documentation
+    #
+    class InvalidRoleException < Aws::EmptyStructure; end
+
+    # The column name to sort by is either not present or was specified in
+    # an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidSortByException AWS API Documentation
+    #
+    class InvalidSortByException < Aws::EmptyStructure; end
+
+    # The sort order was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidSortOrderException AWS API Documentation
+    #
+    class InvalidSortOrderException < Aws::EmptyStructure; end
+
+    # The tag was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTagException AWS API Documentation
+    #
+    class InvalidTagException < Aws::EmptyStructure; end
+
+    # The tag filter was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTagFilterException AWS API Documentation
+    #
+    class InvalidTagFilterException < Aws::EmptyStructure; end
+
+    # The specified tags are not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTagsToAddException AWS API Documentation
+    #
+    class InvalidTagsToAddException < Aws::EmptyStructure; end
+
+    # A target is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTargetException AWS API Documentation
+    #
+    class InvalidTargetException < Aws::EmptyStructure; end
+
+    # The target filter name is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTargetFilterNameException AWS API Documentation
+    #
+    class InvalidTargetFilterNameException < Aws::EmptyStructure; end
+
+    # A target group pair associated with this deployment is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTargetGroupPairException AWS API Documentation
+    #
+    class InvalidTargetGroupPairException < Aws::EmptyStructure; end
+
+    # The target instance configuration is invalid. Possible causes include:
+    #
+    # * Configuration data for target instances was entered for an in-place
+    #   deployment.
+    #
+    # * The limit of 10 tags for a tag type was exceeded.
+    #
+    # * The combined length of the tag names exceeded the limit.
+    #
+    # * A specified tag is not currently applied to any instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTargetInstancesException AWS API Documentation
+    #
+    class InvalidTargetInstancesException < Aws::EmptyStructure; end
+
+    # The specified time range was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTimeRangeException AWS API Documentation
+    #
+    class InvalidTimeRangeException < Aws::EmptyStructure; end
+
+    # The configuration that specifies how traffic is routed during a
+    # deployment is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTrafficRoutingConfigurationException AWS API Documentation
+    #
+    class InvalidTrafficRoutingConfigurationException < Aws::EmptyStructure; end
+
+    # The trigger was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidTriggerConfigException AWS API Documentation
+    #
+    class InvalidTriggerConfigException < Aws::EmptyStructure; end
+
+    # The UpdateOutdatedInstancesOnly value is invalid. For AWS Lambda
+    # deployments, `false` is expected. For EC2/On-premises deployments,
+    # `true` or `false` is expected.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/InvalidUpdateOutdatedInstancesOnlyValueException AWS API Documentation
+    #
+    class InvalidUpdateOutdatedInstancesOnlyValueException < Aws::EmptyStructure; end
 
     # Information about a Lambda function specified in a deployment.
     #
@@ -3038,6 +3690,19 @@ module Aws::CodeDeploy
       :status)
       include Aws::Structure
     end
+
+    # An attempt to return the status of an already completed lifecycle
+    # event occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/LifecycleEventAlreadyCompletedException AWS API Documentation
+    #
+    class LifecycleEventAlreadyCompletedException < Aws::EmptyStructure; end
+
+    # The limit for lifecycle hooks was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/LifecycleHookLimitExceededException AWS API Documentation
+    #
+    class LifecycleHookLimitExceededException < Aws::EmptyStructure; end
 
     # Represents the input of a ListApplicationRevisions operation.
     #
@@ -3804,6 +4469,13 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # Both an IAM user ARN and an IAM session ARN were included in the
+    # request. Use only one ARN type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/MultipleIamArnsProvidedException AWS API Documentation
+    #
+    class MultipleIamArnsProvidedException < Aws::EmptyStructure; end
+
     # Information about groups of on-premises instance tags.
     #
     # @note When making an API call, you may pass OnPremisesTagSet
@@ -3833,6 +4505,12 @@ module Aws::CodeDeploy
       :on_premises_tag_set_list)
       include Aws::Structure
     end
+
+    # The API used does not support the deployment.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/OperationNotSupportedException AWS API Documentation
+    #
+    class OperationNotSupportedException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PutLifecycleEventHookExecutionStatusInput
     #   data as a hash:
@@ -4029,6 +4707,24 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The ARN of a resource is required, but was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ResourceArnRequiredException AWS API Documentation
+    #
+    class ResourceArnRequiredException < Aws::EmptyStructure; end
+
+    # The specified resource could not be validated.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ResourceValidationException AWS API Documentation
+    #
+    class ResourceValidationException < Aws::EmptyStructure; end
+
+    # The named revision does not exist with the IAM user or AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/RevisionDoesNotExistException AWS API Documentation
+    #
+    class RevisionDoesNotExistException < Aws::EmptyStructure; end
+
     # Information about an application revision.
     #
     # @!attribute [rw] revision_location
@@ -4118,6 +4814,18 @@ module Aws::CodeDeploy
       :app_spec_content)
       include Aws::Structure
     end
+
+    # The revision ID was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/RevisionRequiredException AWS API Documentation
+    #
+    class RevisionRequiredException < Aws::EmptyStructure; end
+
+    # The role ID was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/RoleRequiredException AWS API Documentation
+    #
+    class RoleRequiredException < Aws::EmptyStructure; end
 
     # Information about a deployment rollback.
     #
@@ -4340,6 +5048,18 @@ module Aws::CodeDeploy
       include Aws::Structure
     end
 
+    # The maximum allowed number of tags was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/TagLimitExceededException AWS API Documentation
+    #
+    class TagLimitExceededException < Aws::EmptyStructure; end
+
+    # A tag was not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/TagRequiredException AWS API Documentation
+    #
+    class TagRequiredException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass TagResourceInput
     #   data as a hash:
     #
@@ -4374,6 +5094,13 @@ module Aws::CodeDeploy
     # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/TagResourceOutput AWS API Documentation
     #
     class TagResourceOutput < Aws::EmptyStructure; end
+
+    # The number of tag groups included in the tag set list exceeded the
+    # maximum allowed limit of 3.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/TagSetListLimitExceededException AWS API Documentation
+    #
+    class TagSetListLimitExceededException < Aws::EmptyStructure; end
 
     # Information about a target group in Elastic Load Balancing to use in a
     # deployment. Instances are registered as targets in a target group, and
@@ -4504,6 +5231,12 @@ module Aws::CodeDeploy
       :ec2_tag_set)
       include Aws::Structure
     end
+
+    # An API function was called too frequently.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ThrottlingException AWS API Documentation
+    #
+    class ThrottlingException < Aws::EmptyStructure; end
 
     # A configuration that shifts traffic from one version of a Lambda
     # function to another in two increments. The original and target Lambda
@@ -4703,6 +5436,19 @@ module Aws::CodeDeploy
       :trigger_events)
       include Aws::Structure
     end
+
+    # The maximum allowed number of triggers was exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/TriggerTargetsLimitExceededException AWS API Documentation
+    #
+    class TriggerTargetsLimitExceededException < Aws::EmptyStructure; end
+
+    # A call was submitted that is not supported for the specified
+    # deployment type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/UnsupportedActionForDeploymentTypeException AWS API Documentation
+    #
+    class UnsupportedActionForDeploymentTypeException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagResourceInput
     #   data as a hash:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
@@ -395,6 +395,8 @@ module Aws::CodePipeline
     ActionExecutionResult.add_member(:external_execution_url, Shapes::ShapeRef.new(shape: Url, location_name: "externalExecutionUrl"))
     ActionExecutionResult.struct_class = Types::ActionExecutionResult
 
+    ActionNotFoundException.struct_class = Types::ActionNotFoundException
+
     ActionRevision.add_member(:revision_id, Shapes::ShapeRef.new(shape: Revision, required: true, location_name: "revisionId"))
     ActionRevision.add_member(:revision_change_id, Shapes::ShapeRef.new(shape: RevisionChangeIdentifier, required: true, location_name: "revisionChangeId"))
     ActionRevision.add_member(:created, Shapes::ShapeRef.new(shape: Timestamp, required: true, location_name: "created"))
@@ -424,11 +426,15 @@ module Aws::CodePipeline
 
     ActionTypeList.member = Shapes::ShapeRef.new(shape: ActionType)
 
+    ActionTypeNotFoundException.struct_class = Types::ActionTypeNotFoundException
+
     ActionTypeSettings.add_member(:third_party_configuration_url, Shapes::ShapeRef.new(shape: Url, location_name: "thirdPartyConfigurationUrl"))
     ActionTypeSettings.add_member(:entity_url_template, Shapes::ShapeRef.new(shape: UrlTemplate, location_name: "entityUrlTemplate"))
     ActionTypeSettings.add_member(:execution_url_template, Shapes::ShapeRef.new(shape: UrlTemplate, location_name: "executionUrlTemplate"))
     ActionTypeSettings.add_member(:revision_url_template, Shapes::ShapeRef.new(shape: UrlTemplate, location_name: "revisionUrlTemplate"))
     ActionTypeSettings.struct_class = Types::ActionTypeSettings
+
+    ApprovalAlreadyCompletedException.struct_class = Types::ApprovalAlreadyCompletedException
 
     ApprovalResult.add_member(:summary, Shapes::ShapeRef.new(shape: ApprovalSummary, required: true, location_name: "summary"))
     ApprovalResult.add_member(:status, Shapes::ShapeRef.new(shape: ApprovalStatus, required: true, location_name: "status"))
@@ -605,11 +611,35 @@ module Aws::CodePipeline
 
     InputArtifactList.member = Shapes::ShapeRef.new(shape: InputArtifact)
 
+    InvalidActionDeclarationException.struct_class = Types::InvalidActionDeclarationException
+
+    InvalidApprovalTokenException.struct_class = Types::InvalidApprovalTokenException
+
     InvalidArnException.add_member(:message, Shapes::ShapeRef.new(shape: Message, location_name: "message"))
     InvalidArnException.struct_class = Types::InvalidArnException
 
+    InvalidBlockerDeclarationException.struct_class = Types::InvalidBlockerDeclarationException
+
+    InvalidClientTokenException.struct_class = Types::InvalidClientTokenException
+
+    InvalidJobException.struct_class = Types::InvalidJobException
+
+    InvalidJobStateException.struct_class = Types::InvalidJobStateException
+
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
+    InvalidNonceException.struct_class = Types::InvalidNonceException
+
+    InvalidStageDeclarationException.struct_class = Types::InvalidStageDeclarationException
+
+    InvalidStructureException.struct_class = Types::InvalidStructureException
+
     InvalidTagsException.add_member(:message, Shapes::ShapeRef.new(shape: Message, location_name: "message"))
     InvalidTagsException.struct_class = Types::InvalidTagsException
+
+    InvalidWebhookAuthenticationParametersException.struct_class = Types::InvalidWebhookAuthenticationParametersException
+
+    InvalidWebhookFilterPatternException.struct_class = Types::InvalidWebhookFilterPatternException
 
     Job.add_member(:id, Shapes::ShapeRef.new(shape: JobId, location_name: "id"))
     Job.add_member(:data, Shapes::ShapeRef.new(shape: JobData, location_name: "data"))
@@ -633,6 +663,10 @@ module Aws::CodePipeline
     JobDetails.struct_class = Types::JobDetails
 
     JobList.member = Shapes::ShapeRef.new(shape: Job)
+
+    JobNotFoundException.struct_class = Types::JobNotFoundException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListActionExecutionsInput.add_member(:pipeline_name, Shapes::ShapeRef.new(shape: PipelineName, required: true, location_name: "pipelineName"))
     ListActionExecutionsInput.add_member(:filter, Shapes::ShapeRef.new(shape: ActionExecutionFilter, location_name: "filter"))
@@ -694,6 +728,8 @@ module Aws::CodePipeline
     ListWebhooksOutput.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListWebhooksOutput.struct_class = Types::ListWebhooksOutput
 
+    NotLatestPipelineExecutionException.struct_class = Types::NotLatestPipelineExecutionException
+
     OutputArtifact.add_member(:name, Shapes::ShapeRef.new(shape: ArtifactName, required: true, location_name: "name"))
     OutputArtifact.struct_class = Types::OutputArtifact
 
@@ -727,6 +763,8 @@ module Aws::CodePipeline
     PipelineExecution.add_member(:artifact_revisions, Shapes::ShapeRef.new(shape: ArtifactRevisionList, location_name: "artifactRevisions"))
     PipelineExecution.struct_class = Types::PipelineExecution
 
+    PipelineExecutionNotFoundException.struct_class = Types::PipelineExecutionNotFoundException
+
     PipelineExecutionNotStoppableException.add_member(:message, Shapes::ShapeRef.new(shape: Message, location_name: "message"))
     PipelineExecutionNotStoppableException.struct_class = Types::PipelineExecutionNotStoppableException
 
@@ -748,6 +786,10 @@ module Aws::CodePipeline
     PipelineMetadata.add_member(:updated, Shapes::ShapeRef.new(shape: Timestamp, location_name: "updated"))
     PipelineMetadata.struct_class = Types::PipelineMetadata
 
+    PipelineNameInUseException.struct_class = Types::PipelineNameInUseException
+
+    PipelineNotFoundException.struct_class = Types::PipelineNotFoundException
+
     PipelineStageDeclarationList.member = Shapes::ShapeRef.new(shape: StageDeclaration)
 
     PipelineSummary.add_member(:name, Shapes::ShapeRef.new(shape: PipelineName, location_name: "name"))
@@ -755,6 +797,8 @@ module Aws::CodePipeline
     PipelineSummary.add_member(:created, Shapes::ShapeRef.new(shape: Timestamp, location_name: "created"))
     PipelineSummary.add_member(:updated, Shapes::ShapeRef.new(shape: Timestamp, location_name: "updated"))
     PipelineSummary.struct_class = Types::PipelineSummary
+
+    PipelineVersionNotFoundException.struct_class = Types::PipelineVersionNotFoundException
 
     PollForJobsInput.add_member(:action_type_id, Shapes::ShapeRef.new(shape: ActionTypeId, required: true, location_name: "actionTypeId"))
     PollForJobsInput.add_member(:max_batch_size, Shapes::ShapeRef.new(shape: MaxBatchSize, location_name: "maxBatchSize"))
@@ -832,6 +876,8 @@ module Aws::CodePipeline
     ResolvedActionConfigurationMap.key = Shapes::ShapeRef.new(shape: String)
     ResolvedActionConfigurationMap.value = Shapes::ShapeRef.new(shape: String)
 
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     RetryStageExecutionInput.add_member(:pipeline_name, Shapes::ShapeRef.new(shape: PipelineName, required: true, location_name: "pipelineName"))
     RetryStageExecutionInput.add_member(:stage_name, Shapes::ShapeRef.new(shape: StageName, required: true, location_name: "stageName"))
     RetryStageExecutionInput.add_member(:pipeline_execution_id, Shapes::ShapeRef.new(shape: PipelineExecutionId, required: true, location_name: "pipelineExecutionId"))
@@ -872,6 +918,10 @@ module Aws::CodePipeline
     StageExecution.add_member(:pipeline_execution_id, Shapes::ShapeRef.new(shape: PipelineExecutionId, required: true, location_name: "pipelineExecutionId"))
     StageExecution.add_member(:status, Shapes::ShapeRef.new(shape: StageExecutionStatus, required: true, location_name: "status"))
     StageExecution.struct_class = Types::StageExecution
+
+    StageNotFoundException.struct_class = Types::StageNotFoundException
+
+    StageNotRetryableException.struct_class = Types::StageNotRetryableException
 
     StageState.add_member(:stage_name, Shapes::ShapeRef.new(shape: StageName, location_name: "stageName"))
     StageState.add_member(:inbound_transition_state, Shapes::ShapeRef.new(shape: TransitionState, location_name: "inboundTransitionState"))
@@ -956,6 +1006,8 @@ module Aws::CodePipeline
     UpdatePipelineOutput.add_member(:pipeline, Shapes::ShapeRef.new(shape: PipelineDeclaration, location_name: "pipeline"))
     UpdatePipelineOutput.struct_class = Types::UpdatePipelineOutput
 
+    ValidationException.struct_class = Types::ValidationException
+
     WebhookAuthConfiguration.add_member(:allowed_ip_range, Shapes::ShapeRef.new(shape: WebhookAuthConfigurationAllowedIPRange, location_name: "AllowedIPRange"))
     WebhookAuthConfiguration.add_member(:secret_token, Shapes::ShapeRef.new(shape: WebhookAuthConfigurationSecretToken, location_name: "SecretToken"))
     WebhookAuthConfiguration.struct_class = Types::WebhookAuthConfiguration
@@ -975,6 +1027,8 @@ module Aws::CodePipeline
     WebhookFilters.member = Shapes::ShapeRef.new(shape: WebhookFilterRule)
 
     WebhookList.member = Shapes::ShapeRef.new(shape: ListWebhookItem)
+
+    WebhookNotFoundException.struct_class = Types::WebhookNotFoundException
 
 
     # @api private

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
@@ -10,6 +10,39 @@ module Aws::CodePipeline
 
     extend Aws::Errors::DynamicErrors
 
+    class ActionNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::ActionNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ActionTypeNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::ActionTypeNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ApprovalAlreadyCompletedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::ApprovalAlreadyCompletedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class ConcurrentModificationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -42,6 +75,28 @@ module Aws::CodePipeline
 
     end
 
+    class InvalidActionDeclarationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidActionDeclarationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidApprovalTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidApprovalTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidArnException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -54,6 +109,94 @@ module Aws::CodePipeline
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvalidBlockerDeclarationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidBlockerDeclarationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClientTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidClientTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidJobException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidJobException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidJobStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidJobStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNonceException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidNonceException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStageDeclarationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidStageDeclarationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStructureException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidStructureException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -74,6 +217,61 @@ module Aws::CodePipeline
 
     end
 
+    class InvalidWebhookAuthenticationParametersException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidWebhookAuthenticationParametersException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidWebhookFilterPatternException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::InvalidWebhookFilterPatternException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class JobNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::JobNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NotLatestPipelineExecutionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::NotLatestPipelineExecutionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class OutputVariablesSizeExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -86,6 +284,17 @@ module Aws::CodePipeline
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class PipelineExecutionNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::PipelineExecutionNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -106,6 +315,72 @@ module Aws::CodePipeline
 
     end
 
+    class PipelineNameInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::PipelineNameInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PipelineNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::PipelineNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PipelineVersionNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::PipelineVersionNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StageNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::StageNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StageNotRetryableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::StageNotRetryableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class TooManyTagsException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -118,6 +393,28 @@ module Aws::CodePipeline
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class WebhookNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodePipeline::Types::WebhookNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
@@ -578,6 +578,12 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The specified action cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/ActionNotFoundException AWS API Documentation
+    #
+    class ActionNotFoundException < Aws::EmptyStructure; end
+
     # Represents information about the version (or revision) of an action.
     #
     # @note When making an API call, you may pass ActionRevision
@@ -732,6 +738,12 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The specified action type cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/ActionTypeNotFoundException AWS API Documentation
+    #
+    class ActionTypeNotFoundException < Aws::EmptyStructure; end
+
     # Returns information about the settings for an action type.
     #
     # @note When making an API call, you may pass ActionTypeSettings
@@ -780,6 +792,12 @@ module Aws::CodePipeline
       :revision_url_template)
       include Aws::Structure
     end
+
+    # The approval action has already been approved or rejected.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/ApprovalAlreadyCompletedException AWS API Documentation
+    #
+    class ApprovalAlreadyCompletedException < Aws::EmptyStructure; end
 
     # Represents information about the result of an approval request.
     #
@@ -1905,6 +1923,18 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The action declaration was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidActionDeclarationException AWS API Documentation
+    #
+    class InvalidActionDeclarationException < Aws::EmptyStructure; end
+
+    # The approval request already received a response or has expired.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidApprovalTokenException AWS API Documentation
+    #
+    class InvalidApprovalTokenException < Aws::EmptyStructure; end
+
     # The specified resource ARN is invalid.
     #
     # @!attribute [rw] message
@@ -1917,6 +1947,55 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # Reserved for future use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidBlockerDeclarationException AWS API Documentation
+    #
+    class InvalidBlockerDeclarationException < Aws::EmptyStructure; end
+
+    # The client token was specified in an invalid format
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidClientTokenException AWS API Documentation
+    #
+    class InvalidClientTokenException < Aws::EmptyStructure; end
+
+    # The job was specified in an invalid format or cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidJobException AWS API Documentation
+    #
+    class InvalidJobException < Aws::EmptyStructure; end
+
+    # The job state was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidJobStateException AWS API Documentation
+    #
+    class InvalidJobStateException < Aws::EmptyStructure; end
+
+    # The next token was specified in an invalid format. Make sure that the
+    # next token you provide is the token returned by a previous call.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
+    # The nonce was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidNonceException AWS API Documentation
+    #
+    class InvalidNonceException < Aws::EmptyStructure; end
+
+    # The stage declaration was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidStageDeclarationException AWS API Documentation
+    #
+    class InvalidStageDeclarationException < Aws::EmptyStructure; end
+
+    # The structure was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidStructureException AWS API Documentation
+    #
+    class InvalidStructureException < Aws::EmptyStructure; end
+
     # The specified resource tags are invalid.
     #
     # @!attribute [rw] message
@@ -1928,6 +2007,18 @@ module Aws::CodePipeline
       :message)
       include Aws::Structure
     end
+
+    # The specified authentication type is in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidWebhookAuthenticationParametersException AWS API Documentation
+    #
+    class InvalidWebhookAuthenticationParametersException < Aws::EmptyStructure; end
+
+    # The specified event filter rule is in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/InvalidWebhookFilterPatternException AWS API Documentation
+    #
+    class InvalidWebhookFilterPatternException < Aws::EmptyStructure; end
 
     # Represents information about a job.
     #
@@ -2041,6 +2132,19 @@ module Aws::CodePipeline
       :account_id)
       include Aws::Structure
     end
+
+    # The job was specified in an invalid format or cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/JobNotFoundException AWS API Documentation
+    #
+    class JobNotFoundException < Aws::EmptyStructure; end
+
+    # The number of pipelines associated with the AWS account has exceeded
+    # the limit allowed for the account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListActionExecutionsInput
     #   data as a hash:
@@ -2410,6 +2514,13 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The stage has failed in a later run of the pipeline and the
+    # pipelineExecutionId associated with the request is out of date.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/NotLatestPipelineExecutionException AWS API Documentation
+    #
+    class NotLatestPipelineExecutionException < Aws::EmptyStructure; end
+
     # Represents information about the output of an action.
     #
     # @note When making an API call, you may pass OutputArtifact
@@ -2675,6 +2786,13 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The pipeline execution was specified in an invalid format or cannot be
+    # found, or an execution ID does not belong to the specified pipeline.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/PipelineExecutionNotFoundException AWS API Documentation
+    #
+    class PipelineExecutionNotFoundException < Aws::EmptyStructure; end
+
     # Unable to stop the pipeline execution. The execution might already be
     # in a `Stopped` state, or it might no longer be in progress.
     #
@@ -2783,6 +2901,18 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The specified pipeline name is already in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/PipelineNameInUseException AWS API Documentation
+    #
+    class PipelineNameInUseException < Aws::EmptyStructure; end
+
+    # The pipeline was specified in an invalid format or cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/PipelineNotFoundException AWS API Documentation
+    #
+    class PipelineNotFoundException < Aws::EmptyStructure; end
+
     # Returns a summary of a pipeline.
     #
     # @!attribute [rw] name
@@ -2811,6 +2941,13 @@ module Aws::CodePipeline
       :updated)
       include Aws::Structure
     end
+
+    # The pipeline version was specified in an invalid format or cannot be
+    # found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/PipelineVersionNotFoundException AWS API Documentation
+    #
+    class PipelineVersionNotFoundException < Aws::EmptyStructure; end
 
     # Represents the input of a `PollForJobs` action.
     #
@@ -3319,6 +3456,12 @@ module Aws::CodePipeline
     #
     class RegisterWebhookWithThirdPartyOutput < Aws::EmptyStructure; end
 
+    # The resource was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # Represents the input of a `RetryStageExecution` action.
     #
     # @note When making an API call, you may pass RetryStageExecutionInput
@@ -3542,6 +3685,20 @@ module Aws::CodePipeline
       :status)
       include Aws::Structure
     end
+
+    # The stage was specified in an invalid format or cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/StageNotFoundException AWS API Documentation
+    #
+    class StageNotFoundException < Aws::EmptyStructure; end
+
+    # Unable to retry. The pipeline structure or stage state might have
+    # changed while actions awaited retry, or the stage contains no failed
+    # actions.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/StageNotRetryableException AWS API Documentation
+    #
+    class StageNotRetryableException < Aws::EmptyStructure; end
 
     # Represents information about the state of the stage.
     #
@@ -4024,6 +4181,12 @@ module Aws::CodePipeline
       include Aws::Structure
     end
 
+    # The validation was specified in an invalid format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/ValidationException AWS API Documentation
+    #
+    class ValidationException < Aws::EmptyStructure; end
+
     # The authentication applied to incoming webhook trigger requests.
     #
     # @note When making an API call, you may pass WebhookAuthConfiguration
@@ -4183,6 +4346,13 @@ module Aws::CodePipeline
       :match_equals)
       include Aws::Structure
     end
+
+    # The specified webhook was entered in an invalid format or cannot be
+    # found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codepipeline-2015-07-09/WebhookNotFoundException AWS API Documentation
+    #
+    class WebhookNotFoundException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
@@ -141,6 +141,8 @@ module Aws::CodeStar
     CodeSource.add_member(:s3, Shapes::ShapeRef.new(shape: S3Location, required: true, location_name: "s3"))
     CodeSource.struct_class = Types::CodeSource
 
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
+
     CreateProjectRequest.add_member(:name, Shapes::ShapeRef.new(shape: ProjectName, required: true, location_name: "name"))
     CreateProjectRequest.add_member(:id, Shapes::ShapeRef.new(shape: ProjectId, required: true, location_name: "id"))
     CreateProjectRequest.add_member(:description, Shapes::ShapeRef.new(shape: ProjectDescription, location_name: "description"))
@@ -225,6 +227,12 @@ module Aws::CodeStar
     GitHubCodeDestination.add_member(:token, Shapes::ShapeRef.new(shape: GitHubPersonalToken, required: true, location_name: "token"))
     GitHubCodeDestination.struct_class = Types::GitHubCodeDestination
 
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
+    InvalidServiceRoleException.struct_class = Types::InvalidServiceRoleException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     ListProjectsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: PaginationToken, location_name: "nextToken"))
     ListProjectsRequest.add_member(:max_results, Shapes::ShapeRef.new(shape: MaxResults, location_name: "maxResults", metadata: {"box"=>true}))
     ListProjectsRequest.struct_class = Types::ListProjectsRequest
@@ -268,6 +276,14 @@ module Aws::CodeStar
     ListUserProfilesResult.add_member(:next_token, Shapes::ShapeRef.new(shape: PaginationToken, location_name: "nextToken"))
     ListUserProfilesResult.struct_class = Types::ListUserProfilesResult
 
+    ProjectAlreadyExistsException.struct_class = Types::ProjectAlreadyExistsException
+
+    ProjectConfigurationException.struct_class = Types::ProjectConfigurationException
+
+    ProjectCreationFailedException.struct_class = Types::ProjectCreationFailedException
+
+    ProjectNotFoundException.struct_class = Types::ProjectNotFoundException
+
     ProjectStatus.add_member(:state, Shapes::ShapeRef.new(shape: State, required: true, location_name: "state"))
     ProjectStatus.add_member(:reason, Shapes::ShapeRef.new(shape: Reason, location_name: "reason"))
     ProjectStatus.struct_class = Types::ProjectStatus
@@ -305,6 +321,10 @@ module Aws::CodeStar
     TeamMember.add_member(:project_role, Shapes::ShapeRef.new(shape: Role, required: true, location_name: "projectRole"))
     TeamMember.add_member(:remote_access_allowed, Shapes::ShapeRef.new(shape: RemoteAccessAllowed, location_name: "remoteAccessAllowed", metadata: {"box"=>true}))
     TeamMember.struct_class = Types::TeamMember
+
+    TeamMemberAlreadyAssociatedException.struct_class = Types::TeamMemberAlreadyAssociatedException
+
+    TeamMemberNotFoundException.struct_class = Types::TeamMemberNotFoundException
 
     TeamMemberResult.member = Shapes::ShapeRef.new(shape: TeamMember)
 
@@ -357,6 +377,10 @@ module Aws::CodeStar
     UpdateUserProfileResult.add_member(:last_modified_timestamp, Shapes::ShapeRef.new(shape: LastModifiedTimestamp, location_name: "lastModifiedTimestamp"))
     UpdateUserProfileResult.struct_class = Types::UpdateUserProfileResult
 
+    UserProfileAlreadyExistsException.struct_class = Types::UserProfileAlreadyExistsException
+
+    UserProfileNotFoundException.struct_class = Types::UserProfileNotFoundException
+
     UserProfileSummary.add_member(:user_arn, Shapes::ShapeRef.new(shape: UserArn, location_name: "userArn"))
     UserProfileSummary.add_member(:display_name, Shapes::ShapeRef.new(shape: UserProfileDisplayName, location_name: "displayName"))
     UserProfileSummary.add_member(:email_address, Shapes::ShapeRef.new(shape: Email, location_name: "emailAddress"))
@@ -364,6 +388,8 @@ module Aws::CodeStar
     UserProfileSummary.struct_class = Types::UserProfileSummary
 
     UserProfilesList.member = Shapes::ShapeRef.new(shape: UserProfileSummary)
+
+    ValidationException.struct_class = Types::ValidationException
 
 
     # @api private

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
@@ -10,5 +10,148 @@ module Aws::CodeStar
 
     extend Aws::Errors::DynamicErrors
 
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidServiceRoleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::InvalidServiceRoleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProjectAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ProjectAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProjectConfigurationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ProjectConfigurationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProjectCreationFailedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ProjectCreationFailedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProjectNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ProjectNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TeamMemberAlreadyAssociatedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::TeamMemberAlreadyAssociatedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TeamMemberNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::TeamMemberNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UserProfileAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::UserProfileAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UserProfileNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::UserProfileNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::CodeStar::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
@@ -212,6 +212,13 @@ module Aws::CodeStar
       include Aws::Structure
     end
 
+    # Another modification is being made. That modification must complete
+    # before you can make your change.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass CreateProjectRequest
     #   data as a hash:
     #
@@ -735,6 +742,24 @@ module Aws::CodeStar
       include Aws::Structure
     end
 
+    # The next token is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
+    # The service role is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/InvalidServiceRoleException AWS API Documentation
+    #
+    class InvalidServiceRoleException < Aws::EmptyStructure; end
+
+    # A resource limit has been exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass ListProjectsRequest
     #   data as a hash:
     #
@@ -963,6 +988,34 @@ module Aws::CodeStar
       include Aws::Structure
     end
 
+    # An AWS CodeStar project with the same ID already exists in this region
+    # for the AWS account. AWS CodeStar project IDs must be unique within a
+    # region for the AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ProjectAlreadyExistsException AWS API Documentation
+    #
+    class ProjectAlreadyExistsException < Aws::EmptyStructure; end
+
+    # Project configuration information is required but not specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ProjectConfigurationException AWS API Documentation
+    #
+    class ProjectConfigurationException < Aws::EmptyStructure; end
+
+    # The project creation request was valid, but a nonspecific exception or
+    # error occurred during project creation. The project could not be
+    # created in AWS CodeStar.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ProjectCreationFailedException AWS API Documentation
+    #
+    class ProjectCreationFailedException < Aws::EmptyStructure; end
+
+    # The specified AWS CodeStar project was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ProjectNotFoundException AWS API Documentation
+    #
+    class ProjectNotFoundException < Aws::EmptyStructure; end
+
     # An indication of whether a project creation or deletion is failed or
     # successful.
     #
@@ -1109,6 +1162,18 @@ module Aws::CodeStar
       :remote_access_allowed)
       include Aws::Structure
     end
+
+    # The team member is already associated with a role in this project.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/TeamMemberAlreadyAssociatedException AWS API Documentation
+    #
+    class TeamMemberAlreadyAssociatedException < Aws::EmptyStructure; end
+
+    # The specified team member was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/TeamMemberNotFoundException AWS API Documentation
+    #
+    class TeamMemberNotFoundException < Aws::EmptyStructure; end
 
     # The toolchain template file provided with the project request. AWS
     # CodeStar uses the template to provision the toolchain stack in AWS
@@ -1396,6 +1461,20 @@ module Aws::CodeStar
       include Aws::Structure
     end
 
+    # A user profile with that name already exists in this region for the
+    # AWS account. AWS CodeStar user profile names must be unique within a
+    # region for the AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/UserProfileAlreadyExistsException AWS API Documentation
+    #
+    class UserProfileAlreadyExistsException < Aws::EmptyStructure; end
+
+    # The user profile was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/UserProfileNotFoundException AWS API Documentation
+    #
+    class UserProfileNotFoundException < Aws::EmptyStructure; end
+
     # Information about a user's profile in AWS CodeStar.
     #
     # @!attribute [rw] user_arn
@@ -1435,6 +1514,12 @@ module Aws::CodeStar
       :ssh_public_key)
       include Aws::Structure
     end
+
+    # The specified input is either not valid, or it could not be validated.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/codestar-2017-04-19/ValidationException AWS API Documentation
+    #
+    class ValidationException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
@@ -781,6 +781,8 @@ module Aws::ConfigService
 
     ConformancePackStatusDetailsList.member = Shapes::ShapeRef.new(shape: ConformancePackStatusDetail)
 
+    ConformancePackTemplateValidationException.struct_class = Types::ConformancePackTemplateValidationException
+
     DeleteAggregationAuthorizationRequest.add_member(:authorized_account_id, Shapes::ShapeRef.new(shape: AccountId, required: true, location_name: "AuthorizedAccountId"))
     DeleteAggregationAuthorizationRequest.add_member(:authorized_aws_region, Shapes::ShapeRef.new(shape: AwsRegion, required: true, location_name: "AuthorizedAwsRegion"))
     DeleteAggregationAuthorizationRequest.struct_class = Types::DeleteAggregationAuthorizationRequest
@@ -1266,6 +1268,38 @@ module Aws::ConfigService
 
     GroupedResourceCountList.member = Shapes::ShapeRef.new(shape: GroupedResourceCount)
 
+    InsufficientDeliveryPolicyException.struct_class = Types::InsufficientDeliveryPolicyException
+
+    InsufficientPermissionsException.struct_class = Types::InsufficientPermissionsException
+
+    InvalidConfigurationRecorderNameException.struct_class = Types::InvalidConfigurationRecorderNameException
+
+    InvalidDeliveryChannelNameException.struct_class = Types::InvalidDeliveryChannelNameException
+
+    InvalidExpressionException.struct_class = Types::InvalidExpressionException
+
+    InvalidLimitException.struct_class = Types::InvalidLimitException
+
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
+    InvalidParameterValueException.struct_class = Types::InvalidParameterValueException
+
+    InvalidRecordingGroupException.struct_class = Types::InvalidRecordingGroupException
+
+    InvalidResultTokenException.struct_class = Types::InvalidResultTokenException
+
+    InvalidRoleException.struct_class = Types::InvalidRoleException
+
+    InvalidS3KeyPrefixException.struct_class = Types::InvalidS3KeyPrefixException
+
+    InvalidSNSTopicARNException.struct_class = Types::InvalidSNSTopicARNException
+
+    InvalidTimeRangeException.struct_class = Types::InvalidTimeRangeException
+
+    LastDeliveryChannelDeleteFailedException.struct_class = Types::LastDeliveryChannelDeleteFailedException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     ListAggregateDiscoveredResourcesRequest.add_member(:configuration_aggregator_name, Shapes::ShapeRef.new(shape: ConfigurationAggregatorName, required: true, location_name: "ConfigurationAggregatorName"))
     ListAggregateDiscoveredResourcesRequest.add_member(:resource_type, Shapes::ShapeRef.new(shape: ResourceType, required: true, location_name: "ResourceType"))
     ListAggregateDiscoveredResourcesRequest.add_member(:filters, Shapes::ShapeRef.new(shape: ResourceFilters, location_name: "Filters"))
@@ -1298,6 +1332,22 @@ module Aws::ConfigService
     ListTagsForResourceResponse.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListTagsForResourceResponse.struct_class = Types::ListTagsForResourceResponse
 
+    MaxActiveResourcesExceededException.struct_class = Types::MaxActiveResourcesExceededException
+
+    MaxNumberOfConfigRulesExceededException.struct_class = Types::MaxNumberOfConfigRulesExceededException
+
+    MaxNumberOfConfigurationRecordersExceededException.struct_class = Types::MaxNumberOfConfigurationRecordersExceededException
+
+    MaxNumberOfConformancePacksExceededException.struct_class = Types::MaxNumberOfConformancePacksExceededException
+
+    MaxNumberOfDeliveryChannelsExceededException.struct_class = Types::MaxNumberOfDeliveryChannelsExceededException
+
+    MaxNumberOfOrganizationConfigRulesExceededException.struct_class = Types::MaxNumberOfOrganizationConfigRulesExceededException
+
+    MaxNumberOfOrganizationConformancePacksExceededException.struct_class = Types::MaxNumberOfOrganizationConformancePacksExceededException
+
+    MaxNumberOfRetentionConfigurationsExceededException.struct_class = Types::MaxNumberOfRetentionConfigurationsExceededException
+
     MemberAccountStatus.add_member(:account_id, Shapes::ShapeRef.new(shape: AccountId, required: true, location_name: "AccountId"))
     MemberAccountStatus.add_member(:config_rule_name, Shapes::ShapeRef.new(shape: StringWithCharLimit64, required: true, location_name: "ConfigRuleName"))
     MemberAccountStatus.add_member(:member_account_rule_status, Shapes::ShapeRef.new(shape: MemberAccountRuleStatus, required: true, location_name: "MemberAccountRuleStatus"))
@@ -1306,10 +1356,46 @@ module Aws::ConfigService
     MemberAccountStatus.add_member(:last_update_time, Shapes::ShapeRef.new(shape: Date, location_name: "LastUpdateTime"))
     MemberAccountStatus.struct_class = Types::MemberAccountStatus
 
+    NoAvailableConfigurationRecorderException.struct_class = Types::NoAvailableConfigurationRecorderException
+
+    NoAvailableDeliveryChannelException.struct_class = Types::NoAvailableDeliveryChannelException
+
+    NoAvailableOrganizationException.struct_class = Types::NoAvailableOrganizationException
+
+    NoRunningConfigurationRecorderException.struct_class = Types::NoRunningConfigurationRecorderException
+
+    NoSuchBucketException.struct_class = Types::NoSuchBucketException
+
+    NoSuchConfigRuleException.struct_class = Types::NoSuchConfigRuleException
+
+    NoSuchConfigRuleInConformancePackException.struct_class = Types::NoSuchConfigRuleInConformancePackException
+
+    NoSuchConfigurationAggregatorException.struct_class = Types::NoSuchConfigurationAggregatorException
+
+    NoSuchConfigurationRecorderException.struct_class = Types::NoSuchConfigurationRecorderException
+
+    NoSuchConformancePackException.struct_class = Types::NoSuchConformancePackException
+
+    NoSuchDeliveryChannelException.struct_class = Types::NoSuchDeliveryChannelException
+
+    NoSuchOrganizationConfigRuleException.struct_class = Types::NoSuchOrganizationConfigRuleException
+
+    NoSuchOrganizationConformancePackException.struct_class = Types::NoSuchOrganizationConformancePackException
+
+    NoSuchRemediationConfigurationException.struct_class = Types::NoSuchRemediationConfigurationException
+
+    NoSuchRemediationExceptionException.struct_class = Types::NoSuchRemediationExceptionException
+
+    NoSuchRetentionConfigurationException.struct_class = Types::NoSuchRetentionConfigurationException
+
+    OrganizationAccessDeniedException.struct_class = Types::OrganizationAccessDeniedException
+
     OrganizationAggregationSource.add_member(:role_arn, Shapes::ShapeRef.new(shape: String, required: true, location_name: "RoleArn"))
     OrganizationAggregationSource.add_member(:aws_regions, Shapes::ShapeRef.new(shape: AggregatorRegionList, location_name: "AwsRegions"))
     OrganizationAggregationSource.add_member(:all_aws_regions, Shapes::ShapeRef.new(shape: Boolean, location_name: "AllAwsRegions"))
     OrganizationAggregationSource.struct_class = Types::OrganizationAggregationSource
+
+    OrganizationAllFeaturesNotEnabledException.struct_class = Types::OrganizationAllFeaturesNotEnabledException
 
     OrganizationConfigRule.add_member(:organization_config_rule_name, Shapes::ShapeRef.new(shape: OrganizationConfigRuleName, required: true, location_name: "OrganizationConfigRuleName"))
     OrganizationConfigRule.add_member(:organization_config_rule_arn, Shapes::ShapeRef.new(shape: StringWithCharLimit256, required: true, location_name: "OrganizationConfigRuleArn"))
@@ -1366,6 +1452,8 @@ module Aws::ConfigService
 
     OrganizationConformancePackStatuses.member = Shapes::ShapeRef.new(shape: OrganizationConformancePackStatus)
 
+    OrganizationConformancePackTemplateValidationException.struct_class = Types::OrganizationConformancePackTemplateValidationException
+
     OrganizationConformancePacks.member = Shapes::ShapeRef.new(shape: OrganizationConformancePack)
 
     OrganizationCustomRuleMetadata.add_member(:description, Shapes::ShapeRef.new(shape: StringWithCharLimit256Min0, location_name: "Description"))
@@ -1392,6 +1480,8 @@ module Aws::ConfigService
     OrganizationResourceDetailedStatusFilters.add_member(:account_id, Shapes::ShapeRef.new(shape: AccountId, location_name: "AccountId"))
     OrganizationResourceDetailedStatusFilters.add_member(:status, Shapes::ShapeRef.new(shape: OrganizationResourceDetailedStatus, location_name: "Status"))
     OrganizationResourceDetailedStatusFilters.struct_class = Types::OrganizationResourceDetailedStatusFilters
+
+    OversizedConfigurationItemException.struct_class = Types::OversizedConfigurationItemException
 
     PendingAggregationRequest.add_member(:requester_account_id, Shapes::ShapeRef.new(shape: AccountId, location_name: "RequesterAccountId"))
     PendingAggregationRequest.add_member(:requester_aws_region, Shapes::ShapeRef.new(shape: AwsRegion, location_name: "RequesterAwsRegion"))
@@ -1564,6 +1654,8 @@ module Aws::ConfigService
 
     RemediationExecutionSteps.member = Shapes::ShapeRef.new(shape: RemediationExecutionStep)
 
+    RemediationInProgressException.struct_class = Types::RemediationInProgressException
+
     RemediationParameterValue.add_member(:resource_value, Shapes::ShapeRef.new(shape: ResourceValue, location_name: "ResourceValue"))
     RemediationParameterValue.add_member(:static_value, Shapes::ShapeRef.new(shape: StaticValue, location_name: "StaticValue"))
     RemediationParameterValue.struct_class = Types::RemediationParameterValue
@@ -1600,11 +1692,17 @@ module Aws::ConfigService
 
     ResourceIdentifiersList.member = Shapes::ShapeRef.new(shape: AggregateResourceIdentifier)
 
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
     ResourceKey.add_member(:resource_type, Shapes::ShapeRef.new(shape: ResourceType, required: true, location_name: "resourceType"))
     ResourceKey.add_member(:resource_id, Shapes::ShapeRef.new(shape: ResourceId, required: true, location_name: "resourceId"))
     ResourceKey.struct_class = Types::ResourceKey
 
     ResourceKeys.member = Shapes::ShapeRef.new(shape: ResourceKey)
+
+    ResourceNotDiscoveredException.struct_class = Types::ResourceNotDiscoveredException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
 
     ResourceTypeList.member = Shapes::ShapeRef.new(shape: ResourceType)
 
@@ -1705,11 +1803,15 @@ module Aws::ConfigService
 
     TagsList.member = Shapes::ShapeRef.new(shape: Tag)
 
+    TooManyTagsException.struct_class = Types::TooManyTagsException
+
     UnprocessedResourceIdentifierList.member = Shapes::ShapeRef.new(shape: AggregateResourceIdentifier)
 
     UntagResourceRequest.add_member(:resource_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "ResourceArn"))
     UntagResourceRequest.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "TagKeys"))
     UntagResourceRequest.struct_class = Types::UntagResourceRequest
+
+    ValidationException.struct_class = Types::ValidationException
 
 
     # @api private

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
@@ -10,5 +10,566 @@ module Aws::ConfigService
 
     extend Aws::Errors::DynamicErrors
 
+    class ConformancePackTemplateValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::ConformancePackTemplateValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDeliveryPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InsufficientDeliveryPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientPermissionsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InsufficientPermissionsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConfigurationRecorderNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidConfigurationRecorderNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeliveryChannelNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidDeliveryChannelNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidExpressionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidExpressionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLimitException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidLimitException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterValueException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidParameterValueException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRecordingGroupException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidRecordingGroupException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidResultTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidResultTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRoleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidRoleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3KeyPrefixException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidS3KeyPrefixException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSNSTopicARNException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidSNSTopicARNException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTimeRangeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::InvalidTimeRangeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LastDeliveryChannelDeleteFailedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::LastDeliveryChannelDeleteFailedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxActiveResourcesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxActiveResourcesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfConfigRulesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfConfigRulesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfConfigurationRecordersExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfConfigurationRecordersExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfConformancePacksExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfConformancePacksExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfDeliveryChannelsExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfDeliveryChannelsExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfOrganizationConfigRulesExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfOrganizationConfigRulesExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfOrganizationConformancePacksExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfOrganizationConformancePacksExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MaxNumberOfRetentionConfigurationsExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::MaxNumberOfRetentionConfigurationsExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoAvailableConfigurationRecorderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoAvailableConfigurationRecorderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoAvailableDeliveryChannelException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoAvailableDeliveryChannelException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoAvailableOrganizationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoAvailableOrganizationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoRunningConfigurationRecorderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoRunningConfigurationRecorderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchBucketException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchBucketException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchConfigRuleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchConfigRuleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchConfigRuleInConformancePackException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchConfigRuleInConformancePackException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchConfigurationAggregatorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchConfigurationAggregatorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchConfigurationRecorderException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchConfigurationRecorderException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchConformancePackException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchConformancePackException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchDeliveryChannelException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchDeliveryChannelException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchOrganizationConfigRuleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchOrganizationConfigRuleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchOrganizationConformancePackException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchOrganizationConformancePackException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchRemediationConfigurationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchRemediationConfigurationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchRemediationExceptionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchRemediationExceptionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchRetentionConfigurationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::NoSuchRetentionConfigurationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OrganizationAccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::OrganizationAccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OrganizationAllFeaturesNotEnabledException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::OrganizationAllFeaturesNotEnabledException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OrganizationConformancePackTemplateValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::OrganizationConformancePackTemplateValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OversizedConfigurationItemException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::OversizedConfigurationItemException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RemediationInProgressException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::RemediationInProgressException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotDiscoveredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::ResourceNotDiscoveredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ConfigService::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
@@ -1583,6 +1583,12 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # You have specified a template that is not valid or supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/ConformancePackTemplateValidationException AWS API Documentation
+    #
+    class ConformancePackTemplateValidationException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass DeleteAggregationAuthorizationRequest
     #   data as a hash:
     #
@@ -4363,6 +4369,134 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # Your Amazon S3 bucket policy does not permit AWS Config to write to
+    # it.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InsufficientDeliveryPolicyException AWS API Documentation
+    #
+    class InsufficientDeliveryPolicyException < Aws::EmptyStructure; end
+
+    # Indicates one of the following errors:
+    #
+    # * For PutConfigRule, the rule cannot be created because the IAM role
+    #   assigned to AWS Config lacks permissions to perform the config:Put*
+    #   action.
+    #
+    # * For PutConfigRule, the AWS Lambda function cannot be invoked. Check
+    #   the function ARN, and check the function's permissions.
+    #
+    # * For PutOrganizationConfigRule, organization config rule cannot be
+    #   created because you do not have permissions to call IAM `GetRole`
+    #   action or create a service linked role.
+    #
+    # * For PutConformancePack and PutOrganizationConformancePack, a
+    #   conformance pack cannot be created because you do not have
+    #   permissions:
+    #
+    #   * To call IAM `GetRole` action or create a service linked role.
+    #
+    #   * To read Amazon S3 bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InsufficientPermissionsException AWS API Documentation
+    #
+    class InsufficientPermissionsException < Aws::EmptyStructure; end
+
+    # You have provided a configuration recorder name that is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidConfigurationRecorderNameException AWS API Documentation
+    #
+    class InvalidConfigurationRecorderNameException < Aws::EmptyStructure; end
+
+    # The specified delivery channel name is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidDeliveryChannelNameException AWS API Documentation
+    #
+    class InvalidDeliveryChannelNameException < Aws::EmptyStructure; end
+
+    # The syntax of the query is incorrect.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidExpressionException AWS API Documentation
+    #
+    class InvalidExpressionException < Aws::EmptyStructure; end
+
+    # The specified limit is outside the allowable range.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidLimitException AWS API Documentation
+    #
+    class InvalidLimitException < Aws::EmptyStructure; end
+
+    # The specified next token is invalid. Specify the `nextToken` string
+    # that was returned in the previous response to get the next page of
+    # results.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
+    # One or more of the specified parameters are invalid. Verify that your
+    # parameters are valid and try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidParameterValueException AWS API Documentation
+    #
+    class InvalidParameterValueException < Aws::EmptyStructure; end
+
+    # AWS Config throws an exception if the recording group does not contain
+    # a valid list of resource types. Invalid values might also be
+    # incorrectly formatted.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidRecordingGroupException AWS API Documentation
+    #
+    class InvalidRecordingGroupException < Aws::EmptyStructure; end
+
+    # The specified `ResultToken` is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidResultTokenException AWS API Documentation
+    #
+    class InvalidResultTokenException < Aws::EmptyStructure; end
+
+    # You have provided a null or empty role ARN.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidRoleException AWS API Documentation
+    #
+    class InvalidRoleException < Aws::EmptyStructure; end
+
+    # The specified Amazon S3 key prefix is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidS3KeyPrefixException AWS API Documentation
+    #
+    class InvalidS3KeyPrefixException < Aws::EmptyStructure; end
+
+    # The specified Amazon SNS topic does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidSNSTopicARNException AWS API Documentation
+    #
+    class InvalidSNSTopicARNException < Aws::EmptyStructure; end
+
+    # The specified time range is not valid. The earlier time is not
+    # chronologically before the later time.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/InvalidTimeRangeException AWS API Documentation
+    #
+    class InvalidTimeRangeException < Aws::EmptyStructure; end
+
+    # You cannot delete the delivery channel you specified because the
+    # configuration recorder is running.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/LastDeliveryChannelDeleteFailedException AWS API Documentation
+    #
+    class LastDeliveryChannelDeleteFailedException < Aws::EmptyStructure; end
+
+    # For `StartConfigRulesEvaluation` API, this exception is thrown if an
+    # evaluation is in progress or if you call the
+    # StartConfigRulesEvaluation API more than once per minute.
+    #
+    # For `PutConfigurationAggregator` API, this exception is thrown if the
+    # number of accounts and aggregators exceeds the limit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass ListAggregateDiscoveredResourcesRequest
     #   data as a hash:
     #
@@ -4561,6 +4695,63 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # You have reached the limit (100,000) of active custom resource types
+    # in your account. Delete unused resources using `DeleteResourceConfig`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxActiveResourcesExceededException AWS API Documentation
+    #
+    class MaxActiveResourcesExceededException < Aws::EmptyStructure; end
+
+    # Failed to add the AWS Config rule because the account already contains
+    # the maximum number of 150 rules. Consider deleting any deactivated
+    # rules before you add new rules.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfConfigRulesExceededException AWS API Documentation
+    #
+    class MaxNumberOfConfigRulesExceededException < Aws::EmptyStructure; end
+
+    # You have reached the limit of the number of recorders you can create.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfConfigurationRecordersExceededException AWS API Documentation
+    #
+    class MaxNumberOfConfigurationRecordersExceededException < Aws::EmptyStructure; end
+
+    # You have reached the limit (6) of the number of conformance packs in
+    # an account (6 conformance pack with 25 AWS Config rules per pack).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfConformancePacksExceededException AWS API Documentation
+    #
+    class MaxNumberOfConformancePacksExceededException < Aws::EmptyStructure; end
+
+    # You have reached the limit of the number of delivery channels you can
+    # create.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfDeliveryChannelsExceededException AWS API Documentation
+    #
+    class MaxNumberOfDeliveryChannelsExceededException < Aws::EmptyStructure; end
+
+    # You have reached the limit of the number of organization config rules
+    # you can create.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfOrganizationConfigRulesExceededException AWS API Documentation
+    #
+    class MaxNumberOfOrganizationConfigRulesExceededException < Aws::EmptyStructure; end
+
+    # You have reached the limit (6) of the number of organization
+    # conformance packs in an account (6 conformance pack with 25 AWS Config
+    # rules per pack per account).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfOrganizationConformancePacksExceededException AWS API Documentation
+    #
+    class MaxNumberOfOrganizationConformancePacksExceededException < Aws::EmptyStructure; end
+
+    # Failed to add the retention configuration because a retention
+    # configuration with that name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/MaxNumberOfRetentionConfigurationsExceededException AWS API Documentation
+    #
+    class MaxNumberOfRetentionConfigurationsExceededException < Aws::EmptyStructure; end
+
     # Organization config rule creation or deletion status in each member
     # account. This includes the name of the rule, the status, error code
     # and error message when the rule creation or deletion failed.
@@ -4639,6 +4830,119 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # There are no configuration recorders available to provide the role
+    # needed to describe your resources. Create a configuration recorder.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoAvailableConfigurationRecorderException AWS API Documentation
+    #
+    class NoAvailableConfigurationRecorderException < Aws::EmptyStructure; end
+
+    # There is no delivery channel available to record configurations.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoAvailableDeliveryChannelException AWS API Documentation
+    #
+    class NoAvailableDeliveryChannelException < Aws::EmptyStructure; end
+
+    # Organization is no longer available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoAvailableOrganizationException AWS API Documentation
+    #
+    class NoAvailableOrganizationException < Aws::EmptyStructure; end
+
+    # There is no configuration recorder running.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoRunningConfigurationRecorderException AWS API Documentation
+    #
+    class NoRunningConfigurationRecorderException < Aws::EmptyStructure; end
+
+    # The specified Amazon S3 bucket does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchBucketException AWS API Documentation
+    #
+    class NoSuchBucketException < Aws::EmptyStructure; end
+
+    # One or more AWS Config rules in the request are invalid. Verify that
+    # the rule names are correct and try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchConfigRuleException AWS API Documentation
+    #
+    class NoSuchConfigRuleException < Aws::EmptyStructure; end
+
+    # AWS Config rule that you passed in the filter does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchConfigRuleInConformancePackException AWS API Documentation
+    #
+    class NoSuchConfigRuleInConformancePackException < Aws::EmptyStructure; end
+
+    # You have specified a configuration aggregator that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchConfigurationAggregatorException AWS API Documentation
+    #
+    class NoSuchConfigurationAggregatorException < Aws::EmptyStructure; end
+
+    # You have specified a configuration recorder that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchConfigurationRecorderException AWS API Documentation
+    #
+    class NoSuchConfigurationRecorderException < Aws::EmptyStructure; end
+
+    # You specified one or more conformance packs that do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchConformancePackException AWS API Documentation
+    #
+    class NoSuchConformancePackException < Aws::EmptyStructure; end
+
+    # You have specified a delivery channel that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchDeliveryChannelException AWS API Documentation
+    #
+    class NoSuchDeliveryChannelException < Aws::EmptyStructure; end
+
+    # You specified one or more organization config rules that do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchOrganizationConfigRuleException AWS API Documentation
+    #
+    class NoSuchOrganizationConfigRuleException < Aws::EmptyStructure; end
+
+    # AWS Config organization conformance pack that you passed in the filter
+    # does not exist.
+    #
+    # For DeleteOrganizationConformancePack, you tried to delete an
+    # organization conformance pack that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchOrganizationConformancePackException AWS API Documentation
+    #
+    class NoSuchOrganizationConformancePackException < Aws::EmptyStructure; end
+
+    # You specified an AWS Config rule without a remediation configuration.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchRemediationConfigurationException AWS API Documentation
+    #
+    class NoSuchRemediationConfigurationException < Aws::EmptyStructure; end
+
+    # You tried to delete a remediation exception that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchRemediationExceptionException AWS API Documentation
+    #
+    class NoSuchRemediationExceptionException < Aws::EmptyStructure; end
+
+    # You have specified a retention configuration that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/NoSuchRetentionConfigurationException AWS API Documentation
+    #
+    class NoSuchRetentionConfigurationException < Aws::EmptyStructure; end
+
+    # For PutConfigAggregator API, no permission to call
+    # EnableAWSServiceAccess API.
+    #
+    # For all OrganizationConfigRule and OrganizationConformancePack APIs,
+    # AWS Config throws an exception if APIs are called from member
+    # accounts. All APIs must be called from organization master account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/OrganizationAccessDeniedException AWS API Documentation
+    #
+    class OrganizationAccessDeniedException < Aws::EmptyStructure; end
+
     # This object contains regions to set up the aggregator and an IAM role
     # to retrieve organization details.
     #
@@ -4672,6 +4976,13 @@ module Aws::ConfigService
       :all_aws_regions)
       include Aws::Structure
     end
+
+    # AWS Config resource cannot be created because your organization does
+    # not have all features enabled.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/OrganizationAllFeaturesNotEnabledException AWS API Documentation
+    #
+    class OrganizationAllFeaturesNotEnabledException < Aws::EmptyStructure; end
 
     # An organization config rule that has information about config rules
     # that AWS Config creates in member accounts.
@@ -4987,6 +5298,12 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # You have specified a template that is not valid or supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/OrganizationConformancePackTemplateValidationException AWS API Documentation
+    #
+    class OrganizationConformancePackTemplateValidationException < Aws::EmptyStructure; end
+
     # An object that specifies organization custom rule metadata such as
     # resource type, resource ID of AWS resource, Lamdba function ARN, and
     # organization trigger types that trigger AWS Config to evaluate your
@@ -5233,6 +5550,12 @@ module Aws::ConfigService
       :status)
       include Aws::Structure
     end
+
+    # The configuration item size is outside the allowable range.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/OversizedConfigurationItemException AWS API Documentation
+    #
+    class OversizedConfigurationItemException < Aws::EmptyStructure; end
 
     # An object that represents the account ID and region of an aggregator
     # account that is requesting authorization but is not yet authorized.
@@ -6378,6 +6701,13 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # Remediation action is in progress. You can either cancel execution in
+    # AWS Systems Manager or wait and try again later.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/RemediationInProgressException AWS API Documentation
+    #
+    class RemediationInProgressException < Aws::EmptyStructure; end
+
     # The value is either a dynamic (resource) value or a static value. You
     # must select either a dynamic value or a static value.
     #
@@ -6529,6 +6859,36 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # You see this exception in the following cases:
+    #
+    # * For DeleteConfigRule, AWS Config is deleting this rule. Try your
+    #   request again later.
+    #
+    # * For DeleteConfigRule, the rule is deleting your evaluation results.
+    #   Try your request again later.
+    #
+    # * For DeleteConfigRule, a remediation action is associated with the
+    #   rule and AWS Config cannot delete this rule. Delete the remediation
+    #   action associated with the rule before deleting the rule and try
+    #   your request again later.
+    #
+    # * For PutConfigOrganizationRule, organization config rule deletion is
+    #   in progress. Try your request again later.
+    #
+    # * For DeleteOrganizationConfigRule, organization config rule creation
+    #   is in progress. Try your request again later.
+    #
+    # * For PutConformancePack and PutOrganizationConformancePack, a
+    #   conformance pack creation, update, and deletion is in progress. Try
+    #   your request again later.
+    #
+    # * For DeleteConformancePack, a conformance pack creation, update, and
+    #   deletion is in progress. Try your request again later.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/ResourceInUseException AWS API Documentation
+    #
+    class ResourceInUseException < Aws::EmptyStructure; end
+
     # The details that identify a resource within AWS Config, including the
     # resource type and resource ID.
     #
@@ -6555,6 +6915,19 @@ module Aws::ConfigService
       :resource_id)
       include Aws::Structure
     end
+
+    # You have specified a resource that is either unknown or has not been
+    # discovered.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/ResourceNotDiscoveredException AWS API Documentation
+    #
+    class ResourceNotDiscoveredException < Aws::EmptyStructure; end
+
+    # You have specified a resource that does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # The dynamic value of the resource.
     #
@@ -7129,6 +7502,13 @@ module Aws::ConfigService
       include Aws::Structure
     end
 
+    # You have reached the limit of the number of tags you can use. You have
+    # more than 50 tags.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass UntagResourceRequest
     #   data as a hash:
     #
@@ -7155,6 +7535,12 @@ module Aws::ConfigService
       :tag_keys)
       include Aws::Structure
     end
+
+    # The requested action is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/ValidationException AWS API Documentation
+    #
+    class ValidationException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
@@ -147,9 +147,15 @@ module Aws::DAX
     Cluster.add_member(:sse_description, Shapes::ShapeRef.new(shape: SSEDescription, location_name: "SSEDescription"))
     Cluster.struct_class = Types::Cluster
 
+    ClusterAlreadyExistsFault.struct_class = Types::ClusterAlreadyExistsFault
+
     ClusterList.member = Shapes::ShapeRef.new(shape: Cluster)
 
     ClusterNameList.member = Shapes::ShapeRef.new(shape: String)
+
+    ClusterNotFoundFault.struct_class = Types::ClusterNotFoundFault
+
+    ClusterQuotaForCustomerExceededFault.struct_class = Types::ClusterQuotaForCustomerExceededFault
 
     CreateClusterRequest.add_member(:cluster_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ClusterName"))
     CreateClusterRequest.add_member(:node_type, Shapes::ShapeRef.new(shape: String, required: true, location_name: "NodeType"))
@@ -289,11 +295,23 @@ module Aws::DAX
     IncreaseReplicationFactorResponse.add_member(:cluster, Shapes::ShapeRef.new(shape: Cluster, location_name: "Cluster"))
     IncreaseReplicationFactorResponse.struct_class = Types::IncreaseReplicationFactorResponse
 
+    InsufficientClusterCapacityFault.struct_class = Types::InsufficientClusterCapacityFault
+
+    InvalidARNFault.struct_class = Types::InvalidARNFault
+
+    InvalidClusterStateFault.struct_class = Types::InvalidClusterStateFault
+
     InvalidParameterCombinationException.add_member(:message, Shapes::ShapeRef.new(shape: AwsQueryErrorMessage, location_name: "message"))
     InvalidParameterCombinationException.struct_class = Types::InvalidParameterCombinationException
 
+    InvalidParameterGroupStateFault.struct_class = Types::InvalidParameterGroupStateFault
+
     InvalidParameterValueException.add_member(:message, Shapes::ShapeRef.new(shape: AwsQueryErrorMessage, location_name: "message"))
     InvalidParameterValueException.struct_class = Types::InvalidParameterValueException
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
 
     KeyList.member = Shapes::ShapeRef.new(shape: String)
 
@@ -316,6 +334,12 @@ module Aws::DAX
     NodeIdentifierList.member = Shapes::ShapeRef.new(shape: String)
 
     NodeList.member = Shapes::ShapeRef.new(shape: Node)
+
+    NodeNotFoundFault.struct_class = Types::NodeNotFoundFault
+
+    NodeQuotaForClusterExceededFault.struct_class = Types::NodeQuotaForClusterExceededFault
+
+    NodeQuotaForCustomerExceededFault.struct_class = Types::NodeQuotaForCustomerExceededFault
 
     NodeTypeSpecificValue.add_member(:node_type, Shapes::ShapeRef.new(shape: String, location_name: "NodeType"))
     NodeTypeSpecificValue.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "Value"))
@@ -343,9 +367,15 @@ module Aws::DAX
     ParameterGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
     ParameterGroup.struct_class = Types::ParameterGroup
 
+    ParameterGroupAlreadyExistsFault.struct_class = Types::ParameterGroupAlreadyExistsFault
+
     ParameterGroupList.member = Shapes::ShapeRef.new(shape: ParameterGroup)
 
     ParameterGroupNameList.member = Shapes::ShapeRef.new(shape: String)
+
+    ParameterGroupNotFoundFault.struct_class = Types::ParameterGroupNotFoundFault
+
+    ParameterGroupQuotaExceededFault.struct_class = Types::ParameterGroupQuotaExceededFault
 
     ParameterGroupStatus.add_member(:parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupName"))
     ParameterGroupStatus.add_member(:parameter_apply_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterApplyStatus"))
@@ -381,6 +411,8 @@ module Aws::DAX
 
     SecurityGroupMembershipList.member = Shapes::ShapeRef.new(shape: SecurityGroupMembership)
 
+    ServiceLinkedRoleNotFoundFault.struct_class = Types::ServiceLinkedRoleNotFoundFault
+
     Subnet.add_member(:subnet_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier"))
     Subnet.add_member(:subnet_availability_zone, Shapes::ShapeRef.new(shape: String, location_name: "SubnetAvailabilityZone"))
     Subnet.struct_class = Types::Subnet
@@ -391,19 +423,35 @@ module Aws::DAX
     SubnetGroup.add_member(:subnets, Shapes::ShapeRef.new(shape: SubnetList, location_name: "Subnets"))
     SubnetGroup.struct_class = Types::SubnetGroup
 
+    SubnetGroupAlreadyExistsFault.struct_class = Types::SubnetGroupAlreadyExistsFault
+
+    SubnetGroupInUseFault.struct_class = Types::SubnetGroupInUseFault
+
     SubnetGroupList.member = Shapes::ShapeRef.new(shape: SubnetGroup)
 
     SubnetGroupNameList.member = Shapes::ShapeRef.new(shape: String)
 
+    SubnetGroupNotFoundFault.struct_class = Types::SubnetGroupNotFoundFault
+
+    SubnetGroupQuotaExceededFault.struct_class = Types::SubnetGroupQuotaExceededFault
+
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String)
 
+    SubnetInUse.struct_class = Types::SubnetInUse
+
     SubnetList.member = Shapes::ShapeRef.new(shape: Subnet)
+
+    SubnetQuotaExceededFault.struct_class = Types::SubnetQuotaExceededFault
 
     Tag.add_member(:key, Shapes::ShapeRef.new(shape: String, location_name: "Key"))
     Tag.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "Value"))
     Tag.struct_class = Types::Tag
 
     TagList.member = Shapes::ShapeRef.new(shape: Tag)
+
+    TagNotFoundFault.struct_class = Types::TagNotFoundFault
+
+    TagQuotaPerResourceExceeded.struct_class = Types::TagQuotaPerResourceExceeded
 
     TagResourceRequest.add_member(:resource_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ResourceName"))
     TagResourceRequest.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, required: true, location_name: "Tags"))

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
@@ -10,6 +10,72 @@ module Aws::DAX
 
     extend Aws::Errors::DynamicErrors
 
+    class ClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterQuotaForCustomerExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ClusterQuotaForCustomerExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InsufficientClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidARNFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InvalidARNFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InvalidClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidParameterCombinationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -26,6 +92,17 @@ module Aws::DAX
 
     end
 
+    class InvalidParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InvalidParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidParameterValueException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -38,6 +115,193 @@ module Aws::DAX
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::NodeNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeQuotaForClusterExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::NodeQuotaForClusterExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeQuotaForCustomerExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::NodeQuotaForCustomerExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ServiceLinkedRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::ServiceLinkedRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetGroupInUseFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetGroupInUseFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::SubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::TagNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagQuotaPerResourceExceeded < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DAX::Types::TagQuotaPerResourceExceeded] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
@@ -116,6 +116,25 @@ module Aws::DAX
       include Aws::Structure
     end
 
+    # You already have a DAX cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ClusterAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The requested cluster ID does not refer to an existing DAX cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ClusterNotFoundFault AWS API Documentation
+    #
+    class ClusterNotFoundFault < Aws::EmptyStructure; end
+
+    # You have attempted to exceed the maximum number of DAX clusters for
+    # your AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ClusterQuotaForCustomerExceededFault AWS API Documentation
+    #
+    class ClusterQuotaForCustomerExceededFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass CreateClusterRequest
     #   data as a hash:
     #
@@ -962,6 +981,25 @@ module Aws::DAX
       include Aws::Structure
     end
 
+    # There are not enough system resources to create the cluster you
+    # requested (or to resize an already-existing cluster).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InsufficientClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The Amazon Resource Name (ARN) supplied in the request is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InvalidARNFault AWS API Documentation
+    #
+    class InvalidARNFault < Aws::EmptyStructure; end
+
+    # The requested DAX cluster is not in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InvalidClusterStateFault AWS API Documentation
+    #
+    class InvalidClusterStateFault < Aws::EmptyStructure; end
+
     # Two or more incompatible parameters were specified.
     #
     # @!attribute [rw] message
@@ -974,6 +1012,12 @@ module Aws::DAX
       include Aws::Structure
     end
 
+    # One or more parameters in a parameter group are in an invalid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InvalidParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidParameterGroupStateFault < Aws::EmptyStructure; end
+
     # The value for a parameter is invalid.
     #
     # @!attribute [rw] message
@@ -985,6 +1029,18 @@ module Aws::DAX
       :message)
       include Aws::Structure
     end
+
+    # An invalid subnet identifier was specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # The VPC network is in an invalid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListTagsRequest
     #   data as a hash:
@@ -1072,6 +1128,26 @@ module Aws::DAX
       :parameter_group_status)
       include Aws::Structure
     end
+
+    # None of the nodes in the cluster have the given node ID.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/NodeNotFoundFault AWS API Documentation
+    #
+    class NodeNotFoundFault < Aws::EmptyStructure; end
+
+    # You have attempted to exceed the maximum number of nodes for a DAX
+    # cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/NodeQuotaForClusterExceededFault AWS API Documentation
+    #
+    class NodeQuotaForClusterExceededFault < Aws::EmptyStructure; end
+
+    # You have attempted to exceed the maximum number of nodes for your AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/NodeQuotaForCustomerExceededFault AWS API Documentation
+    #
+    class NodeQuotaForCustomerExceededFault < Aws::EmptyStructure; end
 
     # Represents a parameter value that is applicable to a particular node
     # type.
@@ -1193,6 +1269,24 @@ module Aws::DAX
       :description)
       include Aws::Structure
     end
+
+    # The specified parameter group already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class ParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified parameter group does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ParameterGroupNotFoundFault AWS API Documentation
+    #
+    class ParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # You have attempted to exceed the maximum number of parameter groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class ParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # The status of a parameter group.
     #
@@ -1339,6 +1433,12 @@ module Aws::DAX
       include Aws::Structure
     end
 
+    # The specified service linked role (SLR) was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/ServiceLinkedRoleNotFoundFault AWS API Documentation
+    #
+    class ServiceLinkedRoleNotFoundFault < Aws::EmptyStructure; end
+
     # Represents the subnet associated with a DAX cluster. This parameter
     # refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC)
     # and used with DAX.
@@ -1392,6 +1492,45 @@ module Aws::DAX
       include Aws::Structure
     end
 
+    # The specified subnet group already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class SubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified subnet group is currently in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetGroupInUseFault AWS API Documentation
+    #
+    class SubnetGroupInUseFault < Aws::EmptyStructure; end
+
+    # The requested subnet group name does not refer to an existing subnet
+    # group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetGroupNotFoundFault AWS API Documentation
+    #
+    class SubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of subnets in a subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class SubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The requested subnet is being used by another subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetInUse AWS API Documentation
+    #
+    class SubnetInUse < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of subnets in a subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/SubnetQuotaExceededFault AWS API Documentation
+    #
+    class SubnetQuotaExceededFault < Aws::EmptyStructure; end
+
     # A description of a tag. Every tag is a key-value pair. You can add up
     # to 50 tags to a single DAX cluster.
     #
@@ -1428,6 +1567,18 @@ module Aws::DAX
       :value)
       include Aws::Structure
     end
+
+    # The tag does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/TagNotFoundFault AWS API Documentation
+    #
+    class TagNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of tags for this DAX cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/TagQuotaPerResourceExceeded AWS API Documentation
+    #
+    class TagQuotaPerResourceExceeded < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass TagResourceRequest
     #   data as a hash:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
@@ -599,6 +599,8 @@ module Aws::DirectConnect
     DisassociateConnectionFromLagRequest.add_member(:lag_id, Shapes::ShapeRef.new(shape: LagId, required: true, location_name: "lagId"))
     DisassociateConnectionFromLagRequest.struct_class = Types::DisassociateConnectionFromLagRequest
 
+    DuplicateTagKeysException.struct_class = Types::DuplicateTagKeysException
+
     Interconnect.add_member(:interconnect_id, Shapes::ShapeRef.new(shape: InterconnectId, location_name: "interconnectId"))
     Interconnect.add_member(:interconnect_name, Shapes::ShapeRef.new(shape: InterconnectName, location_name: "interconnectName"))
     Interconnect.add_member(:interconnect_state, Shapes::ShapeRef.new(shape: InterconnectState, location_name: "interconnectState"))
@@ -764,6 +766,8 @@ module Aws::DirectConnect
     TagResourceRequest.struct_class = Types::TagResourceRequest
 
     TagResourceResponse.struct_class = Types::TagResourceResponse
+
+    TooManyTagsException.struct_class = Types::TooManyTagsException
 
     UntagResourceRequest.add_member(:resource_arn, Shapes::ShapeRef.new(shape: ResourceArn, required: true, location_name: "resourceArn"))
     UntagResourceRequest.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "tagKeys"))

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
@@ -42,5 +42,27 @@ module Aws::DirectConnect
 
     end
 
+    class DuplicateTagKeysException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DirectConnect::Types::DuplicateTagKeysException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DirectConnect::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
@@ -2502,6 +2502,12 @@ module Aws::DirectConnect
       include Aws::Structure
     end
 
+    # A tag key was specified more than once.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/directconnect-2012-10-25/DuplicateTagKeysException AWS API Documentation
+    #
+    class DuplicateTagKeysException < Aws::EmptyStructure; end
+
     # Information about an interconnect.
     #
     # @!attribute [rw] interconnect_id
@@ -3452,6 +3458,12 @@ module Aws::DirectConnect
     # @see http://docs.aws.amazon.com/goto/WebAPI/directconnect-2012-10-25/TagResourceResponse AWS API Documentation
     #
     class TagResourceResponse < Aws::EmptyStructure; end
+
+    # You have reached the limit on the number of tags that can be assigned.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/directconnect-2012-10-25/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagResourceRequest
     #   data as a hash:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client_api.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client_api.rb
@@ -217,6 +217,8 @@ module Aws::DocDB
 
     AttributeValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "AttributeValue")
 
+    AuthorizationNotFoundFault.struct_class = Types::AuthorizationNotFoundFault
+
     AvailabilityZone.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     AvailabilityZone.struct_class = Types::AvailabilityZone
 
@@ -237,6 +239,8 @@ module Aws::DocDB
     CertificateMessage.add_member(:certificates, Shapes::ShapeRef.new(shape: CertificateList, location_name: "Certificates"))
     CertificateMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CertificateMessage.struct_class = Types::CertificateMessage
+
+    CertificateNotFoundFault.struct_class = Types::CertificateNotFoundFault
 
     CloudwatchLogsExportConfiguration.add_member(:enable_log_types, Shapes::ShapeRef.new(shape: LogTypeList, location_name: "EnableLogTypes"))
     CloudwatchLogsExportConfiguration.add_member(:disable_log_types, Shapes::ShapeRef.new(shape: LogTypeList, location_name: "DisableLogTypes"))
@@ -356,6 +360,8 @@ module Aws::DocDB
     DBCluster.add_member(:deletion_protection, Shapes::ShapeRef.new(shape: Boolean, location_name: "DeletionProtection"))
     DBCluster.struct_class = Types::DBCluster
 
+    DBClusterAlreadyExistsFault.struct_class = Types::DBClusterAlreadyExistsFault
+
     DBClusterList.member = Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster")
 
     DBClusterMember.add_member(:db_instance_identifier, Shapes::ShapeRef.new(shape: String, location_name: "DBInstanceIdentifier"))
@@ -369,6 +375,8 @@ module Aws::DocDB
     DBClusterMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterMessage.add_member(:db_clusters, Shapes::ShapeRef.new(shape: DBClusterList, location_name: "DBClusters"))
     DBClusterMessage.struct_class = Types::DBClusterMessage
+
+    DBClusterNotFoundFault.struct_class = Types::DBClusterNotFoundFault
 
     DBClusterParameterGroup.add_member(:db_cluster_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterParameterGroupName"))
     DBClusterParameterGroup.add_member(:db_parameter_group_family, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupFamily"))
@@ -385,9 +393,13 @@ module Aws::DocDB
     DBClusterParameterGroupNameMessage.add_member(:db_cluster_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterParameterGroupName"))
     DBClusterParameterGroupNameMessage.struct_class = Types::DBClusterParameterGroupNameMessage
 
+    DBClusterParameterGroupNotFoundFault.struct_class = Types::DBClusterParameterGroupNotFoundFault
+
     DBClusterParameterGroupsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterParameterGroupsMessage.add_member(:db_cluster_parameter_groups, Shapes::ShapeRef.new(shape: DBClusterParameterGroupList, location_name: "DBClusterParameterGroups"))
     DBClusterParameterGroupsMessage.struct_class = Types::DBClusterParameterGroupsMessage
+
+    DBClusterQuotaExceededFault.struct_class = Types::DBClusterQuotaExceededFault
 
     DBClusterRole.add_member(:role_arn, Shapes::ShapeRef.new(shape: String, location_name: "RoleArn"))
     DBClusterRole.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
@@ -414,6 +426,8 @@ module Aws::DocDB
     DBClusterSnapshot.add_member(:source_db_cluster_snapshot_arn, Shapes::ShapeRef.new(shape: String, location_name: "SourceDBClusterSnapshotArn"))
     DBClusterSnapshot.struct_class = Types::DBClusterSnapshot
 
+    DBClusterSnapshotAlreadyExistsFault.struct_class = Types::DBClusterSnapshotAlreadyExistsFault
+
     DBClusterSnapshotAttribute.add_member(:attribute_name, Shapes::ShapeRef.new(shape: String, location_name: "AttributeName"))
     DBClusterSnapshotAttribute.add_member(:attribute_values, Shapes::ShapeRef.new(shape: AttributeValueList, location_name: "AttributeValues"))
     DBClusterSnapshotAttribute.struct_class = Types::DBClusterSnapshotAttribute
@@ -429,6 +443,8 @@ module Aws::DocDB
     DBClusterSnapshotMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterSnapshotMessage.add_member(:db_cluster_snapshots, Shapes::ShapeRef.new(shape: DBClusterSnapshotList, location_name: "DBClusterSnapshots"))
     DBClusterSnapshotMessage.struct_class = Types::DBClusterSnapshotMessage
+
+    DBClusterSnapshotNotFoundFault.struct_class = Types::DBClusterSnapshotNotFoundFault
 
     DBEngineVersion.add_member(:engine, Shapes::ShapeRef.new(shape: String, location_name: "Engine"))
     DBEngineVersion.add_member(:engine_version, Shapes::ShapeRef.new(shape: String, location_name: "EngineVersion"))
@@ -474,11 +490,15 @@ module Aws::DocDB
     DBInstance.add_member(:enabled_cloudwatch_logs_exports, Shapes::ShapeRef.new(shape: LogTypeList, location_name: "EnabledCloudwatchLogsExports"))
     DBInstance.struct_class = Types::DBInstance
 
+    DBInstanceAlreadyExistsFault.struct_class = Types::DBInstanceAlreadyExistsFault
+
     DBInstanceList.member = Shapes::ShapeRef.new(shape: DBInstance, location_name: "DBInstance")
 
     DBInstanceMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBInstanceMessage.add_member(:db_instances, Shapes::ShapeRef.new(shape: DBInstanceList, location_name: "DBInstances"))
     DBInstanceMessage.struct_class = Types::DBInstanceMessage
+
+    DBInstanceNotFoundFault.struct_class = Types::DBInstanceNotFoundFault
 
     DBInstanceStatusInfo.add_member(:status_type, Shapes::ShapeRef.new(shape: String, location_name: "StatusType"))
     DBInstanceStatusInfo.add_member(:normal, Shapes::ShapeRef.new(shape: Boolean, location_name: "Normal"))
@@ -488,6 +508,18 @@ module Aws::DocDB
 
     DBInstanceStatusInfoList.member = Shapes::ShapeRef.new(shape: DBInstanceStatusInfo, location_name: "DBInstanceStatusInfo")
 
+    DBParameterGroupAlreadyExistsFault.struct_class = Types::DBParameterGroupAlreadyExistsFault
+
+    DBParameterGroupNotFoundFault.struct_class = Types::DBParameterGroupNotFoundFault
+
+    DBParameterGroupQuotaExceededFault.struct_class = Types::DBParameterGroupQuotaExceededFault
+
+    DBSecurityGroupNotFoundFault.struct_class = Types::DBSecurityGroupNotFoundFault
+
+    DBSnapshotAlreadyExistsFault.struct_class = Types::DBSnapshotAlreadyExistsFault
+
+    DBSnapshotNotFoundFault.struct_class = Types::DBSnapshotNotFoundFault
+
     DBSubnetGroup.add_member(:db_subnet_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupName"))
     DBSubnetGroup.add_member(:db_subnet_group_description, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupDescription"))
     DBSubnetGroup.add_member(:vpc_id, Shapes::ShapeRef.new(shape: String, location_name: "VpcId"))
@@ -496,11 +528,23 @@ module Aws::DocDB
     DBSubnetGroup.add_member(:db_subnet_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupArn"))
     DBSubnetGroup.struct_class = Types::DBSubnetGroup
 
+    DBSubnetGroupAlreadyExistsFault.struct_class = Types::DBSubnetGroupAlreadyExistsFault
+
+    DBSubnetGroupDoesNotCoverEnoughAZs.struct_class = Types::DBSubnetGroupDoesNotCoverEnoughAZs
+
     DBSubnetGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBSubnetGroupMessage.add_member(:db_subnet_groups, Shapes::ShapeRef.new(shape: DBSubnetGroups, location_name: "DBSubnetGroups"))
     DBSubnetGroupMessage.struct_class = Types::DBSubnetGroupMessage
 
+    DBSubnetGroupNotFoundFault.struct_class = Types::DBSubnetGroupNotFoundFault
+
+    DBSubnetGroupQuotaExceededFault.struct_class = Types::DBSubnetGroupQuotaExceededFault
+
     DBSubnetGroups.member = Shapes::ShapeRef.new(shape: DBSubnetGroup, location_name: "DBSubnetGroup")
+
+    DBSubnetQuotaExceededFault.struct_class = Types::DBSubnetQuotaExceededFault
+
+    DBUpgradeDependencyFailureFault.struct_class = Types::DBUpgradeDependencyFailureFault
 
     DeleteDBClusterMessage.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBClusterIdentifier"))
     DeleteDBClusterMessage.add_member(:skip_final_snapshot, Shapes::ShapeRef.new(shape: Boolean, location_name: "SkipFinalSnapshot"))
@@ -682,6 +726,38 @@ module Aws::DocDB
 
     FilterValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "Value")
 
+    InstanceQuotaExceededFault.struct_class = Types::InstanceQuotaExceededFault
+
+    InsufficientDBClusterCapacityFault.struct_class = Types::InsufficientDBClusterCapacityFault
+
+    InsufficientDBInstanceCapacityFault.struct_class = Types::InsufficientDBInstanceCapacityFault
+
+    InsufficientStorageClusterCapacityFault.struct_class = Types::InsufficientStorageClusterCapacityFault
+
+    InvalidDBClusterSnapshotStateFault.struct_class = Types::InvalidDBClusterSnapshotStateFault
+
+    InvalidDBClusterStateFault.struct_class = Types::InvalidDBClusterStateFault
+
+    InvalidDBInstanceStateFault.struct_class = Types::InvalidDBInstanceStateFault
+
+    InvalidDBParameterGroupStateFault.struct_class = Types::InvalidDBParameterGroupStateFault
+
+    InvalidDBSecurityGroupStateFault.struct_class = Types::InvalidDBSecurityGroupStateFault
+
+    InvalidDBSnapshotStateFault.struct_class = Types::InvalidDBSnapshotStateFault
+
+    InvalidDBSubnetGroupStateFault.struct_class = Types::InvalidDBSubnetGroupStateFault
+
+    InvalidDBSubnetStateFault.struct_class = Types::InvalidDBSubnetStateFault
+
+    InvalidRestoreFault.struct_class = Types::InvalidRestoreFault
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
+
+    KMSKeyNotAccessibleFault.struct_class = Types::KMSKeyNotAccessibleFault
+
     KeyList.member = Shapes::ShapeRef.new(shape: String)
 
     ListTagsForResourceMessage.add_member(:resource_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ResourceName"))
@@ -822,6 +898,8 @@ module Aws::DocDB
     ResetDBClusterParameterGroupMessage.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     ResetDBClusterParameterGroupMessage.struct_class = Types::ResetDBClusterParameterGroupMessage
 
+    ResourceNotFoundFault.struct_class = Types::ResourceNotFoundFault
+
     ResourcePendingMaintenanceActions.add_member(:resource_identifier, Shapes::ShapeRef.new(shape: String, location_name: "ResourceIdentifier"))
     ResourcePendingMaintenanceActions.add_member(:pending_maintenance_action_details, Shapes::ShapeRef.new(shape: PendingMaintenanceActionDetails, location_name: "PendingMaintenanceActionDetails"))
     ResourcePendingMaintenanceActions.struct_class = Types::ResourcePendingMaintenanceActions
@@ -859,6 +937,10 @@ module Aws::DocDB
     RestoreDBClusterToPointInTimeResult.add_member(:db_cluster, Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster"))
     RestoreDBClusterToPointInTimeResult.struct_class = Types::RestoreDBClusterToPointInTimeResult
 
+    SharedSnapshotQuotaExceededFault.struct_class = Types::SharedSnapshotQuotaExceededFault
+
+    SnapshotQuotaExceededFault.struct_class = Types::SnapshotQuotaExceededFault
+
     StartDBClusterMessage.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBClusterIdentifier"))
     StartDBClusterMessage.struct_class = Types::StartDBClusterMessage
 
@@ -871,10 +953,16 @@ module Aws::DocDB
     StopDBClusterResult.add_member(:db_cluster, Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster"))
     StopDBClusterResult.struct_class = Types::StopDBClusterResult
 
+    StorageQuotaExceededFault.struct_class = Types::StorageQuotaExceededFault
+
+    StorageTypeNotSupportedFault.struct_class = Types::StorageTypeNotSupportedFault
+
     Subnet.add_member(:subnet_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier"))
     Subnet.add_member(:subnet_availability_zone, Shapes::ShapeRef.new(shape: AvailabilityZone, location_name: "SubnetAvailabilityZone"))
     Subnet.add_member(:subnet_status, Shapes::ShapeRef.new(shape: String, location_name: "SubnetStatus"))
     Subnet.struct_class = Types::Subnet
+
+    SubnetAlreadyInUse.struct_class = Types::SubnetAlreadyInUse
 
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier")
 

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/errors.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/errors.rb
@@ -10,5 +10,489 @@ module Aws::DocDB
 
     extend Aws::Errors::DynamicErrors
 
+    class AuthorizationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::AuthorizationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CertificateNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::CertificateNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBClusterSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBInstanceAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBInstanceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSecurityGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupDoesNotCoverEnoughAZs < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSubnetGroupDoesNotCoverEnoughAZs] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBSubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBUpgradeDependencyFailureFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::DBUpgradeDependencyFailureFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InstanceQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InsufficientDBClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBInstanceCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InsufficientDBInstanceCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientStorageClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InsufficientStorageClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBClusterSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBInstanceStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBInstanceStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSecurityGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBSecurityGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBSubnetGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidDBSubnetStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRestoreFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidRestoreFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KMSKeyNotAccessibleFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::KMSKeyNotAccessibleFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::ResourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SharedSnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::SharedSnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::SnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::StorageQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageTypeNotSupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::StorageTypeNotSupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetAlreadyInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::DocDB::Types::SubnetAlreadyInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/types.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/types.rb
@@ -98,6 +98,16 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # The specified CIDR IP or Amazon EC2 security group isn't authorized
+    # for the specified security group.
+    #
+    # Amazon DocumentDB also might not be authorized to perform necessary
+    # actions on your behalf using IAM.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/AuthorizationNotFoundFault AWS API Documentation
+    #
+    class AuthorizationNotFoundFault < Aws::EmptyStructure; end
+
     # Information about an Availability Zone.
     #
     # @!attribute [rw] name
@@ -178,6 +188,12 @@ module Aws::DocDB
       :marker)
       include Aws::Structure
     end
+
+    # `CertificateIdentifier` doesn't refer to an existing certificate.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/CertificateNotFoundFault AWS API Documentation
+    #
+    class CertificateNotFoundFault < Aws::EmptyStructure; end
 
     # The configuration setting for the log types to be enabled for export
     # to Amazon CloudWatch Logs for a specific instance or cluster.
@@ -1183,6 +1199,12 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # You already have a cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains information about an instance that is part of a cluster.
     #
     # @!attribute [rw] db_instance_identifier
@@ -1234,6 +1256,12 @@ module Aws::DocDB
       :db_clusters)
       include Aws::Structure
     end
+
+    # `DBClusterIdentifier` doesn't refer to an existing cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterNotFoundFault AWS API Documentation
+    #
+    class DBClusterNotFoundFault < Aws::EmptyStructure; end
 
     # Detailed information about a cluster parameter group.
     #
@@ -1310,6 +1338,13 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # `DBClusterParameterGroupName` doesn't refer to an existing cluster
+    # parameter group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBClusterParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
     # Represents the output of DBClusterParameterGroups.
     #
     # @!attribute [rw] marker
@@ -1329,6 +1364,13 @@ module Aws::DocDB
       :db_cluster_parameter_groups)
       include Aws::Structure
     end
+
+    # The cluster can't be created because you have reached the maximum
+    # allowed quota of clusters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes an AWS Identity and Access Management (IAM) role that is
     # associated with a cluster.
@@ -1463,6 +1505,12 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # You already have a cluster snapshot with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the name and values of a manual cluster snapshot attribute.
     #
     # Manual cluster snapshot attributes are used to authorize other AWS
@@ -1531,6 +1579,13 @@ module Aws::DocDB
       :db_cluster_snapshots)
       include Aws::Structure
     end
+
+    # `DBClusterSnapshotIdentifier` doesn't refer to an existing cluster
+    # snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBClusterSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBClusterSnapshotNotFoundFault < Aws::EmptyStructure; end
 
     # Detailed information about an engine version.
     #
@@ -1764,6 +1819,12 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # You already have a instance with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBInstanceAlreadyExistsFault AWS API Documentation
+    #
+    class DBInstanceAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Represents the output of DescribeDBInstances.
     #
     # @!attribute [rw] marker
@@ -1783,6 +1844,12 @@ module Aws::DocDB
       :db_instances)
       include Aws::Structure
     end
+
+    # `DBInstanceIdentifier` doesn't refer to an existing instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBInstanceNotFoundFault AWS API Documentation
+    #
+    class DBInstanceNotFoundFault < Aws::EmptyStructure; end
 
     # Provides a list of status information for an instance.
     #
@@ -1814,6 +1881,43 @@ module Aws::DocDB
       :message)
       include Aws::Structure
     end
+
+    # A parameter group with the same name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # `DBParameterGroupName` doesn't refer to an existing parameter group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # This request would cause you to exceed the allowed number of parameter
+    # groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # `DBSecurityGroupName` doesn't refer to an existing security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSecurityGroupNotFoundFault AWS API Documentation
+    #
+    class DBSecurityGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # `DBSnapshotIdentifier` is already being used by an existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # `DBSnapshotIdentifier` doesn't refer to an existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBSnapshotNotFoundFault < Aws::EmptyStructure; end
 
     # Detailed information about a subnet group.
     #
@@ -1854,6 +1958,19 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # `DBSubnetGroupName` is already being used by an existing subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBSubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # Subnets in the subnet group should cover at least two Availability
+    # Zones unless there is only one Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSubnetGroupDoesNotCoverEnoughAZs AWS API Documentation
+    #
+    class DBSubnetGroupDoesNotCoverEnoughAZs < Aws::EmptyStructure; end
+
     # Represents the output of DescribeDBSubnetGroups.
     #
     # @!attribute [rw] marker
@@ -1873,6 +1990,33 @@ module Aws::DocDB
       :db_subnet_groups)
       include Aws::Structure
     end
+
+    # `DBSubnetGroupName` doesn't refer to an existing subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSubnetGroupNotFoundFault AWS API Documentation
+    #
+    class DBSubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would cause you to exceed the allowed number of subnet
+    # groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request would cause you to exceed the allowed number of subnets in
+    # a subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBSubnetQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The upgrade failed because a resource that the depends on can't be
+    # modified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/DBUpgradeDependencyFailureFault AWS API Documentation
+    #
+    class DBUpgradeDependencyFailureFault < Aws::EmptyStructure; end
 
     # Represents the input to DeleteDBCluster.
     #
@@ -3286,6 +3430,110 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # The request would cause you to exceed the allowed number of instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InstanceQuotaExceededFault AWS API Documentation
+    #
+    class InstanceQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The cluster doesn't have enough capacity for the current operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InsufficientDBClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientDBClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The specified instance class isn't available in the specified
+    # Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InsufficientDBInstanceCapacityFault AWS API Documentation
+    #
+    class InsufficientDBInstanceCapacityFault < Aws::EmptyStructure; end
+
+    # There is not enough storage available for the current action. You
+    # might be able to resolve this error by updating your subnet group to
+    # use different Availability Zones that have more storage available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InsufficientStorageClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientStorageClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The provided value isn't a valid cluster snapshot state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBClusterSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBClusterSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The cluster isn't in a valid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBClusterStateFault AWS API Documentation
+    #
+    class InvalidDBClusterStateFault < Aws::EmptyStructure; end
+
+    # The specified instance isn't in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBInstanceStateFault AWS API Documentation
+    #
+    class InvalidDBInstanceStateFault < Aws::EmptyStructure; end
+
+    # The parameter group is in use, or it is in a state that is not valid.
+    # If you are trying to delete the parameter group, you can't delete it
+    # when the parameter group is in this state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidDBParameterGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the security group doesn't allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBSecurityGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSecurityGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the snapshot doesn't allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The subnet group can't be deleted because it's in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBSubnetGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetGroupStateFault < Aws::EmptyStructure; end
+
+    # The subnet isn't in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidDBSubnetStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetStateFault < Aws::EmptyStructure; end
+
+    # You cannot restore from a virtual private cloud (VPC) backup to a
+    # non-VPC DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidRestoreFault AWS API Documentation
+    #
+    class InvalidRestoreFault < Aws::EmptyStructure; end
+
+    # The requested subnet is not valid, or multiple subnets were requested
+    # that are not all in a common virtual private cloud (VPC).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # The subnet group doesn't cover all Availability Zones after it is
+    # created because of changes that were made.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
+
+    # An error occurred when accessing an AWS KMS key.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/KMSKeyNotAccessibleFault AWS API Documentation
+    #
+    class KMSKeyNotAccessibleFault < Aws::EmptyStructure; end
+
     # Represents the input to ListTagsForResource.
     #
     # @note When making an API call, you may pass ListTagsForResourceMessage
@@ -4248,6 +4496,12 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # The specified resource ID was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/ResourceNotFoundFault AWS API Documentation
+    #
+    class ResourceNotFoundFault < Aws::EmptyStructure; end
+
     # Represents the output of ApplyPendingMaintenanceAction.
     #
     # @!attribute [rw] resource_identifier
@@ -4601,6 +4855,19 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # You have exceeded the maximum number of accounts that you can share a
+    # manual DB snapshot with.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/SharedSnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SharedSnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request would cause you to exceed the allowed number of snapshots.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/SnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass StartDBClusterMessage
     #   data as a hash:
     #
@@ -4661,6 +4928,20 @@ module Aws::DocDB
       include Aws::Structure
     end
 
+    # The request would cause you to exceed the allowed amount of storage
+    # available across all instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/StorageQuotaExceededFault AWS API Documentation
+    #
+    class StorageQuotaExceededFault < Aws::EmptyStructure; end
+
+    # Storage of the specified `StorageType` can't be associated with the
+    # DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/StorageTypeNotSupportedFault AWS API Documentation
+    #
+    class StorageTypeNotSupportedFault < Aws::EmptyStructure; end
+
     # Detailed information about a subnet.
     #
     # @!attribute [rw] subnet_identifier
@@ -4683,6 +4964,12 @@ module Aws::DocDB
       :subnet_status)
       include Aws::Structure
     end
+
+    # The subnet is already in use in the Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/docdb-2014-10-31/SubnetAlreadyInUse AWS API Documentation
+    #
+    class SubnetAlreadyInUse < Aws::EmptyStructure; end
 
     # Metadata assigned to an Amazon DocumentDB resource consisting of a
     # key-value pair.

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
@@ -319,6 +319,8 @@ module Aws::ECS
     VolumeFromList = Shapes::ListShape.new(name: 'VolumeFromList')
     VolumeList = Shapes::ListShape.new(name: 'VolumeList')
 
+    AccessDeniedException.struct_class = Types::AccessDeniedException
+
     Attachment.add_member(:id, Shapes::ShapeRef.new(shape: String, location_name: "id"))
     Attachment.add_member(:type, Shapes::ShapeRef.new(shape: String, location_name: "type"))
     Attachment.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "status"))
@@ -341,6 +343,8 @@ module Aws::ECS
     Attribute.add_member(:target_id, Shapes::ShapeRef.new(shape: String, location_name: "targetId"))
     Attribute.struct_class = Types::Attribute
 
+    AttributeLimitExceededException.struct_class = Types::AttributeLimitExceededException
+
     Attributes.member = Shapes::ShapeRef.new(shape: Attribute)
 
     AutoScalingGroupProvider.add_member(:auto_scaling_group_arn, Shapes::ShapeRef.new(shape: String, required: true, location_name: "autoScalingGroupArn"))
@@ -352,6 +356,8 @@ module Aws::ECS
     AwsVpcConfiguration.add_member(:security_groups, Shapes::ShapeRef.new(shape: StringList, location_name: "securityGroups"))
     AwsVpcConfiguration.add_member(:assign_public_ip, Shapes::ShapeRef.new(shape: AssignPublicIp, location_name: "assignPublicIp"))
     AwsVpcConfiguration.struct_class = Types::AwsVpcConfiguration
+
+    BlockedException.struct_class = Types::BlockedException
 
     CapacityProvider.add_member(:capacity_provider_arn, Shapes::ShapeRef.new(shape: String, location_name: "capacityProviderArn"))
     CapacityProvider.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "name"))
@@ -390,7 +396,15 @@ module Aws::ECS
     Cluster.add_member(:attachments_status, Shapes::ShapeRef.new(shape: String, location_name: "attachmentsStatus"))
     Cluster.struct_class = Types::Cluster
 
+    ClusterContainsContainerInstancesException.struct_class = Types::ClusterContainsContainerInstancesException
+
+    ClusterContainsServicesException.struct_class = Types::ClusterContainsServicesException
+
+    ClusterContainsTasksException.struct_class = Types::ClusterContainsTasksException
+
     ClusterFieldList.member = Shapes::ShapeRef.new(shape: ClusterField)
+
+    ClusterNotFoundException.struct_class = Types::ClusterNotFoundException
 
     ClusterSetting.add_member(:name, Shapes::ShapeRef.new(shape: ClusterSettingName, location_name: "name"))
     ClusterSetting.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "value"))
@@ -792,6 +806,8 @@ module Aws::ECS
 
     InferenceAccelerators.member = Shapes::ShapeRef.new(shape: InferenceAccelerator)
 
+    InvalidParameterException.struct_class = Types::InvalidParameterException
+
     KernelCapabilities.add_member(:add, Shapes::ShapeRef.new(shape: StringList, location_name: "add"))
     KernelCapabilities.add_member(:drop, Shapes::ShapeRef.new(shape: StringList, location_name: "drop"))
     KernelCapabilities.struct_class = Types::KernelCapabilities
@@ -799,6 +815,8 @@ module Aws::ECS
     KeyValuePair.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "name"))
     KeyValuePair.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "value"))
     KeyValuePair.struct_class = Types::KeyValuePair
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     LinuxParameters.add_member(:capabilities, Shapes::ShapeRef.new(shape: KernelCapabilities, location_name: "capabilities"))
     LinuxParameters.add_member(:devices, Shapes::ShapeRef.new(shape: DevicesList, location_name: "devices"))
@@ -927,6 +945,8 @@ module Aws::ECS
     ManagedScaling.add_member(:maximum_scaling_step_size, Shapes::ShapeRef.new(shape: ManagedScalingStepSize, location_name: "maximumScalingStepSize"))
     ManagedScaling.struct_class = Types::ManagedScaling
 
+    MissingVersionException.struct_class = Types::MissingVersionException
+
     MountPoint.add_member(:source_volume, Shapes::ShapeRef.new(shape: String, location_name: "sourceVolume"))
     MountPoint.add_member(:container_path, Shapes::ShapeRef.new(shape: String, location_name: "containerPath"))
     MountPoint.add_member(:read_only, Shapes::ShapeRef.new(shape: BoxedBoolean, location_name: "readOnly"))
@@ -952,6 +972,8 @@ module Aws::ECS
 
     NetworkInterfaces.member = Shapes::ShapeRef.new(shape: NetworkInterface)
 
+    NoUpdateAvailableException.struct_class = Types::NoUpdateAvailableException
+
     PlacementConstraint.add_member(:type, Shapes::ShapeRef.new(shape: PlacementConstraintType, location_name: "type"))
     PlacementConstraint.add_member(:expression, Shapes::ShapeRef.new(shape: String, location_name: "expression"))
     PlacementConstraint.struct_class = Types::PlacementConstraint
@@ -969,6 +991,10 @@ module Aws::ECS
     PlatformDevice.struct_class = Types::PlatformDevice
 
     PlatformDevices.member = Shapes::ShapeRef.new(shape: PlatformDevice)
+
+    PlatformTaskDefinitionIncompatibilityException.struct_class = Types::PlatformTaskDefinitionIncompatibilityException
+
+    PlatformUnknownException.struct_class = Types::PlatformUnknownException
 
     PortMapping.add_member(:container_port, Shapes::ShapeRef.new(shape: BoxedInteger, location_name: "containerPort"))
     PortMapping.add_member(:host_port, Shapes::ShapeRef.new(shape: BoxedInteger, location_name: "hostPort"))
@@ -1062,6 +1088,10 @@ module Aws::ECS
     Resource.add_member(:string_set_value, Shapes::ShapeRef.new(shape: StringList, location_name: "stringSetValue"))
     Resource.struct_class = Types::Resource
 
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ResourceRequirement.add_member(:value, Shapes::ShapeRef.new(shape: String, required: true, location_name: "value"))
     ResourceRequirement.add_member(:type, Shapes::ShapeRef.new(shape: ResourceType, required: true, location_name: "type"))
     ResourceRequirement.struct_class = Types::ResourceRequirement
@@ -1144,6 +1174,10 @@ module Aws::ECS
     ServiceEvents.member = Shapes::ShapeRef.new(shape: ServiceEvent)
 
     ServiceFieldList.member = Shapes::ShapeRef.new(shape: ServiceField)
+
+    ServiceNotActiveException.struct_class = Types::ServiceNotActiveException
+
+    ServiceNotFoundException.struct_class = Types::ServiceNotFoundException
 
     ServiceRegistries.member = Shapes::ShapeRef.new(shape: ServiceRegistry)
 
@@ -1248,6 +1282,8 @@ module Aws::ECS
 
     Tags.member = Shapes::ShapeRef.new(shape: Tag)
 
+    TargetNotFoundException.struct_class = Types::TargetNotFoundException
+
     Task.add_member(:attachments, Shapes::ShapeRef.new(shape: Attachments, location_name: "attachments"))
     Task.add_member(:attributes, Shapes::ShapeRef.new(shape: Attributes, location_name: "attributes"))
     Task.add_member(:availability_zone, Shapes::ShapeRef.new(shape: String, location_name: "availabilityZone"))
@@ -1349,6 +1385,8 @@ module Aws::ECS
 
     TaskSetFieldList.member = Shapes::ShapeRef.new(shape: TaskSetField)
 
+    TaskSetNotFoundException.struct_class = Types::TaskSetNotFoundException
+
     TaskSets.member = Shapes::ShapeRef.new(shape: TaskSet)
 
     Tasks.member = Shapes::ShapeRef.new(shape: Task)
@@ -1366,6 +1404,8 @@ module Aws::ECS
     Ulimit.struct_class = Types::Ulimit
 
     UlimitList.member = Shapes::ShapeRef.new(shape: Ulimit)
+
+    UnsupportedFeatureException.struct_class = Types::UnsupportedFeatureException
 
     UntagResourceRequest.add_member(:resource_arn, Shapes::ShapeRef.new(shape: String, required: true, location_name: "resourceArn"))
     UntagResourceRequest.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeys, required: true, location_name: "tagKeys"))
@@ -1395,6 +1435,8 @@ module Aws::ECS
     UpdateContainerInstancesStateResponse.add_member(:container_instances, Shapes::ShapeRef.new(shape: ContainerInstances, location_name: "containerInstances"))
     UpdateContainerInstancesStateResponse.add_member(:failures, Shapes::ShapeRef.new(shape: Failures, location_name: "failures"))
     UpdateContainerInstancesStateResponse.struct_class = Types::UpdateContainerInstancesStateResponse
+
+    UpdateInProgressException.struct_class = Types::UpdateInProgressException
 
     UpdateServicePrimaryTaskSetRequest.add_member(:cluster, Shapes::ShapeRef.new(shape: String, required: true, location_name: "cluster"))
     UpdateServicePrimaryTaskSetRequest.add_member(:service, Shapes::ShapeRef.new(shape: String, required: true, location_name: "service"))

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
@@ -10,6 +10,39 @@ module Aws::ECS
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::AccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AttributeLimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::AttributeLimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BlockedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::BlockedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class ClientException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -26,6 +59,138 @@ module Aws::ECS
 
     end
 
+    class ClusterContainsContainerInstancesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ClusterContainsContainerInstancesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterContainsServicesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ClusterContainsServicesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterContainsTasksException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ClusterContainsTasksException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ClusterNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::InvalidParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MissingVersionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::MissingVersionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoUpdateAvailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::NoUpdateAvailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PlatformTaskDefinitionIncompatibilityException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::PlatformTaskDefinitionIncompatibilityException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PlatformUnknownException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::PlatformUnknownException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class ServerException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -38,6 +203,72 @@ module Aws::ECS
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class ServiceNotActiveException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ServiceNotActiveException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ServiceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::ServiceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TargetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::TargetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TaskSetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::TaskSetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedFeatureException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::UnsupportedFeatureException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UpdateInProgressException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ECS::Types::UpdateInProgressException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
@@ -8,6 +8,12 @@
 module Aws::ECS
   module Types
 
+    # You do not have authorization to perform the requested action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/AccessDeniedException AWS API Documentation
+    #
+    class AccessDeniedException < Aws::EmptyStructure; end
+
     # An object representing a container instance or task attachment.
     #
     # @!attribute [rw] id
@@ -118,6 +124,14 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # You can apply up to 10 custom attributes per resource. You can view
+    # the attributes of a resource with ListAttributes. You can remove
+    # existing attributes on a resource with DeleteAttributes.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/AttributeLimitExceededException AWS API Documentation
+    #
+    class AttributeLimitExceededException < Aws::EmptyStructure; end
+
     # The details of the Auto Scaling group for the capacity provider.
     #
     # @note When making an API call, you may pass AutoScalingGroupProvider
@@ -222,6 +236,17 @@ module Aws::ECS
       :assign_public_ip)
       include Aws::Structure
     end
+
+    # Your AWS account has been blocked. For more information, contact [AWS
+    # Support][1].
+    #
+    #
+    #
+    # [1]: http://aws.amazon.com/contact-us/
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/BlockedException AWS API Documentation
+    #
+    class BlockedException < Aws::EmptyStructure; end
 
     # The details of a capacity provider.
     #
@@ -525,6 +550,35 @@ module Aws::ECS
       :attachments_status)
       include Aws::Structure
     end
+
+    # You cannot delete a cluster that has registered container instances.
+    # First, deregister the container instances before you can delete the
+    # cluster. For more information, see DeregisterContainerInstance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ClusterContainsContainerInstancesException AWS API Documentation
+    #
+    class ClusterContainsContainerInstancesException < Aws::EmptyStructure; end
+
+    # You cannot delete a cluster that contains services. First, update the
+    # service to reduce its desired task count to 0 and then delete the
+    # service. For more information, see UpdateService and DeleteService.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ClusterContainsServicesException AWS API Documentation
+    #
+    class ClusterContainsServicesException < Aws::EmptyStructure; end
+
+    # You cannot delete a cluster that has active tasks.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ClusterContainsTasksException AWS API Documentation
+    #
+    class ClusterContainsTasksException < Aws::EmptyStructure; end
+
+    # The specified cluster could not be found. You can view your available
+    # clusters with ListClusters. Amazon ECS clusters are Region-specific.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ClusterNotFoundException AWS API Documentation
+    #
+    class ClusterNotFoundException < Aws::EmptyStructure; end
 
     # The settings to use when creating a cluster. This parameter is used to
     # enable CloudWatch Container Insights for a cluster.
@@ -4470,6 +4524,13 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # The specified parameter is invalid. Review the available parameters
+    # for the API request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/InvalidParameterException AWS API Documentation
+    #
+    class InvalidParameterException < Aws::EmptyStructure; end
+
     # The Linux capabilities for the container that are added to or dropped
     # from the default configuration provided by Docker. For more
     # information on the default capabilities and the non-default available
@@ -4576,6 +4637,12 @@ module Aws::ECS
       :value)
       include Aws::Structure
     end
+
+    # The limit for the resource has been exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # Linux-specific options that are applied to the container, such as
     # Linux KernelCapabilities.
@@ -5750,6 +5817,16 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # Amazon ECS is unable to determine the current version of the Amazon
+    # ECS container agent on the container instance and does not have enough
+    # information to proceed with an update. This could be because the agent
+    # running on the container instance is an older or custom version that
+    # does not use our version information.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/MissingVersionException AWS API Documentation
+    #
+    class MissingVersionException < Aws::EmptyStructure; end
+
     # Details on a volume mount point that is used in a container
     # definition.
     #
@@ -5882,6 +5959,14 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # There is no update available for this Amazon ECS container agent. This
+    # could be because the agent is already running the latest version, or
+    # it is so old that there is no update path to the current version.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/NoUpdateAvailableException AWS API Documentation
+    #
+    class NoUpdateAvailableException < Aws::EmptyStructure; end
+
     # An object representing a constraint on task placement. For more
     # information, see [Task Placement Constraints][1] in the *Amazon
     # Elastic Container Service Developer Guide*.
@@ -6005,6 +6090,19 @@ module Aws::ECS
       :type)
       include Aws::Structure
     end
+
+    # The specified platform version does not satisfy the task definition's
+    # required capabilities.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/PlatformTaskDefinitionIncompatibilityException AWS API Documentation
+    #
+    class PlatformTaskDefinitionIncompatibilityException < Aws::EmptyStructure; end
+
+    # The specified platform version does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/PlatformUnknownException AWS API Documentation
+    #
+    class PlatformUnknownException < Aws::EmptyStructure; end
 
     # Port mappings allow containers to access ports on the host container
     # instance to send or receive traffic. Port mappings are specified as
@@ -7184,6 +7282,18 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # The specified resource is in-use and cannot be removed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ResourceInUseException AWS API Documentation
+    #
+    class ResourceInUseException < Aws::EmptyStructure; end
+
+    # The specified resource could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # The type and amount of a resource to assign to a container. The
     # supported resource types are GPUs and Elastic Inference accelerators.
     # For more information, see [Working with GPUs on Amazon ECS][1] or
@@ -7914,6 +8024,22 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # The specified service is not active. You can't update a service that
+    # is inactive. If you have previously deleted a service, you can
+    # re-create it with CreateService.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ServiceNotActiveException AWS API Documentation
+    #
+    class ServiceNotActiveException < Aws::EmptyStructure; end
+
+    # The specified service could not be found. You can view your available
+    # services with ListServices. Amazon ECS services are cluster-specific
+    # and Region-specific.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/ServiceNotFoundException AWS API Documentation
+    #
+    class ServiceNotFoundException < Aws::EmptyStructure; end
+
     # Details of the service registry.
     #
     # @note When making an API call, you may pass ServiceRegistry
@@ -8641,6 +8767,14 @@ module Aws::ECS
     # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/TagResourceResponse AWS API Documentation
     #
     class TagResourceResponse < Aws::EmptyStructure; end
+
+    # The specified target could not be found. You can view your available
+    # container instances with ListContainerInstances. Amazon ECS container
+    # instances are cluster-specific and Region-specific.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/TargetNotFoundException AWS API Documentation
+    #
+    class TargetNotFoundException < Aws::EmptyStructure; end
 
     # Details on a task in a cluster.
     #
@@ -9625,6 +9759,14 @@ module Aws::ECS
       include Aws::Structure
     end
 
+    # The specified task set could not be found. You can view your available
+    # task sets with DescribeTaskSets. Task sets are specific to each
+    # cluster, service and Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/TaskSetNotFoundException AWS API Documentation
+    #
+    class TaskSetNotFoundException < Aws::EmptyStructure; end
+
     # The container path, mount options, and size of the tmpfs mount.
     #
     # @note When making an API call, you may pass Tmpfs
@@ -9696,6 +9838,12 @@ module Aws::ECS
       :hard_limit)
       include Aws::Structure
     end
+
+    # The specified task is not supported in this Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/UnsupportedFeatureException AWS API Documentation
+    #
+    class UnsupportedFeatureException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagResourceRequest
     #   data as a hash:
@@ -9867,6 +10015,17 @@ module Aws::ECS
       :failures)
       include Aws::Structure
     end
+
+    # There is already a current Amazon ECS container agent update in
+    # progress on the specified container instance. If the container agent
+    # becomes disconnected while it is in a transitional stage, such as
+    # `PENDING` or `STAGING`, the update process can get stuck in that
+    # state. However, when the agent reconnects, it resumes where it stopped
+    # previously.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/UpdateInProgressException AWS API Documentation
+    #
+    class UpdateInProgressException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UpdateServicePrimaryTaskSetRequest
     #   data as a hash:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
@@ -273,6 +273,8 @@ module Aws::ElastiCache
     UpdateActionStatusList = Shapes::ListShape.new(name: 'UpdateActionStatusList')
     UpdateActionsMessage = Shapes::StructureShape.new(name: 'UpdateActionsMessage')
 
+    APICallRateForCustomerExceededFault.struct_class = Types::APICallRateForCustomerExceededFault
+
     AddTagsToResourceMessage.add_member(:resource_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ResourceName"))
     AddTagsToResourceMessage.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, required: true, location_name: "Tags"))
     AddTagsToResourceMessage.struct_class = Types::AddTagsToResourceMessage
@@ -280,6 +282,10 @@ module Aws::ElastiCache
     AllowedNodeTypeModificationsMessage.add_member(:scale_up_modifications, Shapes::ShapeRef.new(shape: NodeTypeList, location_name: "ScaleUpModifications"))
     AllowedNodeTypeModificationsMessage.add_member(:scale_down_modifications, Shapes::ShapeRef.new(shape: NodeTypeList, location_name: "ScaleDownModifications"))
     AllowedNodeTypeModificationsMessage.struct_class = Types::AllowedNodeTypeModificationsMessage
+
+    AuthorizationAlreadyExistsFault.struct_class = Types::AuthorizationAlreadyExistsFault
+
+    AuthorizationNotFoundFault.struct_class = Types::AuthorizationNotFoundFault
 
     AuthorizeCacheSecurityGroupIngressMessage.add_member(:cache_security_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "CacheSecurityGroupName"))
     AuthorizeCacheSecurityGroupIngressMessage.add_member(:ec2_security_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "EC2SecurityGroupName"))
@@ -332,6 +338,8 @@ module Aws::ElastiCache
     CacheCluster.add_member(:at_rest_encryption_enabled, Shapes::ShapeRef.new(shape: BooleanOptional, location_name: "AtRestEncryptionEnabled"))
     CacheCluster.struct_class = Types::CacheCluster
 
+    CacheClusterAlreadyExistsFault.struct_class = Types::CacheClusterAlreadyExistsFault
+
     CacheClusterIdList.member = Shapes::ShapeRef.new(shape: String)
 
     CacheClusterList.member = Shapes::ShapeRef.new(shape: CacheCluster, location_name: "CacheCluster")
@@ -339,6 +347,8 @@ module Aws::ElastiCache
     CacheClusterMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CacheClusterMessage.add_member(:cache_clusters, Shapes::ShapeRef.new(shape: CacheClusterList, location_name: "CacheClusters"))
     CacheClusterMessage.struct_class = Types::CacheClusterMessage
+
+    CacheClusterNotFoundFault.struct_class = Types::CacheClusterNotFoundFault
 
     CacheEngineVersion.add_member(:engine, Shapes::ShapeRef.new(shape: String, location_name: "Engine"))
     CacheEngineVersion.add_member(:engine_version, Shapes::ShapeRef.new(shape: String, location_name: "EngineVersion"))
@@ -402,6 +412,8 @@ module Aws::ElastiCache
     CacheParameterGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
     CacheParameterGroup.struct_class = Types::CacheParameterGroup
 
+    CacheParameterGroupAlreadyExistsFault.struct_class = Types::CacheParameterGroupAlreadyExistsFault
+
     CacheParameterGroupDetails.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CacheParameterGroupDetails.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     CacheParameterGroupDetails.add_member(:cache_node_type_specific_parameters, Shapes::ShapeRef.new(shape: CacheNodeTypeSpecificParametersList, location_name: "CacheNodeTypeSpecificParameters"))
@@ -411,6 +423,10 @@ module Aws::ElastiCache
 
     CacheParameterGroupNameMessage.add_member(:cache_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "CacheParameterGroupName"))
     CacheParameterGroupNameMessage.struct_class = Types::CacheParameterGroupNameMessage
+
+    CacheParameterGroupNotFoundFault.struct_class = Types::CacheParameterGroupNotFoundFault
+
+    CacheParameterGroupQuotaExceededFault.struct_class = Types::CacheParameterGroupQuotaExceededFault
 
     CacheParameterGroupStatus.add_member(:cache_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "CacheParameterGroupName"))
     CacheParameterGroupStatus.add_member(:parameter_apply_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterApplyStatus"))
@@ -427,6 +443,8 @@ module Aws::ElastiCache
     CacheSecurityGroup.add_member(:ec2_security_groups, Shapes::ShapeRef.new(shape: EC2SecurityGroupList, location_name: "EC2SecurityGroups"))
     CacheSecurityGroup.struct_class = Types::CacheSecurityGroup
 
+    CacheSecurityGroupAlreadyExistsFault.struct_class = Types::CacheSecurityGroupAlreadyExistsFault
+
     CacheSecurityGroupMembership.add_member(:cache_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "CacheSecurityGroupName"))
     CacheSecurityGroupMembership.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     CacheSecurityGroupMembership.struct_class = Types::CacheSecurityGroupMembership
@@ -439,6 +457,10 @@ module Aws::ElastiCache
 
     CacheSecurityGroupNameList.member = Shapes::ShapeRef.new(shape: String, location_name: "CacheSecurityGroupName")
 
+    CacheSecurityGroupNotFoundFault.struct_class = Types::CacheSecurityGroupNotFoundFault
+
+    CacheSecurityGroupQuotaExceededFault.struct_class = Types::CacheSecurityGroupQuotaExceededFault
+
     CacheSecurityGroups.member = Shapes::ShapeRef.new(shape: CacheSecurityGroup, location_name: "CacheSecurityGroup")
 
     CacheSubnetGroup.add_member(:cache_subnet_group_name, Shapes::ShapeRef.new(shape: String, location_name: "CacheSubnetGroupName"))
@@ -447,13 +469,25 @@ module Aws::ElastiCache
     CacheSubnetGroup.add_member(:subnets, Shapes::ShapeRef.new(shape: SubnetList, location_name: "Subnets"))
     CacheSubnetGroup.struct_class = Types::CacheSubnetGroup
 
+    CacheSubnetGroupAlreadyExistsFault.struct_class = Types::CacheSubnetGroupAlreadyExistsFault
+
+    CacheSubnetGroupInUse.struct_class = Types::CacheSubnetGroupInUse
+
     CacheSubnetGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CacheSubnetGroupMessage.add_member(:cache_subnet_groups, Shapes::ShapeRef.new(shape: CacheSubnetGroups, location_name: "CacheSubnetGroups"))
     CacheSubnetGroupMessage.struct_class = Types::CacheSubnetGroupMessage
 
+    CacheSubnetGroupNotFoundFault.struct_class = Types::CacheSubnetGroupNotFoundFault
+
+    CacheSubnetGroupQuotaExceededFault.struct_class = Types::CacheSubnetGroupQuotaExceededFault
+
     CacheSubnetGroups.member = Shapes::ShapeRef.new(shape: CacheSubnetGroup, location_name: "CacheSubnetGroup")
 
+    CacheSubnetQuotaExceededFault.struct_class = Types::CacheSubnetQuotaExceededFault
+
     ClusterIdList.member = Shapes::ShapeRef.new(shape: String, location_name: "ClusterId")
+
+    ClusterQuotaForCustomerExceededFault.struct_class = Types::ClusterQuotaForCustomerExceededFault
 
     CompleteMigrationMessage.add_member(:replication_group_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ReplicationGroupId"))
     CompleteMigrationMessage.add_member(:force, Shapes::ShapeRef.new(shape: Boolean, location_name: "Force"))
@@ -762,11 +796,31 @@ module Aws::ElastiCache
     IncreaseReplicaCountResult.add_member(:replication_group, Shapes::ShapeRef.new(shape: ReplicationGroup, location_name: "ReplicationGroup"))
     IncreaseReplicaCountResult.struct_class = Types::IncreaseReplicaCountResult
 
+    InsufficientCacheClusterCapacityFault.struct_class = Types::InsufficientCacheClusterCapacityFault
+
+    InvalidARNFault.struct_class = Types::InvalidARNFault
+
+    InvalidCacheClusterStateFault.struct_class = Types::InvalidCacheClusterStateFault
+
+    InvalidCacheParameterGroupStateFault.struct_class = Types::InvalidCacheParameterGroupStateFault
+
+    InvalidCacheSecurityGroupStateFault.struct_class = Types::InvalidCacheSecurityGroupStateFault
+
+    InvalidKMSKeyFault.struct_class = Types::InvalidKMSKeyFault
+
     InvalidParameterCombinationException.add_member(:message, Shapes::ShapeRef.new(shape: AwsQueryErrorMessage, location_name: "message"))
     InvalidParameterCombinationException.struct_class = Types::InvalidParameterCombinationException
 
     InvalidParameterValueException.add_member(:message, Shapes::ShapeRef.new(shape: AwsQueryErrorMessage, location_name: "message"))
     InvalidParameterValueException.struct_class = Types::InvalidParameterValueException
+
+    InvalidReplicationGroupStateFault.struct_class = Types::InvalidReplicationGroupStateFault
+
+    InvalidSnapshotStateFault.struct_class = Types::InvalidSnapshotStateFault
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
 
     KeyList.member = Shapes::ShapeRef.new(shape: String)
 
@@ -849,6 +903,8 @@ module Aws::ElastiCache
     ModifyReplicationGroupShardConfigurationResult.add_member(:replication_group, Shapes::ShapeRef.new(shape: ReplicationGroup, location_name: "ReplicationGroup"))
     ModifyReplicationGroupShardConfigurationResult.struct_class = Types::ModifyReplicationGroupShardConfigurationResult
 
+    NoOperationFault.struct_class = Types::NoOperationFault
+
     NodeGroup.add_member(:node_group_id, Shapes::ShapeRef.new(shape: String, location_name: "NodeGroupId"))
     NodeGroup.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     NodeGroup.add_member(:primary_endpoint, Shapes::ShapeRef.new(shape: Endpoint, location_name: "PrimaryEndpoint"))
@@ -890,15 +946,23 @@ module Aws::ElastiCache
 
     NodeGroupMemberUpdateStatusList.member = Shapes::ShapeRef.new(shape: NodeGroupMemberUpdateStatus, location_name: "NodeGroupMemberUpdateStatus")
 
+    NodeGroupNotFoundFault.struct_class = Types::NodeGroupNotFoundFault
+
     NodeGroupUpdateStatus.add_member(:node_group_id, Shapes::ShapeRef.new(shape: String, location_name: "NodeGroupId"))
     NodeGroupUpdateStatus.add_member(:node_group_member_update_status, Shapes::ShapeRef.new(shape: NodeGroupMemberUpdateStatusList, location_name: "NodeGroupMemberUpdateStatus"))
     NodeGroupUpdateStatus.struct_class = Types::NodeGroupUpdateStatus
 
     NodeGroupUpdateStatusList.member = Shapes::ShapeRef.new(shape: NodeGroupUpdateStatus, location_name: "NodeGroupUpdateStatus")
 
+    NodeGroupsPerReplicationGroupQuotaExceededFault.struct_class = Types::NodeGroupsPerReplicationGroupQuotaExceededFault
+
     NodeGroupsToRemoveList.member = Shapes::ShapeRef.new(shape: AllowedNodeGroupId, location_name: "NodeGroupToRemove")
 
     NodeGroupsToRetainList.member = Shapes::ShapeRef.new(shape: AllowedNodeGroupId, location_name: "NodeGroupToRetain")
+
+    NodeQuotaForClusterExceededFault.struct_class = Types::NodeQuotaForClusterExceededFault
+
+    NodeQuotaForCustomerExceededFault.struct_class = Types::NodeQuotaForCustomerExceededFault
 
     NodeSnapshot.add_member(:cache_cluster_id, Shapes::ShapeRef.new(shape: String, location_name: "CacheClusterId"))
     NodeSnapshot.add_member(:node_group_id, Shapes::ShapeRef.new(shape: String, location_name: "NodeGroupId"))
@@ -1002,6 +1066,10 @@ module Aws::ElastiCache
     ReplicationGroup.add_member(:kms_key_id, Shapes::ShapeRef.new(shape: String, location_name: "KmsKeyId"))
     ReplicationGroup.struct_class = Types::ReplicationGroup
 
+    ReplicationGroupAlreadyExistsFault.struct_class = Types::ReplicationGroupAlreadyExistsFault
+
+    ReplicationGroupAlreadyUnderMigrationFault.struct_class = Types::ReplicationGroupAlreadyUnderMigrationFault
+
     ReplicationGroupIdList.member = Shapes::ShapeRef.new(shape: String)
 
     ReplicationGroupList.member = Shapes::ShapeRef.new(shape: ReplicationGroup, location_name: "ReplicationGroup")
@@ -1009,6 +1077,10 @@ module Aws::ElastiCache
     ReplicationGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReplicationGroupMessage.add_member(:replication_groups, Shapes::ShapeRef.new(shape: ReplicationGroupList, location_name: "ReplicationGroups"))
     ReplicationGroupMessage.struct_class = Types::ReplicationGroupMessage
+
+    ReplicationGroupNotFoundFault.struct_class = Types::ReplicationGroupNotFoundFault
+
+    ReplicationGroupNotUnderMigrationFault.struct_class = Types::ReplicationGroupNotUnderMigrationFault
 
     ReplicationGroupPendingModifiedValues.add_member(:primary_cluster_id, Shapes::ShapeRef.new(shape: String, location_name: "PrimaryClusterId"))
     ReplicationGroupPendingModifiedValues.add_member(:automatic_failover_status, Shapes::ShapeRef.new(shape: PendingAutomaticFailoverStatus, location_name: "AutomaticFailoverStatus"))
@@ -1031,11 +1103,17 @@ module Aws::ElastiCache
     ReservedCacheNode.add_member(:reservation_arn, Shapes::ShapeRef.new(shape: String, location_name: "ReservationARN"))
     ReservedCacheNode.struct_class = Types::ReservedCacheNode
 
+    ReservedCacheNodeAlreadyExistsFault.struct_class = Types::ReservedCacheNodeAlreadyExistsFault
+
     ReservedCacheNodeList.member = Shapes::ShapeRef.new(shape: ReservedCacheNode, location_name: "ReservedCacheNode")
 
     ReservedCacheNodeMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReservedCacheNodeMessage.add_member(:reserved_cache_nodes, Shapes::ShapeRef.new(shape: ReservedCacheNodeList, location_name: "ReservedCacheNodes"))
     ReservedCacheNodeMessage.struct_class = Types::ReservedCacheNodeMessage
+
+    ReservedCacheNodeNotFoundFault.struct_class = Types::ReservedCacheNodeNotFoundFault
+
+    ReservedCacheNodeQuotaExceededFault.struct_class = Types::ReservedCacheNodeQuotaExceededFault
 
     ReservedCacheNodesOffering.add_member(:reserved_cache_nodes_offering_id, Shapes::ShapeRef.new(shape: String, location_name: "ReservedCacheNodesOfferingId"))
     ReservedCacheNodesOffering.add_member(:cache_node_type, Shapes::ShapeRef.new(shape: String, location_name: "CacheNodeType"))
@@ -1052,6 +1130,8 @@ module Aws::ElastiCache
     ReservedCacheNodesOfferingMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReservedCacheNodesOfferingMessage.add_member(:reserved_cache_nodes_offerings, Shapes::ShapeRef.new(shape: ReservedCacheNodesOfferingList, location_name: "ReservedCacheNodesOfferings"))
     ReservedCacheNodesOfferingMessage.struct_class = Types::ReservedCacheNodesOfferingMessage
+
+    ReservedCacheNodesOfferingNotFoundFault.struct_class = Types::ReservedCacheNodesOfferingNotFoundFault
 
     ResetCacheParameterGroupMessage.add_member(:cache_parameter_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "CacheParameterGroupName"))
     ResetCacheParameterGroupMessage.add_member(:reset_all_parameters, Shapes::ShapeRef.new(shape: Boolean, location_name: "ResetAllParameters"))
@@ -1083,6 +1163,8 @@ module Aws::ElastiCache
 
     SecurityGroupMembershipList.member = Shapes::ShapeRef.new(shape: SecurityGroupMembership)
 
+    ServiceLinkedRoleNotFoundFault.struct_class = Types::ServiceLinkedRoleNotFoundFault
+
     ServiceUpdate.add_member(:service_update_name, Shapes::ShapeRef.new(shape: String, location_name: "ServiceUpdateName"))
     ServiceUpdate.add_member(:service_update_release_date, Shapes::ShapeRef.new(shape: TStamp, location_name: "ServiceUpdateReleaseDate"))
     ServiceUpdate.add_member(:service_update_end_date, Shapes::ShapeRef.new(shape: TStamp, location_name: "ServiceUpdateEndDate"))
@@ -1098,6 +1180,8 @@ module Aws::ElastiCache
     ServiceUpdate.struct_class = Types::ServiceUpdate
 
     ServiceUpdateList.member = Shapes::ShapeRef.new(shape: ServiceUpdate, location_name: "ServiceUpdate")
+
+    ServiceUpdateNotFoundFault.struct_class = Types::ServiceUpdateNotFoundFault
 
     ServiceUpdateStatusList.member = Shapes::ShapeRef.new(shape: ServiceUpdateStatus)
 
@@ -1135,9 +1219,17 @@ module Aws::ElastiCache
     Snapshot.add_member(:kms_key_id, Shapes::ShapeRef.new(shape: String, location_name: "KmsKeyId"))
     Snapshot.struct_class = Types::Snapshot
 
+    SnapshotAlreadyExistsFault.struct_class = Types::SnapshotAlreadyExistsFault
+
     SnapshotArnsList.member = Shapes::ShapeRef.new(shape: String, location_name: "SnapshotArn")
 
+    SnapshotFeatureNotSupportedFault.struct_class = Types::SnapshotFeatureNotSupportedFault
+
     SnapshotList.member = Shapes::ShapeRef.new(shape: Snapshot, location_name: "Snapshot")
+
+    SnapshotNotFoundFault.struct_class = Types::SnapshotNotFoundFault
+
+    SnapshotQuotaExceededFault.struct_class = Types::SnapshotQuotaExceededFault
 
     StartMigrationMessage.add_member(:replication_group_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ReplicationGroupId"))
     StartMigrationMessage.add_member(:customer_node_endpoint_list, Shapes::ShapeRef.new(shape: CustomerNodeEndpointList, required: true, location_name: "CustomerNodeEndpointList"))
@@ -1152,6 +1244,8 @@ module Aws::ElastiCache
 
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier")
 
+    SubnetInUse.struct_class = Types::SubnetInUse
+
     SubnetList.member = Shapes::ShapeRef.new(shape: Subnet, location_name: "Subnet")
 
     Tag.add_member(:key, Shapes::ShapeRef.new(shape: String, location_name: "Key"))
@@ -1163,9 +1257,15 @@ module Aws::ElastiCache
     TagListMessage.add_member(:tag_list, Shapes::ShapeRef.new(shape: TagList, location_name: "TagList"))
     TagListMessage.struct_class = Types::TagListMessage
 
+    TagNotFoundFault.struct_class = Types::TagNotFoundFault
+
+    TagQuotaPerResourceExceeded.struct_class = Types::TagQuotaPerResourceExceeded
+
     TestFailoverMessage.add_member(:replication_group_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ReplicationGroupId"))
     TestFailoverMessage.add_member(:node_group_id, Shapes::ShapeRef.new(shape: AllowedNodeGroupId, required: true, location_name: "NodeGroupId"))
     TestFailoverMessage.struct_class = Types::TestFailoverMessage
+
+    TestFailoverNotAvailableFault.struct_class = Types::TestFailoverNotAvailableFault
 
     TestFailoverResult.add_member(:replication_group, Shapes::ShapeRef.new(shape: ReplicationGroup, location_name: "ReplicationGroup"))
     TestFailoverResult.struct_class = Types::TestFailoverResult

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
@@ -10,6 +10,259 @@ module Aws::ElastiCache
 
     extend Aws::Errors::DynamicErrors
 
+    class APICallRateForCustomerExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::APICallRateForCustomerExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::AuthorizationAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::AuthorizationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSecurityGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSecurityGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSecurityGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSecurityGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSecurityGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSecurityGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSubnetGroupInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSubnetGroupInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CacheSubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::CacheSubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterQuotaForCustomerExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ClusterQuotaForCustomerExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientCacheClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InsufficientCacheClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidARNFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidARNFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCacheClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidCacheClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCacheParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidCacheParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidCacheSecurityGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidCacheSecurityGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidKMSKeyFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidKMSKeyFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidParameterCombinationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -38,6 +291,303 @@ module Aws::ElastiCache
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvalidReplicationGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidReplicationGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoOperationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::NoOperationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::NodeGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeGroupsPerReplicationGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::NodeGroupsPerReplicationGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeQuotaForClusterExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::NodeQuotaForClusterExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NodeQuotaForCustomerExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::NodeQuotaForCustomerExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplicationGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReplicationGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplicationGroupAlreadyUnderMigrationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReplicationGroupAlreadyUnderMigrationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplicationGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReplicationGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReplicationGroupNotUnderMigrationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReplicationGroupNotUnderMigrationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedCacheNodeAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReservedCacheNodeAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedCacheNodeNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReservedCacheNodeNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedCacheNodeQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReservedCacheNodeQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedCacheNodesOfferingNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ReservedCacheNodesOfferingNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ServiceLinkedRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ServiceLinkedRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ServiceUpdateNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::ServiceUpdateNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::SnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotFeatureNotSupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::SnapshotFeatureNotSupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::SnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::SnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::SubnetInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::TagNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagQuotaPerResourceExceeded < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::TagQuotaPerResourceExceeded] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TestFailoverNotAvailableFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElastiCache::Types::TestFailoverNotAvailableFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
@@ -8,6 +8,12 @@
 module Aws::ElastiCache
   module Types
 
+    # The customer has exceeded the allowed rate of API calls.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/APICallRateForCustomerExceededFault AWS API Documentation
+    #
+    class APICallRateForCustomerExceededFault < Aws::EmptyStructure; end
+
     # Represents the input of an AddTagsToResource operation.
     #
     # @note When making an API call, you may pass AddTagsToResourceMessage
@@ -79,6 +85,20 @@ module Aws::ElastiCache
       :scale_down_modifications)
       include Aws::Structure
     end
+
+    # The specified Amazon EC2 security group is already authorized for the
+    # specified cache security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/AuthorizationAlreadyExistsFault AWS API Documentation
+    #
+    class AuthorizationAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified Amazon EC2 security group is not authorized for the
+    # specified cache security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/AuthorizationNotFoundFault AWS API Documentation
+    #
+    class AuthorizationNotFoundFault < Aws::EmptyStructure; end
 
     # Represents the input of an AuthorizeCacheSecurityGroupIngress
     # operation.
@@ -488,6 +508,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # You already have a cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheClusterAlreadyExistsFault AWS API Documentation
+    #
+    class CacheClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Represents the output of a `DescribeCacheClusters` operation.
     #
     # @!attribute [rw] marker
@@ -506,6 +532,12 @@ module Aws::ElastiCache
       :cache_clusters)
       include Aws::Structure
     end
+
+    # The requested cluster ID does not refer to an existing cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheClusterNotFoundFault AWS API Documentation
+    #
+    class CacheClusterNotFoundFault < Aws::EmptyStructure; end
 
     # Provides all of the details about a particular cache engine version.
     #
@@ -841,6 +873,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # A cache parameter group with the requested name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class CacheParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Represents the output of a `DescribeCacheParameters` operation.
     #
     # @!attribute [rw] marker
@@ -882,6 +920,20 @@ module Aws::ElastiCache
       :cache_parameter_group_name)
       include Aws::Structure
     end
+
+    # The requested cache parameter group name does not refer to an existing
+    # cache parameter group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheParameterGroupNotFoundFault AWS API Documentation
+    #
+    class CacheParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the maximum
+    # number of cache security groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class CacheParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # Status of the cache parameter group.
     #
@@ -962,6 +1014,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # A cache security group with the specified name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSecurityGroupAlreadyExistsFault AWS API Documentation
+    #
+    class CacheSecurityGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Represents a cluster's status within a particular cache security
     # group.
     #
@@ -1002,6 +1060,20 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The requested cache security group name does not refer to an existing
+    # cache security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSecurityGroupNotFoundFault AWS API Documentation
+    #
+    class CacheSecurityGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of cache security groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSecurityGroupQuotaExceededFault AWS API Documentation
+    #
+    class CacheSecurityGroupQuotaExceededFault < Aws::EmptyStructure; end
+
     # Represents the output of one of the following operations:
     #
     # * `CreateCacheSubnetGroup`
@@ -1035,6 +1107,19 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The requested cache subnet group name is already in use by an existing
+    # cache subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class CacheSubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The requested cache subnet group is currently in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSubnetGroupInUse AWS API Documentation
+    #
+    class CacheSubnetGroupInUse < Aws::EmptyStructure; end
+
     # Represents the output of a `DescribeCacheSubnetGroups` operation.
     #
     # @!attribute [rw] marker
@@ -1053,6 +1138,34 @@ module Aws::ElastiCache
       :cache_subnet_groups)
       include Aws::Structure
     end
+
+    # The requested cache subnet group name does not refer to an existing
+    # cache subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSubnetGroupNotFoundFault AWS API Documentation
+    #
+    class CacheSubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of cache subnet groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class CacheSubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of subnets in a cache subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheSubnetQuotaExceededFault AWS API Documentation
+    #
+    class CacheSubnetQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of clusters per customer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ClusterQuotaForCustomerExceededFault AWS API Documentation
+    #
+    class ClusterQuotaForCustomerExceededFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass CompleteMigrationMessage
     #   data as a hash:
@@ -3868,6 +3981,50 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The requested cache node type is not available in the specified
+    # Availability Zone. For more information, see
+    # [InsufficientCacheClusterCapacity][1] in the ElastiCache User Guide.
+    #
+    #
+    #
+    # [1]: http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ErrorMessages.html#ErrorMessages.INSUFFICIENT_CACHE_CLUSTER_CAPACITY
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InsufficientCacheClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientCacheClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The requested Amazon Resource Name (ARN) does not refer to an existing
+    # resource.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidARNFault AWS API Documentation
+    #
+    class InvalidARNFault < Aws::EmptyStructure; end
+
+    # The requested cluster is not in the `available` state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidCacheClusterStateFault AWS API Documentation
+    #
+    class InvalidCacheClusterStateFault < Aws::EmptyStructure; end
+
+    # The current state of the cache parameter group does not allow the
+    # requested operation to occur.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidCacheParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidCacheParameterGroupStateFault < Aws::EmptyStructure; end
+
+    # The current state of the cache security group does not allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidCacheSecurityGroupStateFault AWS API Documentation
+    #
+    class InvalidCacheSecurityGroupStateFault < Aws::EmptyStructure; end
+
+    # The KMS key supplied is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidKMSKeyFault AWS API Documentation
+    #
+    class InvalidKMSKeyFault < Aws::EmptyStructure; end
+
     # Two or more incompatible parameters were specified.
     #
     # @!attribute [rw] message
@@ -3894,6 +4051,31 @@ module Aws::ElastiCache
       :message)
       include Aws::Structure
     end
+
+    # The requested replication group is not in the `available` state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidReplicationGroupStateFault AWS API Documentation
+    #
+    class InvalidReplicationGroupStateFault < Aws::EmptyStructure; end
+
+    # The current state of the snapshot does not allow the requested
+    # operation to occur.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidSnapshotStateFault AWS API Documentation
+    #
+    class InvalidSnapshotStateFault < Aws::EmptyStructure; end
+
+    # An invalid subnet identifier was specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # The VPC network is in an invalid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
 
     # The input parameters for the `ListAllowedNodeTypeModifications`
     # operation.
@@ -4806,6 +4988,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The operation was not performed because no changes were required.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NoOperationFault AWS API Documentation
+    #
+    class NoOperationFault < Aws::EmptyStructure; end
+
     # Represents a collection of cache nodes in a replication group. One
     # node in the node group is the read/write primary node. All the other
     # nodes are read-only Replica nodes.
@@ -4998,6 +5186,14 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The node group specified by the `NodeGroupId` parameter could not be
+    # found. Please verify that the node group exists and that you spelled
+    # the `NodeGroupId` value correctly.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NodeGroupNotFoundFault AWS API Documentation
+    #
+    class NodeGroupNotFoundFault < Aws::EmptyStructure; end
+
     # The status of the service update on the node group
     #
     # @!attribute [rw] node_group_id
@@ -5015,6 +5211,28 @@ module Aws::ElastiCache
       :node_group_member_update_status)
       include Aws::Structure
     end
+
+    # The request cannot be processed because it would exceed the maximum
+    # allowed number of node groups (shards) in a single replication group.
+    # The default maximum is 90
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NodeGroupsPerReplicationGroupQuotaExceededFault AWS API Documentation
+    #
+    class NodeGroupsPerReplicationGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of cache nodes in a single cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NodeQuotaForClusterExceededFault AWS API Documentation
+    #
+    class NodeQuotaForClusterExceededFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the allowed
+    # number of cache nodes per customer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NodeQuotaForCustomerExceededFault AWS API Documentation
+    #
+    class NodeQuotaForCustomerExceededFault < Aws::EmptyStructure; end
 
     # Represents an individual cache node in a snapshot of a cluster.
     #
@@ -5555,6 +5773,18 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The specified replication group already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReplicationGroupAlreadyExistsFault AWS API Documentation
+    #
+    class ReplicationGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The targeted replication group is not available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReplicationGroupAlreadyUnderMigrationFault AWS API Documentation
+    #
+    class ReplicationGroupAlreadyUnderMigrationFault < Aws::EmptyStructure; end
+
     # Represents the output of a `DescribeReplicationGroups` operation.
     #
     # @!attribute [rw] marker
@@ -5573,6 +5803,18 @@ module Aws::ElastiCache
       :replication_groups)
       include Aws::Structure
     end
+
+    # The specified replication group does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReplicationGroupNotFoundFault AWS API Documentation
+    #
+    class ReplicationGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The designated replication group is not available for data migration.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReplicationGroupNotUnderMigrationFault AWS API Documentation
+    #
+    class ReplicationGroupNotUnderMigrationFault < Aws::EmptyStructure; end
 
     # The settings to be applied to the Redis replication group, either
     # immediately or during the next maintenance window.
@@ -5761,6 +6003,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # You already have a reservation with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReservedCacheNodeAlreadyExistsFault AWS API Documentation
+    #
+    class ReservedCacheNodeAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Represents the output of a `DescribeReservedCacheNodes` operation.
     #
     # @!attribute [rw] marker
@@ -5779,6 +6027,19 @@ module Aws::ElastiCache
       :reserved_cache_nodes)
       include Aws::Structure
     end
+
+    # The requested reserved cache node was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReservedCacheNodeNotFoundFault AWS API Documentation
+    #
+    class ReservedCacheNodeNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the user's
+    # cache node quota.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReservedCacheNodeQuotaExceededFault AWS API Documentation
+    #
+    class ReservedCacheNodeQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes all of the attributes of a reserved cache node offering.
     #
@@ -5916,6 +6177,12 @@ module Aws::ElastiCache
       :reserved_cache_nodes_offerings)
       include Aws::Structure
     end
+
+    # The requested cache node offering does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReservedCacheNodesOfferingNotFoundFault AWS API Documentation
+    #
+    class ReservedCacheNodesOfferingNotFoundFault < Aws::EmptyStructure; end
 
     # Represents the input of a `ResetCacheParameterGroup` operation.
     #
@@ -6074,6 +6341,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The specified service linked role (SLR) was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ServiceLinkedRoleNotFoundFault AWS API Documentation
+    #
+    class ServiceLinkedRoleNotFoundFault < Aws::EmptyStructure; end
+
     # An update that you can apply to your Redis clusters.
     #
     # @!attribute [rw] service_update_name
@@ -6150,6 +6423,12 @@ module Aws::ElastiCache
       :estimated_update_time)
       include Aws::Structure
     end
+
+    # The service update doesn't exist
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ServiceUpdateNotFoundFault AWS API Documentation
+    #
+    class ServiceUpdateNotFoundFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] marker
     #   An optional marker returned from a prior request. Use this marker
@@ -6445,6 +6724,39 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # You already have a snapshot with the given name.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/SnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class SnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # You attempted one of the following operations:
+    #
+    # * Creating a snapshot of a Redis cluster running on a `cache.t1.micro`
+    #   cache node.
+    #
+    # * Creating a snapshot of a cluster that is running Memcached rather
+    #   than Redis.
+    #
+    # Neither of these are supported by ElastiCache.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/SnapshotFeatureNotSupportedFault AWS API Documentation
+    #
+    class SnapshotFeatureNotSupportedFault < Aws::EmptyStructure; end
+
+    # The requested snapshot name does not refer to an existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/SnapshotNotFoundFault AWS API Documentation
+    #
+    class SnapshotNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would exceed the maximum
+    # number of snapshots.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/SnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass StartMigrationMessage
     #   data as a hash:
     #
@@ -6507,6 +6819,12 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The requested subnet is being used by another cache subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/SubnetInUse AWS API Documentation
+    #
+    class SubnetInUse < Aws::EmptyStructure; end
+
     # A cost allocation Tag that can be added to an ElastiCache cluster or
     # replication group. Tags are composed of a Key/Value pair. A tag with a
     # null Value is permitted.
@@ -6549,6 +6867,20 @@ module Aws::ElastiCache
       include Aws::Structure
     end
 
+    # The requested tag was not found on this resource.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TagNotFoundFault AWS API Documentation
+    #
+    class TagNotFoundFault < Aws::EmptyStructure; end
+
+    # The request cannot be processed because it would cause the resource to
+    # have more than the allowed number of tags. The maximum number of tags
+    # permitted on a resource is 50.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TagQuotaPerResourceExceeded AWS API Documentation
+    #
+    class TagQuotaPerResourceExceeded < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass TestFailoverMessage
     #   data as a hash:
     #
@@ -6576,6 +6908,12 @@ module Aws::ElastiCache
       :node_group_id)
       include Aws::Structure
     end
+
+    # The `TestFailover` action is not available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TestFailoverNotAvailableFault AWS API Documentation
+    #
+    class TestFailoverNotAvailableFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] replication_group
     #   Contains all of the attributes of a specific Redis replication

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
@@ -422,6 +422,8 @@ module Aws::ElasticBeanstalk
     CheckDNSAvailabilityResultMessage.add_member(:fully_qualified_cname, Shapes::ShapeRef.new(shape: DNSCname, location_name: "FullyQualifiedCNAME"))
     CheckDNSAvailabilityResultMessage.struct_class = Types::CheckDNSAvailabilityResultMessage
 
+    CodeBuildNotInServiceRegionException.struct_class = Types::CodeBuildNotInServiceRegionException
+
     ComposeEnvironmentsMessage.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, location_name: "ApplicationName"))
     ComposeEnvironmentsMessage.add_member(:group_name, Shapes::ShapeRef.new(shape: GroupName, location_name: "GroupName"))
     ComposeEnvironmentsMessage.add_member(:version_labels, Shapes::ShapeRef.new(shape: VersionLabels, location_name: "VersionLabels"))
@@ -783,6 +785,10 @@ module Aws::ElasticBeanstalk
 
     InstancesHealthAttributes.member = Shapes::ShapeRef.new(shape: InstancesHealthAttribute)
 
+    InsufficientPrivilegesException.struct_class = Types::InsufficientPrivilegesException
+
+    InvalidRequestException.struct_class = Types::InvalidRequestException
+
     Latency.add_member(:p999, Shapes::ShapeRef.new(shape: NullableDouble, location_name: "P999"))
     Latency.add_member(:p99, Shapes::ShapeRef.new(shape: NullableDouble, location_name: "P99"))
     Latency.add_member(:p95, Shapes::ShapeRef.new(shape: NullableDouble, location_name: "P95"))
@@ -856,6 +862,8 @@ module Aws::ElasticBeanstalk
 
     ManagedActionHistoryItems.member = Shapes::ShapeRef.new(shape: ManagedActionHistoryItem)
 
+    ManagedActionInvalidStateException.struct_class = Types::ManagedActionInvalidStateException
+
     ManagedActions.member = Shapes::ShapeRef.new(shape: ManagedAction)
 
     MaxAgeRule.add_member(:enabled, Shapes::ShapeRef.new(shape: BoxedBoolean, required: true, location_name: "Enabled"))
@@ -867,6 +875,8 @@ module Aws::ElasticBeanstalk
     MaxCountRule.add_member(:max_count, Shapes::ShapeRef.new(shape: BoxedInt, location_name: "MaxCount"))
     MaxCountRule.add_member(:delete_source_from_s3, Shapes::ShapeRef.new(shape: BoxedBoolean, location_name: "DeleteSourceFromS3"))
     MaxCountRule.struct_class = Types::MaxCountRule
+
+    OperationInProgressException.struct_class = Types::OperationInProgressException
 
     OptionRestrictionRegex.add_member(:pattern, Shapes::ShapeRef.new(shape: RegexPattern, location_name: "Pattern"))
     OptionRestrictionRegex.add_member(:label, Shapes::ShapeRef.new(shape: RegexLabel, location_name: "Label"))
@@ -932,6 +942,8 @@ module Aws::ElasticBeanstalk
 
     PlatformSummaryList.member = Shapes::ShapeRef.new(shape: PlatformSummary)
 
+    PlatformVersionStillReferencedException.struct_class = Types::PlatformVersionStillReferencedException
+
     Queue.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     Queue.add_member(:url, Shapes::ShapeRef.new(shape: String, location_name: "URL"))
     Queue.struct_class = Types::Queue
@@ -947,6 +959,8 @@ module Aws::ElasticBeanstalk
     RequestEnvironmentInfoMessage.add_member(:info_type, Shapes::ShapeRef.new(shape: EnvironmentInfoType, required: true, location_name: "InfoType"))
     RequestEnvironmentInfoMessage.struct_class = Types::RequestEnvironmentInfoMessage
 
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ResourceQuota.add_member(:maximum, Shapes::ShapeRef.new(shape: BoxedInt, location_name: "Maximum"))
     ResourceQuota.struct_class = Types::ResourceQuota
 
@@ -960,6 +974,8 @@ module Aws::ElasticBeanstalk
     ResourceTagsDescriptionMessage.add_member(:resource_arn, Shapes::ShapeRef.new(shape: ResourceArn, location_name: "ResourceArn"))
     ResourceTagsDescriptionMessage.add_member(:resource_tags, Shapes::ShapeRef.new(shape: TagList, location_name: "ResourceTags"))
     ResourceTagsDescriptionMessage.struct_class = Types::ResourceTagsDescriptionMessage
+
+    ResourceTypeNotSupportedException.struct_class = Types::ResourceTypeNotSupportedException
 
     RestartAppServerMessage.add_member(:environment_id, Shapes::ShapeRef.new(shape: EnvironmentId, location_name: "EnvironmentId"))
     RestartAppServerMessage.add_member(:environment_name, Shapes::ShapeRef.new(shape: EnvironmentName, location_name: "EnvironmentName"))
@@ -976,6 +992,10 @@ module Aws::ElasticBeanstalk
     S3Location.add_member(:s3_bucket, Shapes::ShapeRef.new(shape: S3Bucket, location_name: "S3Bucket"))
     S3Location.add_member(:s3_key, Shapes::ShapeRef.new(shape: S3Key, location_name: "S3Key"))
     S3Location.struct_class = Types::S3Location
+
+    S3LocationNotInServiceRegionException.struct_class = Types::S3LocationNotInServiceRegionException
+
+    S3SubscriptionRequiredException.struct_class = Types::S3SubscriptionRequiredException
 
     SingleInstanceHealth.add_member(:instance_id, Shapes::ShapeRef.new(shape: InstanceId, location_name: "InstanceId"))
     SingleInstanceHealth.add_member(:health_status, Shapes::ShapeRef.new(shape: String, location_name: "HealthStatus"))
@@ -999,6 +1019,8 @@ module Aws::ElasticBeanstalk
     SourceBuildInformation.add_member(:source_repository, Shapes::ShapeRef.new(shape: SourceRepository, required: true, location_name: "SourceRepository"))
     SourceBuildInformation.add_member(:source_location, Shapes::ShapeRef.new(shape: SourceLocation, required: true, location_name: "SourceLocation"))
     SourceBuildInformation.struct_class = Types::SourceBuildInformation
+
+    SourceBundleDeletionException.struct_class = Types::SourceBundleDeletionException
 
     SourceConfiguration.add_member(:application_name, Shapes::ShapeRef.new(shape: ApplicationName, location_name: "ApplicationName"))
     SourceConfiguration.add_member(:template_name, Shapes::ShapeRef.new(shape: ConfigurationTemplateName, location_name: "TemplateName"))
@@ -1039,6 +1061,20 @@ module Aws::ElasticBeanstalk
     TerminateEnvironmentMessage.add_member(:terminate_resources, Shapes::ShapeRef.new(shape: TerminateEnvironmentResources, location_name: "TerminateResources"))
     TerminateEnvironmentMessage.add_member(:force_terminate, Shapes::ShapeRef.new(shape: ForceTerminate, location_name: "ForceTerminate"))
     TerminateEnvironmentMessage.struct_class = Types::TerminateEnvironmentMessage
+
+    TooManyApplicationVersionsException.struct_class = Types::TooManyApplicationVersionsException
+
+    TooManyApplicationsException.struct_class = Types::TooManyApplicationsException
+
+    TooManyBucketsException.struct_class = Types::TooManyBucketsException
+
+    TooManyConfigurationTemplatesException.struct_class = Types::TooManyConfigurationTemplatesException
+
+    TooManyEnvironmentsException.struct_class = Types::TooManyEnvironmentsException
+
+    TooManyPlatformsException.struct_class = Types::TooManyPlatformsException
+
+    TooManyTagsException.struct_class = Types::TooManyTagsException
 
     Trigger.add_member(:name, Shapes::ShapeRef.new(shape: ResourceId, location_name: "Name"))
     Trigger.struct_class = Types::Trigger

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
@@ -10,6 +10,17 @@ module Aws::ElasticBeanstalk
 
     extend Aws::Errors::DynamicErrors
 
+    class CodeBuildNotInServiceRegionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::CodeBuildNotInServiceRegionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class ElasticBeanstalkServiceException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -22,6 +33,193 @@ module Aws::ElasticBeanstalk
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InsufficientPrivilegesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::InsufficientPrivilegesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::InvalidRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ManagedActionInvalidStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::ManagedActionInvalidStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationInProgressException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::OperationInProgressException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PlatformVersionStillReferencedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::PlatformVersionStillReferencedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceTypeNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::ResourceTypeNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class S3LocationNotInServiceRegionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::S3LocationNotInServiceRegionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class S3SubscriptionRequiredException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::S3SubscriptionRequiredException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceBundleDeletionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::SourceBundleDeletionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyApplicationVersionsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyApplicationVersionsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyApplicationsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyApplicationsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyBucketsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyBucketsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyConfigurationTemplatesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyConfigurationTemplatesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyEnvironmentsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyEnvironmentsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyPlatformsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyPlatformsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticBeanstalk::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
@@ -630,6 +630,12 @@ module Aws::ElasticBeanstalk
       include Aws::Structure
     end
 
+    # AWS CodeBuild is not available in the specified region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/CodeBuildNotInServiceRegionException AWS API Documentation
+    #
+    class CodeBuildNotInServiceRegionException < Aws::EmptyStructure; end
+
     # Request to create or update a group of environments.
     #
     # @note When making an API call, you may pass ComposeEnvironmentsMessage
@@ -2934,6 +2940,20 @@ module Aws::ElasticBeanstalk
       include Aws::Structure
     end
 
+    # The specified account does not have sufficient privileges for one or
+    # more AWS services.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/InsufficientPrivilegesException AWS API Documentation
+    #
+    class InsufficientPrivilegesException < Aws::EmptyStructure; end
+
+    # One or more input parameters is not valid. Please correct the input
+    # parameters and try the operation again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/InvalidRequestException AWS API Documentation
+    #
+    class InvalidRequestException < Aws::EmptyStructure; end
+
     # Represents the average latency for the slowest X percent of requests
     # over the last 10 seconds.
     #
@@ -3250,6 +3270,12 @@ module Aws::ElasticBeanstalk
       include Aws::Structure
     end
 
+    # Cannot modify the managed action in its current state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/ManagedActionInvalidStateException AWS API Documentation
+    #
+    class ManagedActionInvalidStateException < Aws::EmptyStructure; end
+
     # A lifecycle rule that deletes application versions after the specified
     # number of days.
     #
@@ -3317,6 +3343,13 @@ module Aws::ElasticBeanstalk
       :delete_source_from_s3)
       include Aws::Structure
     end
+
+    # Unable to perform the specified operation because another operation
+    # that effects an element in this activity is already in progress.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/OperationInProgressException AWS API Documentation
+    #
+    class OperationInProgressException < Aws::EmptyStructure; end
 
     # A regular expression representing a restriction on a string
     # configuration option value.
@@ -3601,6 +3634,13 @@ module Aws::ElasticBeanstalk
       include Aws::Structure
     end
 
+    # You cannot delete the platform version because there are still
+    # environments running on it.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/PlatformVersionStillReferencedException AWS API Documentation
+    #
+    class PlatformVersionStillReferencedException < Aws::EmptyStructure; end
+
     # Describes a queue.
     #
     # @!attribute [rw] name
@@ -3698,6 +3738,13 @@ module Aws::ElasticBeanstalk
       include Aws::Structure
     end
 
+    # A resource doesn't exist for the specified Amazon Resource Name
+    # (ARN).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # The AWS Elastic Beanstalk quota information for a single resource type
     # in an AWS account. It reflects the resource's limits for this
     # account.
@@ -3765,6 +3812,13 @@ module Aws::ElasticBeanstalk
       :resource_tags)
       include Aws::Structure
     end
+
+    # The type of the specified Amazon Resource Name (ARN) isn't supported
+    # for this operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/ResourceTypeNotSupportedException AWS API Documentation
+    #
+    class ResourceTypeNotSupportedException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass RestartAppServerMessage
     #   data as a hash:
@@ -3883,6 +3937,25 @@ module Aws::ElasticBeanstalk
       :s3_key)
       include Aws::Structure
     end
+
+    # The specified S3 bucket does not belong to the S3 region in which the
+    # service is running. The following regions are supported:
+    #
+    # * IAD/us-east-1
+    #
+    # * PDX/us-west-2
+    #
+    # * DUB/eu-west-1
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/S3LocationNotInServiceRegionException AWS API Documentation
+    #
+    class S3LocationNotInServiceRegionException < Aws::EmptyStructure; end
+
+    # The specified account does not have a subscription to Amazon S3.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/S3SubscriptionRequiredException AWS API Documentation
+    #
+    class S3SubscriptionRequiredException < Aws::EmptyStructure; end
 
     # Detailed health information about an Amazon EC2 instance in your
     # Elastic Beanstalk environment.
@@ -4021,6 +4094,13 @@ module Aws::ElasticBeanstalk
       :source_location)
       include Aws::Structure
     end
+
+    # Unable to delete the Amazon S3 source bundle associated with the
+    # application version. The application version was deleted successfully.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/SourceBundleDeletionException AWS API Documentation
+    #
+    class SourceBundleDeletionException < Aws::EmptyStructure; end
 
     # A specification for an environment configuration
     #
@@ -4258,6 +4338,55 @@ module Aws::ElasticBeanstalk
       :force_terminate)
       include Aws::Structure
     end
+
+    # The specified account has reached its limit of application versions.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyApplicationVersionsException AWS API Documentation
+    #
+    class TooManyApplicationVersionsException < Aws::EmptyStructure; end
+
+    # The specified account has reached its limit of applications.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyApplicationsException AWS API Documentation
+    #
+    class TooManyApplicationsException < Aws::EmptyStructure; end
+
+    # The specified account has reached its limit of Amazon S3 buckets.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyBucketsException AWS API Documentation
+    #
+    class TooManyBucketsException < Aws::EmptyStructure; end
+
+    # The specified account has reached its limit of configuration
+    # templates.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyConfigurationTemplatesException AWS API Documentation
+    #
+    class TooManyConfigurationTemplatesException < Aws::EmptyStructure; end
+
+    # The specified account has reached its limit of environments.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyEnvironmentsException AWS API Documentation
+    #
+    class TooManyEnvironmentsException < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of allowed platforms associated
+    # with the account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyPlatformsException AWS API Documentation
+    #
+    class TooManyPlatformsException < Aws::EmptyStructure; end
+
+    # The number of tags in the resource would exceed the number of tags
+    # that each resource can have.
+    #
+    # To calculate this, the operation considers both the number of tags the
+    # resource already has and the tags this operation would add if it
+    # succeeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
 
     # Describes a trigger.
     #

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
@@ -199,6 +199,8 @@ module Aws::ElasticLoadBalancing
     AccessLog.add_member(:s3_bucket_prefix, Shapes::ShapeRef.new(shape: AccessLogPrefix, location_name: "S3BucketPrefix"))
     AccessLog.struct_class = Types::AccessLog
 
+    AccessPointNotFoundException.struct_class = Types::AccessPointNotFoundException
+
     AddAvailabilityZonesInput.add_member(:load_balancer_name, Shapes::ShapeRef.new(shape: AccessPointName, required: true, location_name: "LoadBalancerName"))
     AddAvailabilityZonesInput.add_member(:availability_zones, Shapes::ShapeRef.new(shape: AvailabilityZones, required: true, location_name: "AvailabilityZones"))
     AddAvailabilityZonesInput.struct_class = Types::AddAvailabilityZonesInput
@@ -245,6 +247,8 @@ module Aws::ElasticLoadBalancing
     BackendServerDescription.struct_class = Types::BackendServerDescription
 
     BackendServerDescriptions.member = Shapes::ShapeRef.new(shape: BackendServerDescription)
+
+    CertificateNotFoundException.struct_class = Types::CertificateNotFoundException
 
     ConfigureHealthCheckInput.add_member(:load_balancer_name, Shapes::ShapeRef.new(shape: AccessPointName, required: true, location_name: "LoadBalancerName"))
     ConfigureHealthCheckInput.add_member(:health_check, Shapes::ShapeRef.new(shape: HealthCheck, required: true, location_name: "HealthCheck"))
@@ -320,6 +324,8 @@ module Aws::ElasticLoadBalancing
 
     DeleteLoadBalancerPolicyOutput.struct_class = Types::DeleteLoadBalancerPolicyOutput
 
+    DependencyThrottleException.struct_class = Types::DependencyThrottleException
+
     DeregisterEndPointsInput.add_member(:load_balancer_name, Shapes::ShapeRef.new(shape: AccessPointName, required: true, location_name: "LoadBalancerName"))
     DeregisterEndPointsInput.add_member(:instances, Shapes::ShapeRef.new(shape: Instances, required: true, location_name: "Instances"))
     DeregisterEndPointsInput.struct_class = Types::DeregisterEndPointsInput
@@ -383,6 +389,14 @@ module Aws::ElasticLoadBalancing
     DetachLoadBalancerFromSubnetsOutput.add_member(:subnets, Shapes::ShapeRef.new(shape: Subnets, location_name: "Subnets"))
     DetachLoadBalancerFromSubnetsOutput.struct_class = Types::DetachLoadBalancerFromSubnetsOutput
 
+    DuplicateAccessPointNameException.struct_class = Types::DuplicateAccessPointNameException
+
+    DuplicateListenerException.struct_class = Types::DuplicateListenerException
+
+    DuplicatePolicyNameException.struct_class = Types::DuplicatePolicyNameException
+
+    DuplicateTagKeysException.struct_class = Types::DuplicateTagKeysException
+
     HealthCheck.add_member(:target, Shapes::ShapeRef.new(shape: HealthCheckTarget, required: true, location_name: "Target"))
     HealthCheck.add_member(:interval, Shapes::ShapeRef.new(shape: HealthCheckInterval, required: true, location_name: "Interval"))
     HealthCheck.add_member(:timeout, Shapes::ShapeRef.new(shape: HealthCheckTimeout, required: true, location_name: "Timeout"))
@@ -402,6 +416,16 @@ module Aws::ElasticLoadBalancing
     InstanceStates.member = Shapes::ShapeRef.new(shape: InstanceState)
 
     Instances.member = Shapes::ShapeRef.new(shape: Instance)
+
+    InvalidConfigurationRequestException.struct_class = Types::InvalidConfigurationRequestException
+
+    InvalidEndPointException.struct_class = Types::InvalidEndPointException
+
+    InvalidSchemeException.struct_class = Types::InvalidSchemeException
+
+    InvalidSecurityGroupException.struct_class = Types::InvalidSecurityGroupException
+
+    InvalidSubnetException.struct_class = Types::InvalidSubnetException
 
     LBCookieStickinessPolicies.member = Shapes::ShapeRef.new(shape: LBCookieStickinessPolicy)
 
@@ -428,7 +452,11 @@ module Aws::ElasticLoadBalancing
 
     ListenerDescriptions.member = Shapes::ShapeRef.new(shape: ListenerDescription)
 
+    ListenerNotFoundException.struct_class = Types::ListenerNotFoundException
+
     Listeners.member = Shapes::ShapeRef.new(shape: Listener)
+
+    LoadBalancerAttributeNotFoundException.struct_class = Types::LoadBalancerAttributeNotFoundException
 
     LoadBalancerAttributes.add_member(:cross_zone_load_balancing, Shapes::ShapeRef.new(shape: CrossZoneLoadBalancing, location_name: "CrossZoneLoadBalancing"))
     LoadBalancerAttributes.add_member(:access_log, Shapes::ShapeRef.new(shape: AccessLog, location_name: "AccessLog"))
@@ -469,6 +497,8 @@ module Aws::ElasticLoadBalancing
     ModifyLoadBalancerAttributesOutput.add_member(:load_balancer_attributes, Shapes::ShapeRef.new(shape: LoadBalancerAttributes, location_name: "LoadBalancerAttributes"))
     ModifyLoadBalancerAttributesOutput.struct_class = Types::ModifyLoadBalancerAttributesOutput
 
+    OperationNotPermittedException.struct_class = Types::OperationNotPermittedException
+
     Policies.add_member(:app_cookie_stickiness_policies, Shapes::ShapeRef.new(shape: AppCookieStickinessPolicies, location_name: "AppCookieStickinessPolicies"))
     Policies.add_member(:lb_cookie_stickiness_policies, Shapes::ShapeRef.new(shape: LBCookieStickinessPolicies, location_name: "LBCookieStickinessPolicies"))
     Policies.add_member(:other_policies, Shapes::ShapeRef.new(shape: PolicyNames, location_name: "OtherPolicies"))
@@ -504,6 +534,8 @@ module Aws::ElasticLoadBalancing
 
     PolicyNames.member = Shapes::ShapeRef.new(shape: PolicyName)
 
+    PolicyNotFoundException.struct_class = Types::PolicyNotFoundException
+
     PolicyTypeDescription.add_member(:policy_type_name, Shapes::ShapeRef.new(shape: PolicyTypeName, location_name: "PolicyTypeName"))
     PolicyTypeDescription.add_member(:description, Shapes::ShapeRef.new(shape: Description, location_name: "Description"))
     PolicyTypeDescription.add_member(:policy_attribute_type_descriptions, Shapes::ShapeRef.new(shape: PolicyAttributeTypeDescriptions, location_name: "PolicyAttributeTypeDescriptions"))
@@ -512,6 +544,8 @@ module Aws::ElasticLoadBalancing
     PolicyTypeDescriptions.member = Shapes::ShapeRef.new(shape: PolicyTypeDescription)
 
     PolicyTypeNames.member = Shapes::ShapeRef.new(shape: PolicyTypeName)
+
+    PolicyTypeNotFoundException.struct_class = Types::PolicyTypeNotFoundException
 
     Ports.member = Shapes::ShapeRef.new(shape: AccessPointPort)
 
@@ -562,6 +596,8 @@ module Aws::ElasticLoadBalancing
     SourceSecurityGroup.add_member(:group_name, Shapes::ShapeRef.new(shape: SecurityGroupName, location_name: "GroupName"))
     SourceSecurityGroup.struct_class = Types::SourceSecurityGroup
 
+    SubnetNotFoundException.struct_class = Types::SubnetNotFoundException
+
     Subnets.member = Shapes::ShapeRef.new(shape: SubnetId)
 
     Tag.add_member(:key, Shapes::ShapeRef.new(shape: TagKey, required: true, location_name: "Key"))
@@ -580,6 +616,14 @@ module Aws::ElasticLoadBalancing
     TagKeyOnly.struct_class = Types::TagKeyOnly
 
     TagList.member = Shapes::ShapeRef.new(shape: Tag)
+
+    TooManyAccessPointsException.struct_class = Types::TooManyAccessPointsException
+
+    TooManyPoliciesException.struct_class = Types::TooManyPoliciesException
+
+    TooManyTagsException.struct_class = Types::TooManyTagsException
+
+    UnsupportedProtocolException.struct_class = Types::UnsupportedProtocolException
 
 
     # @api private

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
@@ -10,5 +10,247 @@ module Aws::ElasticLoadBalancing
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessPointNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::AccessPointNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CertificateNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::CertificateNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DependencyThrottleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::DependencyThrottleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateAccessPointNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::DuplicateAccessPointNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateListenerException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::DuplicateListenerException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicatePolicyNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::DuplicatePolicyNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateTagKeysException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::DuplicateTagKeysException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConfigurationRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::InvalidConfigurationRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEndPointException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::InvalidEndPointException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSchemeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::InvalidSchemeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSecurityGroupException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::InvalidSecurityGroupException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::InvalidSubnetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ListenerNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::ListenerNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LoadBalancerAttributeNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::LoadBalancerAttributeNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotPermittedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::OperationNotPermittedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PolicyNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::PolicyNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PolicyTypeNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::PolicyTypeNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::SubnetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyAccessPointsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::TooManyAccessPointsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyPoliciesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::TooManyPoliciesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedProtocolException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancing::Types::UnsupportedProtocolException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
@@ -51,6 +51,12 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # The specified load balancer does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/AccessPointNotFoundException AWS API Documentation
+    #
+    class AccessPointNotFoundException < Aws::EmptyStructure; end
+
     # Contains the parameters for EnableAvailabilityZonesForLoadBalancer.
     #
     # @note When making an API call, you may pass AddAvailabilityZonesInput
@@ -272,6 +278,15 @@ module Aws::ElasticLoadBalancing
       :policy_names)
       include Aws::Structure
     end
+
+    # The specified ARN does not refer to a valid SSL certificate in AWS
+    # Identity and Access Management (IAM) or AWS Certificate Manager (ACM).
+    # Note that if you recently uploaded the certificate to IAM, this error
+    # might indicate that the certificate is not fully available yet.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/CertificateNotFoundException AWS API Documentation
+    #
+    class CertificateNotFoundException < Aws::EmptyStructure; end
 
     # Contains the parameters for ConfigureHealthCheck.
     #
@@ -775,6 +790,13 @@ module Aws::ElasticLoadBalancing
     #
     class DeleteLoadBalancerPolicyOutput < Aws::EmptyStructure; end
 
+    # A request made by Elastic Load Balancing to another service exceeds
+    # the maximum request rate permitted for your account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DependencyThrottleException AWS API Documentation
+    #
+    class DependencyThrottleException < Aws::EmptyStructure; end
+
     # Contains the parameters for DeregisterInstancesFromLoadBalancer.
     #
     # @note When making an API call, you may pass DeregisterEndPointsInput
@@ -1134,6 +1156,33 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # The specified load balancer name already exists for this account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DuplicateAccessPointNameException AWS API Documentation
+    #
+    class DuplicateAccessPointNameException < Aws::EmptyStructure; end
+
+    # A listener already exists for the specified load balancer name and
+    # port, but with a different instance port, protocol, or SSL
+    # certificate.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DuplicateListenerException AWS API Documentation
+    #
+    class DuplicateListenerException < Aws::EmptyStructure; end
+
+    # A policy with the specified name already exists for this load
+    # balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DuplicatePolicyNameException AWS API Documentation
+    #
+    class DuplicatePolicyNameException < Aws::EmptyStructure; end
+
+    # A tag key was specified more than once.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DuplicateTagKeysException AWS API Documentation
+    #
+    class DuplicateTagKeysException < Aws::EmptyStructure; end
+
     # Information about a health check.
     #
     # @note When making an API call, you may pass HealthCheck
@@ -1284,6 +1333,37 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # The requested configuration change is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/InvalidConfigurationRequestException AWS API Documentation
+    #
+    class InvalidConfigurationRequestException < Aws::EmptyStructure; end
+
+    # The specified endpoint is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/InvalidEndPointException AWS API Documentation
+    #
+    class InvalidEndPointException < Aws::EmptyStructure; end
+
+    # The specified value for the schema is not valid. You can only specify
+    # a scheme for load balancers in a VPC.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/InvalidSchemeException AWS API Documentation
+    #
+    class InvalidSchemeException < Aws::EmptyStructure; end
+
+    # One or more of the specified security groups do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/InvalidSecurityGroupException AWS API Documentation
+    #
+    class InvalidSecurityGroupException < Aws::EmptyStructure; end
+
+    # The specified VPC has no associated Internet gateway.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/InvalidSubnetException AWS API Documentation
+    #
+    class InvalidSubnetException < Aws::EmptyStructure; end
+
     # Information about a policy for duration-based session stickiness.
     #
     # @!attribute [rw] policy_name
@@ -1415,6 +1495,19 @@ module Aws::ElasticLoadBalancing
       :policy_names)
       include Aws::Structure
     end
+
+    # The load balancer does not have a listener configured at the specified
+    # port.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/ListenerNotFoundException AWS API Documentation
+    #
+    class ListenerNotFoundException < Aws::EmptyStructure; end
+
+    # The specified load balancer attribute does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/LoadBalancerAttributeNotFoundException AWS API Documentation
+    #
+    class LoadBalancerAttributeNotFoundException < Aws::EmptyStructure; end
 
     # The attributes for a load balancer.
     #
@@ -1685,6 +1778,12 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # This operation is not allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/OperationNotPermittedException AWS API Documentation
+    #
+    class OperationNotPermittedException < Aws::EmptyStructure; end
+
     # The policies for a load balancer.
     #
     # @!attribute [rw] app_cookie_stickiness_policies
@@ -1820,6 +1919,12 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # One or more of the specified policies do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/PolicyNotFoundException AWS API Documentation
+    #
+    class PolicyNotFoundException < Aws::EmptyStructure; end
+
     # Information about a policy type.
     #
     # @!attribute [rw] policy_type_name
@@ -1843,6 +1948,12 @@ module Aws::ElasticLoadBalancing
       :policy_attribute_type_descriptions)
       include Aws::Structure
     end
+
+    # One or more of the specified policy types do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/PolicyTypeNotFoundException AWS API Documentation
+    #
+    class PolicyTypeNotFoundException < Aws::EmptyStructure; end
 
     # Contains the parameters for RegisterInstancesWithLoadBalancer.
     #
@@ -2098,6 +2209,12 @@ module Aws::ElasticLoadBalancing
       include Aws::Structure
     end
 
+    # One or more of the specified subnets do not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/SubnetNotFoundException AWS API Documentation
+    #
+    class SubnetNotFoundException < Aws::EmptyStructure; end
+
     # Information about a tag.
     #
     # @note When making an API call, you may pass Tag
@@ -2161,6 +2278,32 @@ module Aws::ElasticLoadBalancing
       :key)
       include Aws::Structure
     end
+
+    # The quota for the number of load balancers has been reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/TooManyAccessPointsException AWS API Documentation
+    #
+    class TooManyAccessPointsException < Aws::EmptyStructure; end
+
+    # The quota for the number of policies for this load balancer has been
+    # reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/TooManyPoliciesException AWS API Documentation
+    #
+    class TooManyPoliciesException < Aws::EmptyStructure; end
+
+    # The quota for the number of tags that can be assigned to a load
+    # balancer has been reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
+
+    # The specified protocol or signature version is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/UnsupportedProtocolException AWS API Documentation
+    #
+    class UnsupportedProtocolException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
@@ -309,6 +309,8 @@ module Aws::ElasticLoadBalancingV2
 
     AddTagsOutput.struct_class = Types::AddTagsOutput
 
+    AllocationIdNotFoundException.struct_class = Types::AllocationIdNotFoundException
+
     AuthenticateCognitoActionAuthenticationRequestExtraParams.key = Shapes::ShapeRef.new(shape: AuthenticateCognitoActionAuthenticationRequestParamName)
     AuthenticateCognitoActionAuthenticationRequestExtraParams.value = Shapes::ShapeRef.new(shape: AuthenticateCognitoActionAuthenticationRequestParamValue)
 
@@ -344,6 +346,8 @@ module Aws::ElasticLoadBalancingV2
     AvailabilityZone.add_member(:load_balancer_addresses, Shapes::ShapeRef.new(shape: LoadBalancerAddresses, location_name: "LoadBalancerAddresses"))
     AvailabilityZone.struct_class = Types::AvailabilityZone
 
+    AvailabilityZoneNotSupportedException.struct_class = Types::AvailabilityZoneNotSupportedException
+
     AvailabilityZones.member = Shapes::ShapeRef.new(shape: AvailabilityZone)
 
     Certificate.add_member(:certificate_arn, Shapes::ShapeRef.new(shape: CertificateArn, location_name: "CertificateArn"))
@@ -351,6 +355,8 @@ module Aws::ElasticLoadBalancingV2
     Certificate.struct_class = Types::Certificate
 
     CertificateList.member = Shapes::ShapeRef.new(shape: Certificate)
+
+    CertificateNotFoundException.struct_class = Types::CertificateNotFoundException
 
     Cipher.add_member(:name, Shapes::ShapeRef.new(shape: CipherName, location_name: "Name"))
     Cipher.add_member(:priority, Shapes::ShapeRef.new(shape: CipherPriority, location_name: "Priority"))
@@ -528,6 +534,14 @@ module Aws::ElasticLoadBalancingV2
     DescribeTargetHealthOutput.add_member(:target_health_descriptions, Shapes::ShapeRef.new(shape: TargetHealthDescriptions, location_name: "TargetHealthDescriptions"))
     DescribeTargetHealthOutput.struct_class = Types::DescribeTargetHealthOutput
 
+    DuplicateListenerException.struct_class = Types::DuplicateListenerException
+
+    DuplicateLoadBalancerNameException.struct_class = Types::DuplicateLoadBalancerNameException
+
+    DuplicateTagKeysException.struct_class = Types::DuplicateTagKeysException
+
+    DuplicateTargetGroupNameException.struct_class = Types::DuplicateTargetGroupNameException
+
     FixedResponseActionConfig.add_member(:message_body, Shapes::ShapeRef.new(shape: FixedResponseActionMessage, location_name: "MessageBody"))
     FixedResponseActionConfig.add_member(:status_code, Shapes::ShapeRef.new(shape: FixedResponseActionStatusCode, required: true, location_name: "StatusCode"))
     FixedResponseActionConfig.add_member(:content_type, Shapes::ShapeRef.new(shape: FixedResponseActionContentType, location_name: "ContentType"))
@@ -536,6 +550,8 @@ module Aws::ElasticLoadBalancingV2
     ForwardActionConfig.add_member(:target_groups, Shapes::ShapeRef.new(shape: TargetGroupList, location_name: "TargetGroups"))
     ForwardActionConfig.add_member(:target_group_stickiness_config, Shapes::ShapeRef.new(shape: TargetGroupStickinessConfig, location_name: "TargetGroupStickinessConfig"))
     ForwardActionConfig.struct_class = Types::ForwardActionConfig
+
+    HealthUnavailableException.struct_class = Types::HealthUnavailableException
 
     HostHeaderConditionConfig.add_member(:values, Shapes::ShapeRef.new(shape: ListOfString, location_name: "Values"))
     HostHeaderConditionConfig.struct_class = Types::HostHeaderConditionConfig
@@ -546,6 +562,20 @@ module Aws::ElasticLoadBalancingV2
 
     HttpRequestMethodConditionConfig.add_member(:values, Shapes::ShapeRef.new(shape: ListOfString, location_name: "Values"))
     HttpRequestMethodConditionConfig.struct_class = Types::HttpRequestMethodConditionConfig
+
+    IncompatibleProtocolsException.struct_class = Types::IncompatibleProtocolsException
+
+    InvalidConfigurationRequestException.struct_class = Types::InvalidConfigurationRequestException
+
+    InvalidLoadBalancerActionException.struct_class = Types::InvalidLoadBalancerActionException
+
+    InvalidSchemeException.struct_class = Types::InvalidSchemeException
+
+    InvalidSecurityGroupException.struct_class = Types::InvalidSecurityGroupException
+
+    InvalidSubnetException.struct_class = Types::InvalidSubnetException
+
+    InvalidTargetException.struct_class = Types::InvalidTargetException
 
     Limit.add_member(:name, Shapes::ShapeRef.new(shape: Name, location_name: "Name"))
     Limit.add_member(:max, Shapes::ShapeRef.new(shape: Max, location_name: "Max"))
@@ -565,6 +595,8 @@ module Aws::ElasticLoadBalancingV2
     Listener.struct_class = Types::Listener
 
     ListenerArns.member = Shapes::ShapeRef.new(shape: ListenerArn)
+
+    ListenerNotFoundException.struct_class = Types::ListenerNotFoundException
 
     Listeners.member = Shapes::ShapeRef.new(shape: Listener)
 
@@ -598,6 +630,8 @@ module Aws::ElasticLoadBalancingV2
     LoadBalancerAttributes.member = Shapes::ShapeRef.new(shape: LoadBalancerAttribute)
 
     LoadBalancerNames.member = Shapes::ShapeRef.new(shape: LoadBalancerName)
+
+    LoadBalancerNotFoundException.struct_class = Types::LoadBalancerNotFoundException
 
     LoadBalancerState.add_member(:code, Shapes::ShapeRef.new(shape: LoadBalancerStateEnum, location_name: "Code"))
     LoadBalancerState.add_member(:reason, Shapes::ShapeRef.new(shape: StateReason, location_name: "Reason"))
@@ -656,8 +690,12 @@ module Aws::ElasticLoadBalancingV2
     ModifyTargetGroupOutput.add_member(:target_groups, Shapes::ShapeRef.new(shape: TargetGroups, location_name: "TargetGroups"))
     ModifyTargetGroupOutput.struct_class = Types::ModifyTargetGroupOutput
 
+    OperationNotPermittedException.struct_class = Types::OperationNotPermittedException
+
     PathPatternConditionConfig.add_member(:values, Shapes::ShapeRef.new(shape: ListOfString, location_name: "Values"))
     PathPatternConditionConfig.struct_class = Types::PathPatternConditionConfig
+
+    PriorityInUseException.struct_class = Types::PriorityInUseException
 
     QueryStringConditionConfig.add_member(:values, Shapes::ShapeRef.new(shape: QueryStringKeyValuePairList, location_name: "Values"))
     QueryStringConditionConfig.struct_class = Types::QueryStringConditionConfig
@@ -696,6 +734,8 @@ module Aws::ElasticLoadBalancingV2
 
     ResourceArns.member = Shapes::ShapeRef.new(shape: ResourceArn)
 
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
     Rule.add_member(:rule_arn, Shapes::ShapeRef.new(shape: RuleArn, location_name: "RuleArn"))
     Rule.add_member(:priority, Shapes::ShapeRef.new(shape: String, location_name: "Priority"))
     Rule.add_member(:conditions, Shapes::ShapeRef.new(shape: RuleConditionList, location_name: "Conditions"))
@@ -717,6 +757,8 @@ module Aws::ElasticLoadBalancingV2
 
     RuleConditionList.member = Shapes::ShapeRef.new(shape: RuleCondition)
 
+    RuleNotFoundException.struct_class = Types::RuleNotFoundException
+
     RulePriorityList.member = Shapes::ShapeRef.new(shape: RulePriorityPair)
 
     RulePriorityPair.add_member(:rule_arn, Shapes::ShapeRef.new(shape: RuleArn, location_name: "RuleArn"))
@@ -724,6 +766,8 @@ module Aws::ElasticLoadBalancingV2
     RulePriorityPair.struct_class = Types::RulePriorityPair
 
     Rules.member = Shapes::ShapeRef.new(shape: Rule)
+
+    SSLPolicyNotFoundException.struct_class = Types::SSLPolicyNotFoundException
 
     SecurityGroups.member = Shapes::ShapeRef.new(shape: SecurityGroupId)
 
@@ -776,6 +820,8 @@ module Aws::ElasticLoadBalancingV2
 
     SubnetMappings.member = Shapes::ShapeRef.new(shape: SubnetMapping)
 
+    SubnetNotFoundException.struct_class = Types::SubnetNotFoundException
+
     Subnets.member = Shapes::ShapeRef.new(shape: SubnetId)
 
     Tag.add_member(:key, Shapes::ShapeRef.new(shape: TagKey, required: true, location_name: "Key"))
@@ -819,6 +865,8 @@ module Aws::ElasticLoadBalancingV2
 
     TargetGroupArns.member = Shapes::ShapeRef.new(shape: TargetGroupArn)
 
+    TargetGroupAssociationLimitException.struct_class = Types::TargetGroupAssociationLimitException
+
     TargetGroupAttribute.add_member(:key, Shapes::ShapeRef.new(shape: TargetGroupAttributeKey, location_name: "Key"))
     TargetGroupAttribute.add_member(:value, Shapes::ShapeRef.new(shape: TargetGroupAttributeValue, location_name: "Value"))
     TargetGroupAttribute.struct_class = Types::TargetGroupAttribute
@@ -828,6 +876,8 @@ module Aws::ElasticLoadBalancingV2
     TargetGroupList.member = Shapes::ShapeRef.new(shape: TargetGroupTuple)
 
     TargetGroupNames.member = Shapes::ShapeRef.new(shape: TargetGroupName)
+
+    TargetGroupNotFoundException.struct_class = Types::TargetGroupNotFoundException
 
     TargetGroupStickinessConfig.add_member(:enabled, Shapes::ShapeRef.new(shape: TargetGroupStickinessEnabled, location_name: "Enabled"))
     TargetGroupStickinessConfig.add_member(:duration_seconds, Shapes::ShapeRef.new(shape: TargetGroupStickinessDurationSeconds, location_name: "DurationSeconds"))
@@ -850,6 +900,28 @@ module Aws::ElasticLoadBalancingV2
     TargetHealthDescription.struct_class = Types::TargetHealthDescription
 
     TargetHealthDescriptions.member = Shapes::ShapeRef.new(shape: TargetHealthDescription)
+
+    TooManyActionsException.struct_class = Types::TooManyActionsException
+
+    TooManyCertificatesException.struct_class = Types::TooManyCertificatesException
+
+    TooManyListenersException.struct_class = Types::TooManyListenersException
+
+    TooManyLoadBalancersException.struct_class = Types::TooManyLoadBalancersException
+
+    TooManyRegistrationsForTargetIdException.struct_class = Types::TooManyRegistrationsForTargetIdException
+
+    TooManyRulesException.struct_class = Types::TooManyRulesException
+
+    TooManyTagsException.struct_class = Types::TooManyTagsException
+
+    TooManyTargetGroupsException.struct_class = Types::TooManyTargetGroupsException
+
+    TooManyTargetsException.struct_class = Types::TooManyTargetsException
+
+    TooManyUniqueTargetGroupsPerLoadBalancerException.struct_class = Types::TooManyUniqueTargetGroupsPerLoadBalancerException
+
+    UnsupportedProtocolException.struct_class = Types::UnsupportedProtocolException
 
 
     # @api private

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
@@ -10,5 +10,401 @@ module Aws::ElasticLoadBalancingV2
 
     extend Aws::Errors::DynamicErrors
 
+    class AllocationIdNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::AllocationIdNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AvailabilityZoneNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::AvailabilityZoneNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CertificateNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::CertificateNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateListenerException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::DuplicateListenerException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateLoadBalancerNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::DuplicateLoadBalancerNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateTagKeysException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::DuplicateTagKeysException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DuplicateTargetGroupNameException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::DuplicateTargetGroupNameException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HealthUnavailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::HealthUnavailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IncompatibleProtocolsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::IncompatibleProtocolsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidConfigurationRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidConfigurationRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidLoadBalancerActionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidLoadBalancerActionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSchemeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidSchemeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSecurityGroupException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidSecurityGroupException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidSubnetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTargetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::InvalidTargetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ListenerNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::ListenerNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LoadBalancerNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::LoadBalancerNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotPermittedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::OperationNotPermittedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PriorityInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::PriorityInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class RuleNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::RuleNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SSLPolicyNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::SSLPolicyNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::SubnetNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TargetGroupAssociationLimitException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TargetGroupAssociationLimitException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TargetGroupNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TargetGroupNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyActionsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyActionsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyCertificatesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyCertificatesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyListenersException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyListenersException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyLoadBalancersException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyLoadBalancersException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyRegistrationsForTargetIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyRegistrationsForTargetIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyRulesException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyRulesException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTagsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyTagsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTargetGroupsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyTargetGroupsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyTargetsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyTargetsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyUniqueTargetGroupsPerLoadBalancerException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::TooManyUniqueTargetGroupsPerLoadBalancerException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedProtocolException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticLoadBalancingV2::Types::UnsupportedProtocolException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
@@ -212,6 +212,12 @@ module Aws::ElasticLoadBalancingV2
     #
     class AddTagsOutput < Aws::EmptyStructure; end
 
+    # The specified allocation ID does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AllocationIdNotFoundException AWS API Documentation
+    #
+    class AllocationIdNotFoundException < Aws::EmptyStructure; end
+
     # Request parameters to use when integrating with Amazon Cognito to
     # authenticate users.
     #
@@ -433,6 +439,12 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # The specified Availability Zone is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AvailabilityZoneNotSupportedException AWS API Documentation
+    #
+    class AvailabilityZoneNotSupportedException < Aws::EmptyStructure; end
+
     # Information about an SSL server certificate.
     #
     # @note When making an API call, you may pass Certificate
@@ -461,6 +473,12 @@ module Aws::ElasticLoadBalancingV2
       :is_default)
       include Aws::Structure
     end
+
+    # The specified certificate does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/CertificateNotFoundException AWS API Documentation
+    #
+    class CertificateNotFoundException < Aws::EmptyStructure; end
 
     # Information about a cipher used in a policy.
     #
@@ -1697,6 +1715,30 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # A listener with the specified port already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DuplicateListenerException AWS API Documentation
+    #
+    class DuplicateListenerException < Aws::EmptyStructure; end
+
+    # A load balancer with the specified name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DuplicateLoadBalancerNameException AWS API Documentation
+    #
+    class DuplicateLoadBalancerNameException < Aws::EmptyStructure; end
+
+    # A tag key was specified more than once.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DuplicateTagKeysException AWS API Documentation
+    #
+    class DuplicateTagKeysException < Aws::EmptyStructure; end
+
+    # A target group with the specified name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DuplicateTargetGroupNameException AWS API Documentation
+    #
+    class DuplicateTargetGroupNameException < Aws::EmptyStructure; end
+
     # Information about an action that returns a custom HTTP response.
     #
     # @note When making an API call, you may pass FixedResponseActionConfig
@@ -1766,6 +1808,13 @@ module Aws::ElasticLoadBalancingV2
       :target_group_stickiness_config)
       include Aws::Structure
     end
+
+    # The health of the specified targets could not be retrieved due to an
+    # internal error.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/HealthUnavailableException AWS API Documentation
+    #
+    class HealthUnavailableException < Aws::EmptyStructure; end
 
     # Information about a host header condition.
     #
@@ -1874,6 +1923,49 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # The specified configuration is not valid with this protocol.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/IncompatibleProtocolsException AWS API Documentation
+    #
+    class IncompatibleProtocolsException < Aws::EmptyStructure; end
+
+    # The requested configuration is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidConfigurationRequestException AWS API Documentation
+    #
+    class InvalidConfigurationRequestException < Aws::EmptyStructure; end
+
+    # The requested action is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidLoadBalancerActionException AWS API Documentation
+    #
+    class InvalidLoadBalancerActionException < Aws::EmptyStructure; end
+
+    # The requested scheme is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidSchemeException AWS API Documentation
+    #
+    class InvalidSchemeException < Aws::EmptyStructure; end
+
+    # The specified security group does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidSecurityGroupException AWS API Documentation
+    #
+    class InvalidSecurityGroupException < Aws::EmptyStructure; end
+
+    # The specified subnet is out of available addresses.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidSubnetException AWS API Documentation
+    #
+    class InvalidSubnetException < Aws::EmptyStructure; end
+
+    # The specified target does not exist, is not in the same VPC as the
+    # target group, or has an unsupported instance type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/InvalidTargetException AWS API Documentation
+    #
+    class InvalidTargetException < Aws::EmptyStructure; end
+
     # Information about an Elastic Load Balancing resource limit for your
     # AWS account.
     #
@@ -1961,6 +2053,12 @@ module Aws::ElasticLoadBalancingV2
       :default_actions)
       include Aws::Structure
     end
+
+    # The specified listener does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/ListenerNotFoundException AWS API Documentation
+    #
+    class ListenerNotFoundException < Aws::EmptyStructure; end
 
     # Information about a load balancer.
     #
@@ -2136,6 +2234,12 @@ module Aws::ElasticLoadBalancingV2
       :value)
       include Aws::Structure
     end
+
+    # The specified load balancer does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/LoadBalancerNotFoundException AWS API Documentation
+    #
+    class LoadBalancerNotFoundException < Aws::EmptyStructure; end
 
     # Information about the state of the load balancer.
     #
@@ -2683,6 +2787,12 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # This operation is not allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/OperationNotPermittedException AWS API Documentation
+    #
+    class OperationNotPermittedException < Aws::EmptyStructure; end
+
     # Information about a path pattern condition.
     #
     # @note When making an API call, you may pass PathPatternConditionConfig
@@ -2710,6 +2820,12 @@ module Aws::ElasticLoadBalancingV2
       :values)
       include Aws::Structure
     end
+
+    # The specified priority is in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/PriorityInUseException AWS API Documentation
+    #
+    class PriorityInUseException < Aws::EmptyStructure; end
 
     # Information about a query string condition.
     #
@@ -2958,6 +3074,12 @@ module Aws::ElasticLoadBalancingV2
     #
     class RemoveTagsOutput < Aws::EmptyStructure; end
 
+    # A specified resource is in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/ResourceInUseException AWS API Documentation
+    #
+    class ResourceInUseException < Aws::EmptyStructure; end
+
     # Information about a rule.
     #
     # @!attribute [rw] rule_arn
@@ -3126,6 +3248,12 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # The specified rule does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/RuleNotFoundException AWS API Documentation
+    #
+    class RuleNotFoundException < Aws::EmptyStructure; end
+
     # Information about the priorities for the rules for a listener.
     #
     # @note When making an API call, you may pass RulePriorityPair
@@ -3151,6 +3279,12 @@ module Aws::ElasticLoadBalancingV2
       :priority)
       include Aws::Structure
     end
+
+    # The specified SSL policy does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/SSLPolicyNotFoundException AWS API Documentation
+    #
+    class SSLPolicyNotFoundException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass SetIpAddressTypeInput
     #   data as a hash:
@@ -3410,6 +3544,12 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # The specified subnet does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/SubnetNotFoundException AWS API Documentation
+    #
+    class SubnetNotFoundException < Aws::EmptyStructure; end
+
     # Information about a tag.
     #
     # @note When making an API call, you may pass Tag
@@ -3606,6 +3746,13 @@ module Aws::ElasticLoadBalancingV2
       include Aws::Structure
     end
 
+    # You've reached the limit on the number of load balancers per target
+    # group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TargetGroupAssociationLimitException AWS API Documentation
+    #
+    class TargetGroupAssociationLimitException < Aws::EmptyStructure; end
+
     # Information about a target group attribute.
     #
     # @note When making an API call, you may pass TargetGroupAttribute
@@ -3691,6 +3838,12 @@ module Aws::ElasticLoadBalancingV2
       :value)
       include Aws::Structure
     end
+
+    # The specified target group does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TargetGroupNotFoundException AWS API Documentation
+    #
+    class TargetGroupNotFoundException < Aws::EmptyStructure; end
 
     # Information about the target group stickiness for a rule.
     #
@@ -3855,6 +4008,79 @@ module Aws::ElasticLoadBalancingV2
       :target_health)
       include Aws::Structure
     end
+
+    # You've reached the limit on the number of actions per rule.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyActionsException AWS API Documentation
+    #
+    class TooManyActionsException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of certificates per load
+    # balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyCertificatesException AWS API Documentation
+    #
+    class TooManyCertificatesException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of listeners per load
+    # balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyListenersException AWS API Documentation
+    #
+    class TooManyListenersException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of load balancers for your AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyLoadBalancersException AWS API Documentation
+    #
+    class TooManyLoadBalancersException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of times a target can be
+    # registered with a load balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyRegistrationsForTargetIdException AWS API Documentation
+    #
+    class TooManyRegistrationsForTargetIdException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of rules per load balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyRulesException AWS API Documentation
+    #
+    class TooManyRulesException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of tags per load balancer.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyTagsException AWS API Documentation
+    #
+    class TooManyTagsException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of target groups for your AWS
+    # account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyTargetGroupsException AWS API Documentation
+    #
+    class TooManyTargetGroupsException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of targets.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyTargetsException AWS API Documentation
+    #
+    class TooManyTargetsException < Aws::EmptyStructure; end
+
+    # You've reached the limit on the number of unique target groups per
+    # load balancer across all listeners. If a target group is used by
+    # multiple actions for a load balancer, it is counted as only one use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/TooManyUniqueTargetGroupsPerLoadBalancerException AWS API Documentation
+    #
+    class TooManyUniqueTargetGroupsPerLoadBalancerException < Aws::EmptyStructure; end
+
+    # The specified protocol is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/UnsupportedProtocolException AWS API Documentation
+    #
+    class UnsupportedProtocolException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
@@ -305,6 +305,8 @@ module Aws::ElasticsearchService
     DescribeReservedElasticsearchInstancesResponse.add_member(:reserved_elasticsearch_instances, Shapes::ShapeRef.new(shape: ReservedElasticsearchInstanceList, location_name: "ReservedElasticsearchInstances"))
     DescribeReservedElasticsearchInstancesResponse.struct_class = Types::DescribeReservedElasticsearchInstancesResponse
 
+    DisabledOperationException.struct_class = Types::DisabledOperationException
+
     DomainEndpointOptions.add_member(:enforce_https, Shapes::ShapeRef.new(shape: Boolean, location_name: "EnforceHTTPS"))
     DomainEndpointOptions.add_member(:tls_security_policy, Shapes::ShapeRef.new(shape: TLSSecurityPolicy, location_name: "TLSSecurityPolicy"))
     DomainEndpointOptions.struct_class = Types::DomainEndpointOptions
@@ -437,7 +439,13 @@ module Aws::ElasticsearchService
     InstanceLimits.add_member(:instance_count_limits, Shapes::ShapeRef.new(shape: InstanceCountLimits, location_name: "InstanceCountLimits"))
     InstanceLimits.struct_class = Types::InstanceLimits
 
+    InternalException.struct_class = Types::InternalException
+
+    InvalidTypeException.struct_class = Types::InvalidTypeException
+
     Issues.member = Shapes::ShapeRef.new(shape: Issue)
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     LimitValueList.member = Shapes::ShapeRef.new(shape: LimitValue)
 
@@ -554,6 +562,10 @@ module Aws::ElasticsearchService
 
     ReservedElasticsearchInstanceOfferingList.member = Shapes::ShapeRef.new(shape: ReservedElasticsearchInstanceOffering)
 
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ServiceSoftwareOptions.add_member(:current_version, Shapes::ShapeRef.new(shape: String, location_name: "CurrentVersion"))
     ServiceSoftwareOptions.add_member(:new_version, Shapes::ShapeRef.new(shape: String, location_name: "NewVersion"))
     ServiceSoftwareOptions.add_member(:update_available, Shapes::ShapeRef.new(shape: Boolean, location_name: "UpdateAvailable"))
@@ -652,6 +664,8 @@ module Aws::ElasticsearchService
     VPCOptions.add_member(:subnet_ids, Shapes::ShapeRef.new(shape: StringList, location_name: "SubnetIds"))
     VPCOptions.add_member(:security_group_ids, Shapes::ShapeRef.new(shape: StringList, location_name: "SecurityGroupIds"))
     VPCOptions.struct_class = Types::VPCOptions
+
+    ValidationException.struct_class = Types::ValidationException
 
     ZoneAwarenessConfig.add_member(:availability_zone_count, Shapes::ShapeRef.new(shape: IntegerClass, location_name: "AvailabilityZoneCount"))
     ZoneAwarenessConfig.struct_class = Types::ZoneAwarenessConfig

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
@@ -26,5 +26,82 @@ module Aws::ElasticsearchService
 
     end
 
+    class DisabledOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::DisabledOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::InternalException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTypeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::InvalidTypeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticsearchService::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
@@ -789,6 +789,11 @@ module Aws::ElasticsearchService
       include Aws::Structure
     end
 
+    # An error occured because the client wanted to access a not supported
+    # operation. Gives http status code of 409.
+    #
+    class DisabledOperationException < Aws::EmptyStructure; end
+
     # Options to configure endpoint for the Elasticsearch domain.
     #
     # @note When making an API call, you may pass DomainEndpointOptions
@@ -1493,6 +1498,22 @@ module Aws::ElasticsearchService
       include Aws::Structure
     end
 
+    # The request processing has failed because of an unknown error,
+    # exception or failure (the failure is internal to the service) . Gives
+    # http status code of 500.
+    #
+    class InternalException < Aws::EmptyStructure; end
+
+    # An exception for trying to create or access sub-resource that is
+    # either invalid or not supported. Gives http status code of 409.
+    #
+    class InvalidTypeException < Aws::EmptyStructure; end
+
+    # An exception for trying to create more than allowed resources or
+    # sub-resources. Gives http status code of 409.
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # Limits for given InstanceType and for each of it's role.
     #  Limits contains following ` StorageTypes, ` ` InstanceLimits ` and `
     # AdditionalLimits `
@@ -2049,6 +2070,16 @@ module Aws::ElasticsearchService
       :recurring_charges)
       include Aws::Structure
     end
+
+    # An exception for creating a resource that already exists. Gives http
+    # status code of 400.
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    # An exception for accessing or deleting a resource that does not exist.
+    # Gives http status code of 400.
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # The current options of an Elasticsearch domain service software
     # options.
@@ -2627,6 +2658,11 @@ module Aws::ElasticsearchService
       :security_group_ids)
       include Aws::Structure
     end
+
+    # An exception for missing / invalid input fields. Gives http status
+    # code of 400.
+    #
+    class ValidationException < Aws::EmptyStructure; end
 
     # Specifies the zone awareness configuration for the domain cluster,
     # such as the number of availability zones.

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
@@ -185,6 +185,8 @@ module Aws::ElasticTranscoder
 
     AccessControls.member = Shapes::ShapeRef.new(shape: AccessControl)
 
+    AccessDeniedException.struct_class = Types::AccessDeniedException
+
     Artwork.add_member(:input_key, Shapes::ShapeRef.new(shape: WatermarkKey, location_name: "InputKey"))
     Artwork.add_member(:max_width, Shapes::ShapeRef.new(shape: DigitsOrAuto, location_name: "MaxWidth"))
     Artwork.add_member(:max_height, Shapes::ShapeRef.new(shape: DigitsOrAuto, location_name: "MaxHeight"))
@@ -340,9 +342,13 @@ module Aws::ElasticTranscoder
     HlsContentProtection.add_member(:key_storage_policy, Shapes::ShapeRef.new(shape: KeyStoragePolicy, location_name: "KeyStoragePolicy"))
     HlsContentProtection.struct_class = Types::HlsContentProtection
 
+    IncompatibleVersionException.struct_class = Types::IncompatibleVersionException
+
     InputCaptions.add_member(:merge_policy, Shapes::ShapeRef.new(shape: CaptionMergePolicy, location_name: "MergePolicy"))
     InputCaptions.add_member(:caption_sources, Shapes::ShapeRef.new(shape: CaptionSources, location_name: "CaptionSources"))
     InputCaptions.struct_class = Types::InputCaptions
+
+    InternalServiceException.struct_class = Types::InternalServiceException
 
     Job.add_member(:id, Shapes::ShapeRef.new(shape: Id, location_name: "Id"))
     Job.add_member(:arn, Shapes::ShapeRef.new(shape: String, location_name: "Arn"))
@@ -409,6 +415,8 @@ module Aws::ElasticTranscoder
     JobWatermarks.member = Shapes::ShapeRef.new(shape: JobWatermark)
 
     Jobs.member = Shapes::ShapeRef.new(shape: Job)
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListJobsByPipelineRequest.add_member(:pipeline_id, Shapes::ShapeRef.new(shape: Id, required: true, location: "uri", location_name: "PipelineId"))
     ListJobsByPipelineRequest.add_member(:ascending, Shapes::ShapeRef.new(shape: Ascending, location: "querystring", location_name: "Ascending"))
@@ -544,6 +552,10 @@ module Aws::ElasticTranscoder
     ReadPresetResponse.add_member(:preset, Shapes::ShapeRef.new(shape: Preset, location_name: "Preset"))
     ReadPresetResponse.struct_class = Types::ReadPresetResponse
 
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     SnsTopics.member = Shapes::ShapeRef.new(shape: SnsTopic)
 
     TestRoleRequest.add_member(:role, Shapes::ShapeRef.new(shape: Role, required: true, location_name: "Role"))
@@ -605,6 +617,8 @@ module Aws::ElasticTranscoder
 
     UserMetadata.key = Shapes::ShapeRef.new(shape: String)
     UserMetadata.value = Shapes::ShapeRef.new(shape: String)
+
+    ValidationException.struct_class = Types::ValidationException
 
     VideoParameters.add_member(:codec, Shapes::ShapeRef.new(shape: VideoCodec, location_name: "Codec"))
     VideoParameters.add_member(:codec_options, Shapes::ShapeRef.new(shape: CodecOptions, location_name: "CodecOptions"))

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
@@ -10,5 +10,82 @@ module Aws::ElasticTranscoder
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::AccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IncompatibleVersionException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::IncompatibleVersionException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalServiceException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::InternalServiceException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ValidationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ElasticTranscoder::Types::ValidationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
@@ -8,6 +8,10 @@
 module Aws::ElasticTranscoder
   module Types
 
+    # General authentication failure. The request was not signed correctly.
+    #
+    class AccessDeniedException < Aws::EmptyStructure; end
+
     # The file to be used as album art. There can be multiple artworks
     # associated with an audio file, to a maximum of 20.
     #
@@ -2145,6 +2149,8 @@ module Aws::ElasticTranscoder
       include Aws::Structure
     end
 
+    class IncompatibleVersionException < Aws::EmptyStructure; end
+
     # The captions to be created, if any.
     #
     # @note When making an API call, you may pass InputCaptions
@@ -2203,6 +2209,11 @@ module Aws::ElasticTranscoder
       :caption_sources)
       include Aws::Structure
     end
+
+    # Elastic Transcoder encountered an unexpected exception while trying to
+    # fulfill the request.
+    #
+    class InternalServiceException < Aws::EmptyStructure; end
 
     # A section of the response body that provides information about the job
     # that is created.
@@ -2907,6 +2918,11 @@ module Aws::ElasticTranscoder
       :encryption)
       include Aws::Structure
     end
+
+    # Too many operations for a given AWS account. For example, the number
+    # of pipelines exceeds the maximum allowed.
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # The `ListJobsByPipelineRequest` structure.
     #
@@ -4045,6 +4061,17 @@ module Aws::ElasticTranscoder
       include Aws::Structure
     end
 
+    # The resource you are attempting to change is in use. For example, you
+    # are attempting to delete a pipeline that is currently in use.
+    #
+    class ResourceInUseException < Aws::EmptyStructure; end
+
+    # The requested resource does not exist or is not available. For
+    # example, the pipeline to which you're trying to add a job doesn't
+    # exist or is still being created.
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # The `TestRoleRequest` structure.
     #
     # @note When making an API call, you may pass TestRoleRequest
@@ -4674,6 +4701,11 @@ module Aws::ElasticTranscoder
       :pipeline)
       include Aws::Structure
     end
+
+    # One or more required parameter values were not provided in the
+    # request.
+    #
+    class ValidationException < Aws::EmptyStructure; end
 
     # The `VideoParameters` structure.
     #

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
@@ -702,6 +702,8 @@ module Aws::EMR
 
     InstanceTypeSpecificationList.member = Shapes::ShapeRef.new(shape: InstanceTypeSpecification)
 
+    InternalServerError.struct_class = Types::InternalServerError
+
     InternalServerException.add_member(:message, Shapes::ShapeRef.new(shape: ErrorMessage, location_name: "Message"))
     InternalServerException.struct_class = Types::InternalServerException
 

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
@@ -10,6 +10,17 @@ module Aws::EMR
 
     extend Aws::Errors::DynamicErrors
 
+    class InternalServerError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EMR::Types::InternalServerError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InternalServerException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
@@ -2994,6 +2994,13 @@ module Aws::EMR
       include Aws::Structure
     end
 
+    # Indicates that an error occurred while processing the request and that
+    # the request was not completed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/elasticmapreduce-2009-03-31/InternalServerError AWS API Documentation
+    #
+    class InternalServerError < Aws::EmptyStructure; end
+
     # This exception occurs when there is an internal failure in the EMR
     # service.
     #

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client_api.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client_api.rb
@@ -185,6 +185,8 @@ module Aws::EventBridge
     BatchRetryStrategy.add_member(:attempts, Shapes::ShapeRef.new(shape: Integer, location_name: "Attempts"))
     BatchRetryStrategy.struct_class = Types::BatchRetryStrategy
 
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
+
     Condition.add_member(:type, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Type"))
     Condition.add_member(:key, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Key"))
     Condition.add_member(:value, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Value"))
@@ -300,8 +302,16 @@ module Aws::EventBridge
     InputTransformer.add_member(:input_template, Shapes::ShapeRef.new(shape: TransformerInput, required: true, location_name: "InputTemplate"))
     InputTransformer.struct_class = Types::InputTransformer
 
+    InternalException.struct_class = Types::InternalException
+
+    InvalidEventPatternException.struct_class = Types::InvalidEventPatternException
+
+    InvalidStateException.struct_class = Types::InvalidStateException
+
     KinesisParameters.add_member(:partition_key_path, Shapes::ShapeRef.new(shape: TargetPartitionKeyPath, required: true, location_name: "PartitionKeyPath"))
     KinesisParameters.struct_class = Types::KinesisParameters
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListEventBusesRequest.add_member(:name_prefix, Shapes::ShapeRef.new(shape: EventBusName, location_name: "NamePrefix"))
     ListEventBusesRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
@@ -375,6 +385,8 @@ module Aws::EventBridge
     ListTargetsByRuleResponse.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListTargetsByRuleResponse.struct_class = Types::ListTargetsByRuleResponse
 
+    ManagedRuleException.struct_class = Types::ManagedRuleException
+
     NetworkConfiguration.add_member(:awsvpc_configuration, Shapes::ShapeRef.new(shape: AwsVpcConfiguration, location_name: "awsvpcConfiguration"))
     NetworkConfiguration.struct_class = Types::NetworkConfiguration
 
@@ -391,6 +403,8 @@ module Aws::EventBridge
     PartnerEventSourceAccountList.member = Shapes::ShapeRef.new(shape: PartnerEventSourceAccount)
 
     PartnerEventSourceList.member = Shapes::ShapeRef.new(shape: PartnerEventSource)
+
+    PolicyLengthExceededException.struct_class = Types::PolicyLengthExceededException
 
     PutEventsRequest.add_member(:entries, Shapes::ShapeRef.new(shape: PutEventsRequestEntryList, required: true, location_name: "Entries"))
     PutEventsRequest.struct_class = Types::PutEventsRequest
@@ -495,6 +509,10 @@ module Aws::EventBridge
     RemoveTargetsResultEntry.struct_class = Types::RemoveTargetsResultEntry
 
     RemoveTargetsResultEntryList.member = Shapes::ShapeRef.new(shape: RemoveTargetsResultEntry)
+
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
 
     Rule.add_member(:name, Shapes::ShapeRef.new(shape: RuleName, location_name: "Name"))
     Rule.add_member(:arn, Shapes::ShapeRef.new(shape: RuleArn, location_name: "Arn"))

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/errors.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/errors.rb
@@ -10,5 +10,104 @@ module Aws::EventBridge
 
     extend Aws::Errors::DynamicErrors
 
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::InternalException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventPatternException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::InvalidEventPatternException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::InvalidStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ManagedRuleException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::ManagedRuleException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PolicyLengthExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::PolicyLengthExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::EventBridge::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/types.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/types.rb
@@ -164,6 +164,12 @@ module Aws::EventBridge
       include Aws::Structure
     end
 
+    # There is concurrent modification on a rule or target.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
+
     # A JSON string which you can use to limit the event bus permissions you
     # are granting to only accounts that fulfill the condition. Currently,
     # the only supported condition is membership in a certain AWS
@@ -907,6 +913,24 @@ module Aws::EventBridge
       include Aws::Structure
     end
 
+    # This exception occurs due to unexpected causes.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/InternalException AWS API Documentation
+    #
+    class InternalException < Aws::EmptyStructure; end
+
+    # The event pattern is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/InvalidEventPatternException AWS API Documentation
+    #
+    class InvalidEventPatternException < Aws::EmptyStructure; end
+
+    # The specified state is not a valid state for an event source.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/InvalidStateException AWS API Documentation
+    #
+    class InvalidStateException < Aws::EmptyStructure; end
+
     # This object enables you to specify a JSON path to extract from the
     # event and use as the partition key for the Amazon Kinesis data stream,
     # so that you can control the shard to which the event goes. If you do
@@ -936,6 +960,13 @@ module Aws::EventBridge
       :partition_key_path)
       include Aws::Structure
     end
+
+    # You tried to create more rules or add more targets to a rule than is
+    # allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListEventBusesRequest
     #   data as a hash:
@@ -1336,6 +1367,18 @@ module Aws::EventBridge
       include Aws::Structure
     end
 
+    # This rule was created by an AWS service on behalf of your account. It
+    # is managed by that service. If you see this error in response to
+    # `DeleteRule` or `RemoveTargets`, you can use the `Force` parameter in
+    # those calls to delete the rule or remove targets from the rule. You
+    # cannot modify these managed rules by using `DisableRule`,
+    # `EnableRule`, `PutTargets`, `PutRule`, `TagResource`, or
+    # `UntagResource`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ManagedRuleException AWS API Documentation
+    #
+    class ManagedRuleException < Aws::EmptyStructure; end
+
     # This structure specifies the network configuration for an ECS task.
     #
     # @note When making an API call, you may pass NetworkConfiguration
@@ -1417,6 +1460,13 @@ module Aws::EventBridge
       :state)
       include Aws::Structure
     end
+
+    # The event bus policy is too long. For more information, see the
+    # limits.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/PolicyLengthExceededException AWS API Documentation
+    #
+    class PolicyLengthExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PutEventsRequest
     #   data as a hash:
@@ -2053,6 +2103,18 @@ module Aws::EventBridge
       :error_message)
       include Aws::Structure
     end
+
+    # The resource you are trying to create already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ResourceAlreadyExistsException AWS API Documentation
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    # An entity that you specified does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
 
     # Contains information about a rule in Amazon EventBridge.
     #

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client_api.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client_api.rb
@@ -123,6 +123,8 @@ module Aws::ManagedBlockchain
     VoteValue = Shapes::StringShape.new(name: 'VoteValue')
     VotingPolicy = Shapes::StructureShape.new(name: 'VotingPolicy')
 
+    AccessDeniedException.struct_class = Types::AccessDeniedException
+
     ApprovalThresholdPolicy.add_member(:threshold_percentage, Shapes::ShapeRef.new(shape: ThresholdPercentageInt, location_name: "ThresholdPercentage"))
     ApprovalThresholdPolicy.add_member(:proposal_duration_in_hours, Shapes::ShapeRef.new(shape: ProposalDurationInt, location_name: "ProposalDurationInHours"))
     ApprovalThresholdPolicy.add_member(:threshold_comparator, Shapes::ShapeRef.new(shape: ThresholdComparator, location_name: "ThresholdComparator"))
@@ -213,6 +215,8 @@ module Aws::ManagedBlockchain
 
     IllegalActionException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     IllegalActionException.struct_class = Types::IllegalActionException
+
+    InternalServiceErrorException.struct_class = Types::InternalServiceErrorException
 
     InvalidRequestException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidRequestException.struct_class = Types::InvalidRequestException
@@ -448,6 +452,8 @@ module Aws::ManagedBlockchain
 
     ResourceNotReadyException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     ResourceNotReadyException.struct_class = Types::ResourceNotReadyException
+
+    ThrottlingException.struct_class = Types::ThrottlingException
 
     VoteOnProposalInput.add_member(:network_id, Shapes::ShapeRef.new(shape: ResourceIdString, required: true, location: "uri", location_name: "networkId"))
     VoteOnProposalInput.add_member(:proposal_id, Shapes::ShapeRef.new(shape: ResourceIdString, required: true, location: "uri", location_name: "proposalId"))

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/errors.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/errors.rb
@@ -10,6 +10,17 @@ module Aws::ManagedBlockchain
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ManagedBlockchain::Types::AccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class IllegalActionException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -22,6 +33,17 @@ module Aws::ManagedBlockchain
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InternalServiceErrorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ManagedBlockchain::Types::InternalServiceErrorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -102,6 +124,17 @@ module Aws::ManagedBlockchain
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class ThrottlingException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ManagedBlockchain::Types::ThrottlingException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/types.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/types.rb
@@ -8,6 +8,12 @@
 module Aws::ManagedBlockchain
   module Types
 
+    # You do not have sufficient access to perform this action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/managedblockchain-2018-09-24/AccessDeniedException AWS API Documentation
+    #
+    class AccessDeniedException < Aws::EmptyStructure; end
+
     # A policy type that defines the voting rules for the network. The rules
     # decide if a proposal is approved. Approval may be based on criteria
     # such as the percentage of `YES` votes and the duration of the
@@ -571,6 +577,13 @@ module Aws::ManagedBlockchain
       :message)
       include Aws::Structure
     end
+
+    # The request processing has failed because of an unknown error,
+    # exception or failure.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/managedblockchain-2018-09-24/InternalServiceErrorException AWS API Documentation
+    #
+    class InternalServiceErrorException < Aws::EmptyStructure; end
 
     # The action or operation requested is invalid. Verify that the action
     # is typed correctly.
@@ -1877,6 +1890,16 @@ module Aws::ManagedBlockchain
       :message)
       include Aws::Structure
     end
+
+    # The request or operation could not be performed because a service is
+    # throttling requests. The most common source of throttling errors is
+    # launching EC2 instances such that your service limit for EC2 instances
+    # is exceeded. Request a limit increase or delete unused resources if
+    # possible.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/managedblockchain-2018-09-24/ThrottlingException AWS API Documentation
+    #
+    class ThrottlingException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass VoteOnProposalInput
     #   data as a hash:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client_api.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client_api.rb
@@ -303,12 +303,16 @@ module Aws::Neptune
 
     AttributeValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "AttributeValue")
 
+    AuthorizationNotFoundFault.struct_class = Types::AuthorizationNotFoundFault
+
     AvailabilityZone.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     AvailabilityZone.struct_class = Types::AvailabilityZone
 
     AvailabilityZoneList.member = Shapes::ShapeRef.new(shape: AvailabilityZone, location_name: "AvailabilityZone")
 
     AvailabilityZones.member = Shapes::ShapeRef.new(shape: String, location_name: "AvailabilityZone")
+
+    CertificateNotFoundFault.struct_class = Types::CertificateNotFoundFault
 
     CharacterSet.add_member(:character_set_name, Shapes::ShapeRef.new(shape: String, location_name: "CharacterSetName"))
     CharacterSet.add_member(:character_set_description, Shapes::ShapeRef.new(shape: String, location_name: "CharacterSetDescription"))
@@ -510,6 +514,8 @@ module Aws::Neptune
     DBCluster.add_member(:deletion_protection, Shapes::ShapeRef.new(shape: BooleanOptional, location_name: "DeletionProtection"))
     DBCluster.struct_class = Types::DBCluster
 
+    DBClusterAlreadyExistsFault.struct_class = Types::DBClusterAlreadyExistsFault
+
     DBClusterList.member = Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster")
 
     DBClusterMember.add_member(:db_instance_identifier, Shapes::ShapeRef.new(shape: String, location_name: "DBInstanceIdentifier"))
@@ -523,6 +529,8 @@ module Aws::Neptune
     DBClusterMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterMessage.add_member(:db_clusters, Shapes::ShapeRef.new(shape: DBClusterList, location_name: "DBClusters"))
     DBClusterMessage.struct_class = Types::DBClusterMessage
+
+    DBClusterNotFoundFault.struct_class = Types::DBClusterNotFoundFault
 
     DBClusterOptionGroupMemberships.member = Shapes::ShapeRef.new(shape: DBClusterOptionGroupStatus, location_name: "DBClusterOptionGroup")
 
@@ -545,13 +553,23 @@ module Aws::Neptune
     DBClusterParameterGroupNameMessage.add_member(:db_cluster_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterParameterGroupName"))
     DBClusterParameterGroupNameMessage.struct_class = Types::DBClusterParameterGroupNameMessage
 
+    DBClusterParameterGroupNotFoundFault.struct_class = Types::DBClusterParameterGroupNotFoundFault
+
     DBClusterParameterGroupsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterParameterGroupsMessage.add_member(:db_cluster_parameter_groups, Shapes::ShapeRef.new(shape: DBClusterParameterGroupList, location_name: "DBClusterParameterGroups"))
     DBClusterParameterGroupsMessage.struct_class = Types::DBClusterParameterGroupsMessage
 
+    DBClusterQuotaExceededFault.struct_class = Types::DBClusterQuotaExceededFault
+
     DBClusterRole.add_member(:role_arn, Shapes::ShapeRef.new(shape: String, location_name: "RoleArn"))
     DBClusterRole.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     DBClusterRole.struct_class = Types::DBClusterRole
+
+    DBClusterRoleAlreadyExistsFault.struct_class = Types::DBClusterRoleAlreadyExistsFault
+
+    DBClusterRoleNotFoundFault.struct_class = Types::DBClusterRoleNotFoundFault
+
+    DBClusterRoleQuotaExceededFault.struct_class = Types::DBClusterRoleQuotaExceededFault
 
     DBClusterRoles.member = Shapes::ShapeRef.new(shape: DBClusterRole, location_name: "DBClusterRole")
 
@@ -577,6 +595,8 @@ module Aws::Neptune
     DBClusterSnapshot.add_member(:iam_database_authentication_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "IAMDatabaseAuthenticationEnabled"))
     DBClusterSnapshot.struct_class = Types::DBClusterSnapshot
 
+    DBClusterSnapshotAlreadyExistsFault.struct_class = Types::DBClusterSnapshotAlreadyExistsFault
+
     DBClusterSnapshotAttribute.add_member(:attribute_name, Shapes::ShapeRef.new(shape: String, location_name: "AttributeName"))
     DBClusterSnapshotAttribute.add_member(:attribute_values, Shapes::ShapeRef.new(shape: AttributeValueList, location_name: "AttributeValues"))
     DBClusterSnapshotAttribute.struct_class = Types::DBClusterSnapshotAttribute
@@ -592,6 +612,8 @@ module Aws::Neptune
     DBClusterSnapshotMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterSnapshotMessage.add_member(:db_cluster_snapshots, Shapes::ShapeRef.new(shape: DBClusterSnapshotList, location_name: "DBClusterSnapshots"))
     DBClusterSnapshotMessage.struct_class = Types::DBClusterSnapshotMessage
+
+    DBClusterSnapshotNotFoundFault.struct_class = Types::DBClusterSnapshotNotFoundFault
 
     DBEngineVersion.add_member(:engine, Shapes::ShapeRef.new(shape: String, location_name: "Engine"))
     DBEngineVersion.add_member(:engine_version, Shapes::ShapeRef.new(shape: String, location_name: "EngineVersion"))
@@ -668,11 +690,15 @@ module Aws::Neptune
     DBInstance.add_member(:deletion_protection, Shapes::ShapeRef.new(shape: BooleanOptional, location_name: "DeletionProtection"))
     DBInstance.struct_class = Types::DBInstance
 
+    DBInstanceAlreadyExistsFault.struct_class = Types::DBInstanceAlreadyExistsFault
+
     DBInstanceList.member = Shapes::ShapeRef.new(shape: DBInstance, location_name: "DBInstance")
 
     DBInstanceMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBInstanceMessage.add_member(:db_instances, Shapes::ShapeRef.new(shape: DBInstanceList, location_name: "DBInstances"))
     DBInstanceMessage.struct_class = Types::DBInstanceMessage
+
+    DBInstanceNotFoundFault.struct_class = Types::DBInstanceNotFoundFault
 
     DBInstanceStatusInfo.add_member(:status_type, Shapes::ShapeRef.new(shape: String, location_name: "StatusType"))
     DBInstanceStatusInfo.add_member(:normal, Shapes::ShapeRef.new(shape: Boolean, location_name: "Normal"))
@@ -688,6 +714,8 @@ module Aws::Neptune
     DBParameterGroup.add_member(:db_parameter_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupArn"))
     DBParameterGroup.struct_class = Types::DBParameterGroup
 
+    DBParameterGroupAlreadyExistsFault.struct_class = Types::DBParameterGroupAlreadyExistsFault
+
     DBParameterGroupDetails.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     DBParameterGroupDetails.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBParameterGroupDetails.struct_class = Types::DBParameterGroupDetails
@@ -696,6 +724,10 @@ module Aws::Neptune
 
     DBParameterGroupNameMessage.add_member(:db_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupName"))
     DBParameterGroupNameMessage.struct_class = Types::DBParameterGroupNameMessage
+
+    DBParameterGroupNotFoundFault.struct_class = Types::DBParameterGroupNotFoundFault
+
+    DBParameterGroupQuotaExceededFault.struct_class = Types::DBParameterGroupQuotaExceededFault
 
     DBParameterGroupStatus.add_member(:db_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupName"))
     DBParameterGroupStatus.add_member(:parameter_apply_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterApplyStatus"))
@@ -715,6 +747,12 @@ module Aws::Neptune
 
     DBSecurityGroupNameList.member = Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupName")
 
+    DBSecurityGroupNotFoundFault.struct_class = Types::DBSecurityGroupNotFoundFault
+
+    DBSnapshotAlreadyExistsFault.struct_class = Types::DBSnapshotAlreadyExistsFault
+
+    DBSnapshotNotFoundFault.struct_class = Types::DBSnapshotNotFoundFault
+
     DBSubnetGroup.add_member(:db_subnet_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupName"))
     DBSubnetGroup.add_member(:db_subnet_group_description, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupDescription"))
     DBSubnetGroup.add_member(:vpc_id, Shapes::ShapeRef.new(shape: String, location_name: "VpcId"))
@@ -723,11 +761,23 @@ module Aws::Neptune
     DBSubnetGroup.add_member(:db_subnet_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupArn"))
     DBSubnetGroup.struct_class = Types::DBSubnetGroup
 
+    DBSubnetGroupAlreadyExistsFault.struct_class = Types::DBSubnetGroupAlreadyExistsFault
+
+    DBSubnetGroupDoesNotCoverEnoughAZs.struct_class = Types::DBSubnetGroupDoesNotCoverEnoughAZs
+
     DBSubnetGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBSubnetGroupMessage.add_member(:db_subnet_groups, Shapes::ShapeRef.new(shape: DBSubnetGroups, location_name: "DBSubnetGroups"))
     DBSubnetGroupMessage.struct_class = Types::DBSubnetGroupMessage
 
+    DBSubnetGroupNotFoundFault.struct_class = Types::DBSubnetGroupNotFoundFault
+
+    DBSubnetGroupQuotaExceededFault.struct_class = Types::DBSubnetGroupQuotaExceededFault
+
     DBSubnetGroups.member = Shapes::ShapeRef.new(shape: DBSubnetGroup, location_name: "DBSubnetGroup")
+
+    DBSubnetQuotaExceededFault.struct_class = Types::DBSubnetQuotaExceededFault
+
+    DBUpgradeDependencyFailureFault.struct_class = Types::DBUpgradeDependencyFailureFault
 
     DeleteDBClusterMessage.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBClusterIdentifier"))
     DeleteDBClusterMessage.add_member(:skip_final_snapshot, Shapes::ShapeRef.new(shape: Boolean, location_name: "SkipFinalSnapshot"))
@@ -906,6 +956,8 @@ module Aws::Neptune
 
     DomainMembershipList.member = Shapes::ShapeRef.new(shape: DomainMembership, location_name: "DomainMembership")
 
+    DomainNotFoundFault.struct_class = Types::DomainNotFoundFault
+
     DoubleRange.add_member(:from, Shapes::ShapeRef.new(shape: Double, location_name: "From"))
     DoubleRange.add_member(:to, Shapes::ShapeRef.new(shape: Double, location_name: "To"))
     DoubleRange.struct_class = Types::DoubleRange
@@ -955,6 +1007,8 @@ module Aws::Neptune
     EventSubscription.add_member(:event_subscription_arn, Shapes::ShapeRef.new(shape: String, location_name: "EventSubscriptionArn"))
     EventSubscription.struct_class = Types::EventSubscription
 
+    EventSubscriptionQuotaExceededFault.struct_class = Types::EventSubscriptionQuotaExceededFault
+
     EventSubscriptionsList.member = Shapes::ShapeRef.new(shape: EventSubscription, location_name: "EventSubscription")
 
     EventSubscriptionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -979,6 +1033,40 @@ module Aws::Neptune
     FilterList.member = Shapes::ShapeRef.new(shape: Filter, location_name: "Filter")
 
     FilterValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "Value")
+
+    InstanceQuotaExceededFault.struct_class = Types::InstanceQuotaExceededFault
+
+    InsufficientDBClusterCapacityFault.struct_class = Types::InsufficientDBClusterCapacityFault
+
+    InsufficientDBInstanceCapacityFault.struct_class = Types::InsufficientDBInstanceCapacityFault
+
+    InsufficientStorageClusterCapacityFault.struct_class = Types::InsufficientStorageClusterCapacityFault
+
+    InvalidDBClusterSnapshotStateFault.struct_class = Types::InvalidDBClusterSnapshotStateFault
+
+    InvalidDBClusterStateFault.struct_class = Types::InvalidDBClusterStateFault
+
+    InvalidDBInstanceStateFault.struct_class = Types::InvalidDBInstanceStateFault
+
+    InvalidDBParameterGroupStateFault.struct_class = Types::InvalidDBParameterGroupStateFault
+
+    InvalidDBSecurityGroupStateFault.struct_class = Types::InvalidDBSecurityGroupStateFault
+
+    InvalidDBSnapshotStateFault.struct_class = Types::InvalidDBSnapshotStateFault
+
+    InvalidDBSubnetGroupStateFault.struct_class = Types::InvalidDBSubnetGroupStateFault
+
+    InvalidDBSubnetStateFault.struct_class = Types::InvalidDBSubnetStateFault
+
+    InvalidEventSubscriptionStateFault.struct_class = Types::InvalidEventSubscriptionStateFault
+
+    InvalidRestoreFault.struct_class = Types::InvalidRestoreFault
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
+
+    KMSKeyNotAccessibleFault.struct_class = Types::KMSKeyNotAccessibleFault
 
     KeyList.member = Shapes::ShapeRef.new(shape: String)
 
@@ -1091,6 +1179,8 @@ module Aws::Neptune
 
     OptionGroupMembershipList.member = Shapes::ShapeRef.new(shape: OptionGroupMembership, location_name: "OptionGroupMembership")
 
+    OptionGroupNotFoundFault.struct_class = Types::OptionGroupNotFoundFault
+
     OrderableDBInstanceOption.add_member(:engine, Shapes::ShapeRef.new(shape: String, location_name: "Engine"))
     OrderableDBInstanceOption.add_member(:engine_version, Shapes::ShapeRef.new(shape: String, location_name: "EngineVersion"))
     OrderableDBInstanceOption.add_member(:db_instance_class, Shapes::ShapeRef.new(shape: String, location_name: "DBInstanceClass"))
@@ -1175,6 +1265,8 @@ module Aws::Neptune
     PromoteReadReplicaDBClusterResult.add_member(:db_cluster, Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster"))
     PromoteReadReplicaDBClusterResult.struct_class = Types::PromoteReadReplicaDBClusterResult
 
+    ProvisionedIopsNotAvailableInAZFault.struct_class = Types::ProvisionedIopsNotAvailableInAZFault
+
     Range.add_member(:from, Shapes::ShapeRef.new(shape: Integer, location_name: "From"))
     Range.add_member(:to, Shapes::ShapeRef.new(shape: Integer, location_name: "To"))
     Range.add_member(:step, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "Step"))
@@ -1219,6 +1311,8 @@ module Aws::Neptune
     ResetDBParameterGroupMessage.add_member(:reset_all_parameters, Shapes::ShapeRef.new(shape: Boolean, location_name: "ResetAllParameters"))
     ResetDBParameterGroupMessage.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     ResetDBParameterGroupMessage.struct_class = Types::ResetDBParameterGroupMessage
+
+    ResourceNotFoundFault.struct_class = Types::ResourceNotFoundFault
 
     ResourcePendingMaintenanceActions.add_member(:resource_identifier, Shapes::ShapeRef.new(shape: String, location_name: "ResourceIdentifier"))
     ResourcePendingMaintenanceActions.add_member(:pending_maintenance_action_details, Shapes::ShapeRef.new(shape: PendingMaintenanceActionDetails, location_name: "PendingMaintenanceActionDetails"))
@@ -1265,7 +1359,19 @@ module Aws::Neptune
     RestoreDBClusterToPointInTimeResult.add_member(:db_cluster, Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster"))
     RestoreDBClusterToPointInTimeResult.struct_class = Types::RestoreDBClusterToPointInTimeResult
 
+    SNSInvalidTopicFault.struct_class = Types::SNSInvalidTopicFault
+
+    SNSNoAuthorizationFault.struct_class = Types::SNSNoAuthorizationFault
+
+    SNSTopicArnNotFoundFault.struct_class = Types::SNSTopicArnNotFoundFault
+
+    SharedSnapshotQuotaExceededFault.struct_class = Types::SharedSnapshotQuotaExceededFault
+
+    SnapshotQuotaExceededFault.struct_class = Types::SnapshotQuotaExceededFault
+
     SourceIdsList.member = Shapes::ShapeRef.new(shape: String, location_name: "SourceId")
+
+    SourceNotFoundFault.struct_class = Types::SourceNotFoundFault
 
     StartDBClusterMessage.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBClusterIdentifier"))
     StartDBClusterMessage.struct_class = Types::StartDBClusterMessage
@@ -1279,14 +1385,26 @@ module Aws::Neptune
     StopDBClusterResult.add_member(:db_cluster, Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster"))
     StopDBClusterResult.struct_class = Types::StopDBClusterResult
 
+    StorageQuotaExceededFault.struct_class = Types::StorageQuotaExceededFault
+
+    StorageTypeNotSupportedFault.struct_class = Types::StorageTypeNotSupportedFault
+
     Subnet.add_member(:subnet_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier"))
     Subnet.add_member(:subnet_availability_zone, Shapes::ShapeRef.new(shape: AvailabilityZone, location_name: "SubnetAvailabilityZone"))
     Subnet.add_member(:subnet_status, Shapes::ShapeRef.new(shape: String, location_name: "SubnetStatus"))
     Subnet.struct_class = Types::Subnet
 
+    SubnetAlreadyInUse.struct_class = Types::SubnetAlreadyInUse
+
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier")
 
     SubnetList.member = Shapes::ShapeRef.new(shape: Subnet, location_name: "Subnet")
+
+    SubscriptionAlreadyExistFault.struct_class = Types::SubscriptionAlreadyExistFault
+
+    SubscriptionCategoryNotFoundFault.struct_class = Types::SubscriptionCategoryNotFoundFault
+
+    SubscriptionNotFoundFault.struct_class = Types::SubscriptionNotFoundFault
 
     SupportedCharacterSetsList.member = Shapes::ShapeRef.new(shape: CharacterSet, location_name: "CharacterSet")
 

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/errors.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/errors.rb
@@ -10,5 +10,654 @@ module Aws::Neptune
 
     extend Aws::Errors::DynamicErrors
 
+    class AuthorizationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::AuthorizationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CertificateNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::CertificateNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterRoleAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterRoleQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBClusterSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBInstanceAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBInstanceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSecurityGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupDoesNotCoverEnoughAZs < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSubnetGroupDoesNotCoverEnoughAZs] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBSubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBUpgradeDependencyFailureFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DBUpgradeDependencyFailureFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DomainNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::DomainNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EventSubscriptionQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::EventSubscriptionQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InstanceQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InsufficientDBClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBInstanceCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InsufficientDBInstanceCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientStorageClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InsufficientStorageClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBClusterSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBInstanceStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBInstanceStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSecurityGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBSecurityGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBSubnetGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidDBSubnetStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventSubscriptionStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidEventSubscriptionStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRestoreFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidRestoreFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KMSKeyNotAccessibleFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::KMSKeyNotAccessibleFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OptionGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::OptionGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProvisionedIopsNotAvailableInAZFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::ProvisionedIopsNotAvailableInAZFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::ResourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSInvalidTopicFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SNSInvalidTopicFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSNoAuthorizationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SNSNoAuthorizationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSTopicArnNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SNSTopicArnNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SharedSnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SharedSnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::StorageQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageTypeNotSupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::StorageTypeNotSupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetAlreadyInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SubnetAlreadyInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionAlreadyExistFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SubscriptionAlreadyExistFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionCategoryNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SubscriptionCategoryNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Neptune::Types::SubscriptionNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/types.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/types.rb
@@ -181,6 +181,16 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # Specified CIDRIP or EC2 security group is not authorized for the
+    # specified DB security group.
+    #
+    # Neptune may not also be authorized via IAM to perform necessary
+    # actions on your behalf.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/AuthorizationNotFoundFault AWS API Documentation
+    #
+    class AuthorizationNotFoundFault < Aws::EmptyStructure; end
+
     # Specifies an Availability Zone.
     #
     # @!attribute [rw] name
@@ -193,6 +203,12 @@ module Aws::Neptune
       :name)
       include Aws::Structure
     end
+
+    # *CertificateIdentifier* does not refer to an existing certificate.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/CertificateNotFoundFault AWS API Documentation
+    #
+    class CertificateNotFoundFault < Aws::EmptyStructure; end
 
     # Specifies a character set.
     #
@@ -1884,6 +1900,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # User already has a DB cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains information about an instance that is part of a DB cluster.
     #
     # @!attribute [rw] db_instance_identifier
@@ -1932,6 +1954,12 @@ module Aws::Neptune
       :db_clusters)
       include Aws::Structure
     end
+
+    # *DBClusterIdentifier* does not refer to an existing DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterNotFoundFault AWS API Documentation
+    #
+    class DBClusterNotFoundFault < Aws::EmptyStructure; end
 
     # Contains status information for a DB cluster option group.
     #
@@ -2026,6 +2054,13 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # *DBClusterParameterGroupName* does not refer to an existing DB Cluster
+    # parameter group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBClusterParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
     #   `DescribeDBClusterParameterGroups` request. If this parameter is
@@ -2044,6 +2079,13 @@ module Aws::Neptune
       :db_cluster_parameter_groups)
       include Aws::Structure
     end
+
+    # User attempted to create a new DB cluster and the user has already
+    # reached the maximum allowed DB cluster quota.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes an AWS Identity and Access Management (IAM) role that is
     # associated with a DB cluster.
@@ -2075,6 +2117,27 @@ module Aws::Neptune
       :status)
       include Aws::Structure
     end
+
+    # The specified IAM role Amazon Resource Name (ARN) is already
+    # associated with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterRoleAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterRoleAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified IAM role Amazon Resource Name (ARN) is not associated
+    # with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterRoleNotFoundFault AWS API Documentation
+    #
+    class DBClusterRoleNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of IAM roles that can be
+    # associated with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterRoleQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterRoleQuotaExceededFault < Aws::EmptyStructure; end
 
     # Contains the details for an Amazon Neptune DB cluster snapshot
     #
@@ -2213,6 +2276,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # User already has a DB cluster snapshot with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the name and values of a manual DB cluster snapshot
     # attribute.
     #
@@ -2290,6 +2359,13 @@ module Aws::Neptune
       :db_cluster_snapshots)
       include Aws::Structure
     end
+
+    # *DBClusterSnapshotIdentifier* does not refer to an existing DB cluster
+    # snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBClusterSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBClusterSnapshotNotFoundFault < Aws::EmptyStructure; end
 
     # This data type is used as a response element in the action
     # DescribeDBEngineVersions.
@@ -2703,6 +2779,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # User already has a DB instance with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBInstanceAlreadyExistsFault AWS API Documentation
+    #
+    class DBInstanceAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous request. If this
     #   parameter is specified, the response includes only records beyond
@@ -2720,6 +2802,12 @@ module Aws::Neptune
       :db_instances)
       include Aws::Structure
     end
+
+    # *DBInstanceIdentifier* does not refer to an existing DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBInstanceNotFoundFault AWS API Documentation
+    #
+    class DBInstanceNotFoundFault < Aws::EmptyStructure; end
 
     # Provides a list of status information for a DB instance.
     #
@@ -2785,6 +2873,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # A DB parameter group with the same name exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] parameters
     #   A list of Parameter values.
     #   @return [Array<Types::Parameter>]
@@ -2813,6 +2907,20 @@ module Aws::Neptune
       :db_parameter_group_name)
       include Aws::Structure
     end
+
+    # *DBParameterGroupName* does not refer to an existing DB parameter
+    # group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # Request would result in user exceeding the allowed number of DB
+    # parameter groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # The status of the DB parameter group.
     #
@@ -2878,6 +2986,24 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # *DBSecurityGroupName* does not refer to an existing DB security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSecurityGroupNotFoundFault AWS API Documentation
+    #
+    class DBSecurityGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # *DBSnapshotIdentifier* is already used by an existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # *DBSnapshotIdentifier* does not refer to an existing DB snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBSnapshotNotFoundFault < Aws::EmptyStructure; end
+
     # Contains the details of an Amazon Neptune DB subnet group.
     #
     # This data type is used as a response element in the
@@ -2919,6 +3045,19 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # *DBSubnetGroupName* is already used by an existing DB subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBSubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # Subnets in the DB subnet group should cover at least two Availability
+    # Zones unless there is only one Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSubnetGroupDoesNotCoverEnoughAZs AWS API Documentation
+    #
+    class DBSubnetGroupDoesNotCoverEnoughAZs < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous request. If this
     #   parameter is specified, the response includes only records beyond
@@ -2936,6 +3075,33 @@ module Aws::Neptune
       :db_subnet_groups)
       include Aws::Structure
     end
+
+    # *DBSubnetGroupName* does not refer to an existing DB subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSubnetGroupNotFoundFault AWS API Documentation
+    #
+    class DBSubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # Request would result in user exceeding the allowed number of DB subnet
+    # groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # Request would result in user exceeding the allowed number of subnets
+    # in a DB subnet groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBSubnetQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The DB upgrade failed because a resource the DB depends on could not
+    # be modified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DBUpgradeDependencyFailureFault AWS API Documentation
+    #
+    class DBUpgradeDependencyFailureFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass DeleteDBClusterMessage
     #   data as a hash:
@@ -4487,6 +4653,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # *Domain* does not refer to an existing Active Directory Domain.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/DomainNotFoundFault AWS API Documentation
+    #
+    class DomainNotFoundFault < Aws::EmptyStructure; end
+
     # A range of double values.
     #
     # @!attribute [rw] from
@@ -4697,6 +4869,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # You have exceeded the number of events you can subscribe to.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/EventSubscriptionQuotaExceededFault AWS API Documentation
+    #
+    class EventSubscriptionQuotaExceededFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
     #   DescribeOrderableDBInstanceOptions request. If this parameter is
@@ -4807,6 +4985,117 @@ module Aws::Neptune
       :values)
       include Aws::Structure
     end
+
+    # Request would result in user exceeding the allowed number of DB
+    # instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InstanceQuotaExceededFault AWS API Documentation
+    #
+    class InstanceQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The DB cluster does not have enough capacity for the current
+    # operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InsufficientDBClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientDBClusterCapacityFault < Aws::EmptyStructure; end
+
+    # Specified DB instance class is not available in the specified
+    # Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InsufficientDBInstanceCapacityFault AWS API Documentation
+    #
+    class InsufficientDBInstanceCapacityFault < Aws::EmptyStructure; end
+
+    # There is insufficient storage available for the current action. You
+    # may be able to resolve this error by updating your subnet group to use
+    # different Availability Zones that have more storage available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InsufficientStorageClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientStorageClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The supplied value is not a valid DB cluster snapshot state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBClusterSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBClusterSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The DB cluster is not in a valid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBClusterStateFault AWS API Documentation
+    #
+    class InvalidDBClusterStateFault < Aws::EmptyStructure; end
+
+    # The specified DB instance is not in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBInstanceStateFault AWS API Documentation
+    #
+    class InvalidDBInstanceStateFault < Aws::EmptyStructure; end
+
+    # The DB parameter group is in use or is in an invalid state. If you are
+    # attempting to delete the parameter group, you cannot delete it when
+    # the parameter group is in this state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidDBParameterGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the DB security group does not allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBSecurityGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSecurityGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the DB snapshot does not allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The DB subnet group cannot be deleted because it is in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBSubnetGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetGroupStateFault < Aws::EmptyStructure; end
+
+    # The DB subnet is not in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidDBSubnetStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetStateFault < Aws::EmptyStructure; end
+
+    # The event subscription is in an invalid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidEventSubscriptionStateFault AWS API Documentation
+    #
+    class InvalidEventSubscriptionStateFault < Aws::EmptyStructure; end
+
+    # Cannot restore from vpc backup to non-vpc DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidRestoreFault AWS API Documentation
+    #
+    class InvalidRestoreFault < Aws::EmptyStructure; end
+
+    # The requested subnet is invalid, or multiple subnets were requested
+    # that are not all in a common VPC.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # DB subnet group does not cover all Availability Zones after it is
+    # created because users' change.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
+
+    # Error accessing KMS key.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/KMSKeyNotAccessibleFault AWS API Documentation
+    #
+    class KMSKeyNotAccessibleFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListTagsForResourceMessage
     #   data as a hash:
@@ -5790,6 +6079,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # The designated option group could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/OptionGroupNotFoundFault AWS API Documentation
+    #
+    class OptionGroupNotFoundFault < Aws::EmptyStructure; end
+
     # Contains a list of available options for a DB instance.
     #
     # This data type is used as a response element in the
@@ -6215,6 +6510,12 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # Provisioned IOPS not available in the specified Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/ProvisionedIopsNotAvailableInAZFault AWS API Documentation
+    #
+    class ProvisionedIopsNotAvailableInAZFault < Aws::EmptyStructure; end
+
     # A range of integer values.
     #
     # @!attribute [rw] from
@@ -6491,6 +6792,12 @@ module Aws::Neptune
       :parameters)
       include Aws::Structure
     end
+
+    # The specified resource ID was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/ResourceNotFoundFault AWS API Documentation
+    #
+    class ResourceNotFoundFault < Aws::EmptyStructure; end
 
     # Describes the pending maintenance actions for a resource.
     #
@@ -6922,6 +7229,44 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # The SNS topic is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SNSInvalidTopicFault AWS API Documentation
+    #
+    class SNSInvalidTopicFault < Aws::EmptyStructure; end
+
+    # There is no SNS authorization.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SNSNoAuthorizationFault AWS API Documentation
+    #
+    class SNSNoAuthorizationFault < Aws::EmptyStructure; end
+
+    # The ARN of the SNS topic could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SNSTopicArnNotFoundFault AWS API Documentation
+    #
+    class SNSTopicArnNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of accounts that you can share a
+    # manual DB snapshot with.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SharedSnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SharedSnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
+    # Request would result in user exceeding the allowed number of DB
+    # snapshots.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The source could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SourceNotFoundFault AWS API Documentation
+    #
+    class SourceNotFoundFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass StartDBClusterMessage
     #   data as a hash:
     #
@@ -6988,6 +7333,19 @@ module Aws::Neptune
       include Aws::Structure
     end
 
+    # Request would result in user exceeding the allowed amount of storage
+    # available across all DB instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/StorageQuotaExceededFault AWS API Documentation
+    #
+    class StorageQuotaExceededFault < Aws::EmptyStructure; end
+
+    # *StorageType* specified cannot be associated with the DB Instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/StorageTypeNotSupportedFault AWS API Documentation
+    #
+    class StorageTypeNotSupportedFault < Aws::EmptyStructure; end
+
     # Specifies a subnet.
     #
     # This data type is used as a response element in the
@@ -7013,6 +7371,30 @@ module Aws::Neptune
       :subnet_status)
       include Aws::Structure
     end
+
+    # The DB subnet is already in use in the Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SubnetAlreadyInUse AWS API Documentation
+    #
+    class SubnetAlreadyInUse < Aws::EmptyStructure; end
+
+    # This subscription already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SubscriptionAlreadyExistFault AWS API Documentation
+    #
+    class SubscriptionAlreadyExistFault < Aws::EmptyStructure; end
+
+    # The designated subscription category could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SubscriptionCategoryNotFoundFault AWS API Documentation
+    #
+    class SubscriptionCategoryNotFoundFault < Aws::EmptyStructure; end
+
+    # The designated subscription could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/neptune-2014-10-31/SubscriptionNotFoundFault AWS API Documentation
+    #
+    class SubscriptionNotFoundFault < Aws::EmptyStructure; end
 
     # Metadata assigned to an Amazon Neptune resource consisting of a
     # key-value pair.

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client_api.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client_api.rb
@@ -224,6 +224,12 @@ module Aws::PinpointEmail
     VolumeStatistics = Shapes::StructureShape.new(name: 'VolumeStatistics')
     WarmupStatus = Shapes::StringShape.new(name: 'WarmupStatus')
 
+    AccountSuspendedException.struct_class = Types::AccountSuspendedException
+
+    AlreadyExistsException.struct_class = Types::AlreadyExistsException
+
+    BadRequestException.struct_class = Types::BadRequestException
+
     BlacklistEntries.member = Shapes::ShapeRef.new(shape: BlacklistEntry)
 
     BlacklistEntry.add_member(:rbl_name, Shapes::ShapeRef.new(shape: RblName, location_name: "RblName"))
@@ -249,6 +255,8 @@ module Aws::PinpointEmail
     CloudWatchDimensionConfiguration.struct_class = Types::CloudWatchDimensionConfiguration
 
     CloudWatchDimensionConfigurations.member = Shapes::ShapeRef.new(shape: CloudWatchDimensionConfiguration)
+
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
 
     ConfigurationSetNameList.member = Shapes::ShapeRef.new(shape: ConfigurationSetName)
 
@@ -541,6 +549,8 @@ module Aws::PinpointEmail
     KinesisFirehoseDestination.add_member(:delivery_stream_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "DeliveryStreamArn"))
     KinesisFirehoseDestination.struct_class = Types::KinesisFirehoseDestination
 
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     ListConfigurationSetsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location: "querystring", location_name: "NextToken"))
     ListConfigurationSetsRequest.add_member(:page_size, Shapes::ShapeRef.new(shape: MaxItems, location: "querystring", location_name: "PageSize"))
     ListConfigurationSetsRequest.struct_class = Types::ListConfigurationSetsRequest
@@ -597,15 +607,21 @@ module Aws::PinpointEmail
     MailFromAttributes.add_member(:behavior_on_mx_failure, Shapes::ShapeRef.new(shape: BehaviorOnMxFailure, required: true, location_name: "BehaviorOnMxFailure"))
     MailFromAttributes.struct_class = Types::MailFromAttributes
 
+    MailFromDomainNotVerifiedException.struct_class = Types::MailFromDomainNotVerifiedException
+
     Message.add_member(:subject, Shapes::ShapeRef.new(shape: Content, required: true, location_name: "Subject"))
     Message.add_member(:body, Shapes::ShapeRef.new(shape: Body, required: true, location_name: "Body"))
     Message.struct_class = Types::Message
+
+    MessageRejected.struct_class = Types::MessageRejected
 
     MessageTag.add_member(:name, Shapes::ShapeRef.new(shape: MessageTagName, required: true, location_name: "Name"))
     MessageTag.add_member(:value, Shapes::ShapeRef.new(shape: MessageTagValue, required: true, location_name: "Value"))
     MessageTag.struct_class = Types::MessageTag
 
     MessageTagList.member = Shapes::ShapeRef.new(shape: MessageTag)
+
+    NotFoundException.struct_class = Types::NotFoundException
 
     OverallVolume.add_member(:volume_statistics, Shapes::ShapeRef.new(shape: VolumeStatistics, location_name: "VolumeStatistics"))
     OverallVolume.add_member(:read_rate_percent, Shapes::ShapeRef.new(shape: Percentage, location_name: "ReadRatePercent"))
@@ -721,6 +737,8 @@ module Aws::PinpointEmail
     SendingOptions.add_member(:sending_enabled, Shapes::ShapeRef.new(shape: Enabled, location_name: "SendingEnabled"))
     SendingOptions.struct_class = Types::SendingOptions
 
+    SendingPausedException.struct_class = Types::SendingPausedException
+
     SnsDestination.add_member(:topic_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "TopicArn"))
     SnsDestination.struct_class = Types::SnsDestination
 
@@ -741,6 +759,8 @@ module Aws::PinpointEmail
     Template.add_member(:template_arn, Shapes::ShapeRef.new(shape: TemplateArn, location_name: "TemplateArn"))
     Template.add_member(:template_data, Shapes::ShapeRef.new(shape: TemplateData, location_name: "TemplateData"))
     Template.struct_class = Types::Template
+
+    TooManyRequestsException.struct_class = Types::TooManyRequestsException
 
     TrackingOptions.add_member(:custom_redirect_domain, Shapes::ShapeRef.new(shape: CustomRedirectDomain, required: true, location_name: "CustomRedirectDomain"))
     TrackingOptions.struct_class = Types::TrackingOptions

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/errors.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/errors.rb
@@ -10,5 +10,115 @@ module Aws::PinpointEmail
 
     extend Aws::Errors::DynamicErrors
 
+    class AccountSuspendedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::AccountSuspendedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::AlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BadRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::BadRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MailFromDomainNotVerifiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::MailFromDomainNotVerifiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MessageRejected < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::MessageRejected] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::NotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SendingPausedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::SendingPausedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyRequestsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::PinpointEmail::Types::TooManyRequestsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/types.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/types.rb
@@ -8,6 +8,25 @@
 module Aws::PinpointEmail
   module Types
 
+    # The message can't be sent because the account's ability to send
+    # email has been permanently restricted.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/AccountSuspendedException AWS API Documentation
+    #
+    class AccountSuspendedException < Aws::EmptyStructure; end
+
+    # The resource specified in your request already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/AlreadyExistsException AWS API Documentation
+    #
+    class AlreadyExistsException < Aws::EmptyStructure; end
+
+    # The input you provided is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/BadRequestException AWS API Documentation
+    #
+    class BadRequestException < Aws::EmptyStructure; end
+
     # An object that contains information about a blacklisting event that
     # impacts one of the dedicated IP addresses that is associated with your
     # account.
@@ -151,6 +170,12 @@ module Aws::PinpointEmail
       :default_dimension_value)
       include Aws::Structure
     end
+
+    # The resource is being modified by another operation or thread.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
 
     # An object that represents the content of the email, and optionally a
     # character set specification.
@@ -2053,6 +2078,12 @@ module Aws::PinpointEmail
       include Aws::Structure
     end
 
+    # There are too many instances of the specified resource type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # A request to obtain a list of configuration sets for your Amazon
     # Pinpoint account in the current AWS Region.
     #
@@ -2441,6 +2472,12 @@ module Aws::PinpointEmail
       include Aws::Structure
     end
 
+    # The message can't be sent because the sending domain isn't verified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/MailFromDomainNotVerifiedException AWS API Documentation
+    #
+    class MailFromDomainNotVerifiedException < Aws::EmptyStructure; end
+
     # Represents the email message that you're sending. The `Message`
     # object consists of a subject line and a message body.
     #
@@ -2488,6 +2525,12 @@ module Aws::PinpointEmail
       include Aws::Structure
     end
 
+    # The message can't be sent because it contains invalid content.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/MessageRejected AWS API Documentation
+    #
+    class MessageRejected < Aws::EmptyStructure; end
+
     # Contains the name and value of a tag that you apply to an email. You
     # can use message tags when you publish email sending events.
     #
@@ -2526,6 +2569,12 @@ module Aws::PinpointEmail
       :value)
       include Aws::Structure
     end
+
+    # The resource you attempted to access doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/NotFoundException AWS API Documentation
+    #
+    class NotFoundException < Aws::EmptyStructure; end
 
     # An object that contains information about email that was sent from the
     # selected domain.
@@ -3360,6 +3409,13 @@ module Aws::PinpointEmail
       include Aws::Structure
     end
 
+    # The message can't be sent because the account's ability to send
+    # email is currently paused.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/SendingPausedException AWS API Documentation
+    #
+    class SendingPausedException < Aws::EmptyStructure; end
+
     # An object that defines an Amazon SNS destination for email events. You
     # can use Amazon SNS to send notification when certain email events
     # occur.
@@ -3511,6 +3567,12 @@ module Aws::PinpointEmail
       :template_data)
       include Aws::Structure
     end
+
+    # Too many requests have been made to the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/pinpoint-email-2018-07-26/TooManyRequestsException AWS API Documentation
+    #
+    class TooManyRequestsException < Aws::EmptyStructure; end
 
     # An object that defines the tracking options for a configuration set.
     # When you use Amazon Pinpoint to send an email, it contains an

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
@@ -601,6 +601,12 @@ module Aws::RDS
 
     AttributeValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "AttributeValue")
 
+    AuthorizationAlreadyExistsFault.struct_class = Types::AuthorizationAlreadyExistsFault
+
+    AuthorizationNotFoundFault.struct_class = Types::AuthorizationNotFoundFault
+
+    AuthorizationQuotaExceededFault.struct_class = Types::AuthorizationQuotaExceededFault
+
     AuthorizeDBSecurityGroupIngressMessage.add_member(:db_security_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBSecurityGroupName"))
     AuthorizeDBSecurityGroupIngressMessage.add_member(:cidrip, Shapes::ShapeRef.new(shape: String, location_name: "CIDRIP"))
     AuthorizeDBSecurityGroupIngressMessage.add_member(:ec2_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "EC2SecurityGroupName"))
@@ -631,6 +637,8 @@ module Aws::RDS
     BacktrackDBClusterMessage.add_member(:use_earliest_time_on_point_in_time_unavailable, Shapes::ShapeRef.new(shape: BooleanOptional, location_name: "UseEarliestTimeOnPointInTimeUnavailable"))
     BacktrackDBClusterMessage.struct_class = Types::BacktrackDBClusterMessage
 
+    BackupPolicyNotFoundFault.struct_class = Types::BackupPolicyNotFoundFault
+
     CancelExportTaskMessage.add_member(:export_task_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ExportTaskIdentifier"))
     CancelExportTaskMessage.struct_class = Types::CancelExportTaskMessage
 
@@ -649,6 +657,8 @@ module Aws::RDS
     CertificateMessage.add_member(:certificates, Shapes::ShapeRef.new(shape: CertificateList, location_name: "Certificates"))
     CertificateMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CertificateMessage.struct_class = Types::CertificateMessage
+
+    CertificateNotFoundFault.struct_class = Types::CertificateNotFoundFault
 
     CharacterSet.add_member(:character_set_name, Shapes::ShapeRef.new(shape: String, location_name: "CharacterSetName"))
     CharacterSet.add_member(:character_set_description, Shapes::ShapeRef.new(shape: String, location_name: "CharacterSetDescription"))
@@ -976,11 +986,17 @@ module Aws::RDS
     CustomAvailabilityZone.add_member(:vpn_details, Shapes::ShapeRef.new(shape: VpnDetails, location_name: "VpnDetails"))
     CustomAvailabilityZone.struct_class = Types::CustomAvailabilityZone
 
+    CustomAvailabilityZoneAlreadyExistsFault.struct_class = Types::CustomAvailabilityZoneAlreadyExistsFault
+
     CustomAvailabilityZoneList.member = Shapes::ShapeRef.new(shape: CustomAvailabilityZone, location_name: "CustomAvailabilityZone")
 
     CustomAvailabilityZoneMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     CustomAvailabilityZoneMessage.add_member(:custom_availability_zones, Shapes::ShapeRef.new(shape: CustomAvailabilityZoneList, location_name: "CustomAvailabilityZones"))
     CustomAvailabilityZoneMessage.struct_class = Types::CustomAvailabilityZoneMessage
+
+    CustomAvailabilityZoneNotFoundFault.struct_class = Types::CustomAvailabilityZoneNotFoundFault
+
+    CustomAvailabilityZoneQuotaExceededFault.struct_class = Types::CustomAvailabilityZoneQuotaExceededFault
 
     DBCluster.add_member(:allocated_storage, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "AllocatedStorage"))
     DBCluster.add_member(:availability_zones, Shapes::ShapeRef.new(shape: AvailabilityZones, location_name: "AvailabilityZones"))
@@ -1036,6 +1052,8 @@ module Aws::RDS
     DBCluster.add_member(:domain_memberships, Shapes::ShapeRef.new(shape: DomainMembershipList, location_name: "DomainMemberships"))
     DBCluster.struct_class = Types::DBCluster
 
+    DBClusterAlreadyExistsFault.struct_class = Types::DBClusterAlreadyExistsFault
+
     DBClusterBacktrack.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterIdentifier"))
     DBClusterBacktrack.add_member(:backtrack_identifier, Shapes::ShapeRef.new(shape: String, location_name: "BacktrackIdentifier"))
     DBClusterBacktrack.add_member(:backtrack_to, Shapes::ShapeRef.new(shape: TStamp, location_name: "BacktrackTo"))
@@ -1049,6 +1067,8 @@ module Aws::RDS
     DBClusterBacktrackMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterBacktrackMessage.add_member(:db_cluster_backtracks, Shapes::ShapeRef.new(shape: DBClusterBacktrackList, location_name: "DBClusterBacktracks"))
     DBClusterBacktrackMessage.struct_class = Types::DBClusterBacktrackMessage
+
+    DBClusterBacktrackNotFoundFault.struct_class = Types::DBClusterBacktrackNotFoundFault
 
     DBClusterCapacityInfo.add_member(:db_cluster_identifier, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterIdentifier"))
     DBClusterCapacityInfo.add_member(:pending_capacity, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "PendingCapacity"))
@@ -1069,11 +1089,17 @@ module Aws::RDS
     DBClusterEndpoint.add_member(:db_cluster_endpoint_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterEndpointArn"))
     DBClusterEndpoint.struct_class = Types::DBClusterEndpoint
 
+    DBClusterEndpointAlreadyExistsFault.struct_class = Types::DBClusterEndpointAlreadyExistsFault
+
     DBClusterEndpointList.member = Shapes::ShapeRef.new(shape: DBClusterEndpoint, location_name: "DBClusterEndpointList")
 
     DBClusterEndpointMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterEndpointMessage.add_member(:db_cluster_endpoints, Shapes::ShapeRef.new(shape: DBClusterEndpointList, location_name: "DBClusterEndpoints"))
     DBClusterEndpointMessage.struct_class = Types::DBClusterEndpointMessage
+
+    DBClusterEndpointNotFoundFault.struct_class = Types::DBClusterEndpointNotFoundFault
+
+    DBClusterEndpointQuotaExceededFault.struct_class = Types::DBClusterEndpointQuotaExceededFault
 
     DBClusterList.member = Shapes::ShapeRef.new(shape: DBCluster, location_name: "DBCluster")
 
@@ -1088,6 +1114,8 @@ module Aws::RDS
     DBClusterMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterMessage.add_member(:db_clusters, Shapes::ShapeRef.new(shape: DBClusterList, location_name: "DBClusters"))
     DBClusterMessage.struct_class = Types::DBClusterMessage
+
+    DBClusterNotFoundFault.struct_class = Types::DBClusterNotFoundFault
 
     DBClusterOptionGroupMemberships.member = Shapes::ShapeRef.new(shape: DBClusterOptionGroupStatus, location_name: "DBClusterOptionGroup")
 
@@ -1110,14 +1138,24 @@ module Aws::RDS
     DBClusterParameterGroupNameMessage.add_member(:db_cluster_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterParameterGroupName"))
     DBClusterParameterGroupNameMessage.struct_class = Types::DBClusterParameterGroupNameMessage
 
+    DBClusterParameterGroupNotFoundFault.struct_class = Types::DBClusterParameterGroupNotFoundFault
+
     DBClusterParameterGroupsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterParameterGroupsMessage.add_member(:db_cluster_parameter_groups, Shapes::ShapeRef.new(shape: DBClusterParameterGroupList, location_name: "DBClusterParameterGroups"))
     DBClusterParameterGroupsMessage.struct_class = Types::DBClusterParameterGroupsMessage
+
+    DBClusterQuotaExceededFault.struct_class = Types::DBClusterQuotaExceededFault
 
     DBClusterRole.add_member(:role_arn, Shapes::ShapeRef.new(shape: String, location_name: "RoleArn"))
     DBClusterRole.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     DBClusterRole.add_member(:feature_name, Shapes::ShapeRef.new(shape: String, location_name: "FeatureName"))
     DBClusterRole.struct_class = Types::DBClusterRole
+
+    DBClusterRoleAlreadyExistsFault.struct_class = Types::DBClusterRoleAlreadyExistsFault
+
+    DBClusterRoleNotFoundFault.struct_class = Types::DBClusterRoleNotFoundFault
+
+    DBClusterRoleQuotaExceededFault.struct_class = Types::DBClusterRoleQuotaExceededFault
 
     DBClusterRoles.member = Shapes::ShapeRef.new(shape: DBClusterRole, location_name: "DBClusterRole")
 
@@ -1143,6 +1181,8 @@ module Aws::RDS
     DBClusterSnapshot.add_member(:iam_database_authentication_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "IAMDatabaseAuthenticationEnabled"))
     DBClusterSnapshot.struct_class = Types::DBClusterSnapshot
 
+    DBClusterSnapshotAlreadyExistsFault.struct_class = Types::DBClusterSnapshotAlreadyExistsFault
+
     DBClusterSnapshotAttribute.add_member(:attribute_name, Shapes::ShapeRef.new(shape: String, location_name: "AttributeName"))
     DBClusterSnapshotAttribute.add_member(:attribute_values, Shapes::ShapeRef.new(shape: AttributeValueList, location_name: "AttributeValues"))
     DBClusterSnapshotAttribute.struct_class = Types::DBClusterSnapshotAttribute
@@ -1158,6 +1198,8 @@ module Aws::RDS
     DBClusterSnapshotMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBClusterSnapshotMessage.add_member(:db_cluster_snapshots, Shapes::ShapeRef.new(shape: DBClusterSnapshotList, location_name: "DBClusterSnapshots"))
     DBClusterSnapshotMessage.struct_class = Types::DBClusterSnapshotMessage
+
+    DBClusterSnapshotNotFoundFault.struct_class = Types::DBClusterSnapshotNotFoundFault
 
     DBEngineVersion.add_member(:engine, Shapes::ShapeRef.new(shape: String, location_name: "Engine"))
     DBEngineVersion.add_member(:engine_version, Shapes::ShapeRef.new(shape: String, location_name: "EngineVersion"))
@@ -1242,6 +1284,8 @@ module Aws::RDS
     DBInstance.add_member(:max_allocated_storage, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "MaxAllocatedStorage"))
     DBInstance.struct_class = Types::DBInstance
 
+    DBInstanceAlreadyExistsFault.struct_class = Types::DBInstanceAlreadyExistsFault
+
     DBInstanceAutomatedBackup.add_member(:db_instance_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBInstanceArn"))
     DBInstanceAutomatedBackup.add_member(:dbi_resource_id, Shapes::ShapeRef.new(shape: String, location_name: "DbiResourceId"))
     DBInstanceAutomatedBackup.add_member(:region, Shapes::ShapeRef.new(shape: String, location_name: "Region"))
@@ -1273,16 +1317,28 @@ module Aws::RDS
     DBInstanceAutomatedBackupMessage.add_member(:db_instance_automated_backups, Shapes::ShapeRef.new(shape: DBInstanceAutomatedBackupList, location_name: "DBInstanceAutomatedBackups"))
     DBInstanceAutomatedBackupMessage.struct_class = Types::DBInstanceAutomatedBackupMessage
 
+    DBInstanceAutomatedBackupNotFoundFault.struct_class = Types::DBInstanceAutomatedBackupNotFoundFault
+
+    DBInstanceAutomatedBackupQuotaExceededFault.struct_class = Types::DBInstanceAutomatedBackupQuotaExceededFault
+
     DBInstanceList.member = Shapes::ShapeRef.new(shape: DBInstance, location_name: "DBInstance")
 
     DBInstanceMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBInstanceMessage.add_member(:db_instances, Shapes::ShapeRef.new(shape: DBInstanceList, location_name: "DBInstances"))
     DBInstanceMessage.struct_class = Types::DBInstanceMessage
 
+    DBInstanceNotFoundFault.struct_class = Types::DBInstanceNotFoundFault
+
     DBInstanceRole.add_member(:role_arn, Shapes::ShapeRef.new(shape: String, location_name: "RoleArn"))
     DBInstanceRole.add_member(:feature_name, Shapes::ShapeRef.new(shape: String, location_name: "FeatureName"))
     DBInstanceRole.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     DBInstanceRole.struct_class = Types::DBInstanceRole
+
+    DBInstanceRoleAlreadyExistsFault.struct_class = Types::DBInstanceRoleAlreadyExistsFault
+
+    DBInstanceRoleNotFoundFault.struct_class = Types::DBInstanceRoleNotFoundFault
+
+    DBInstanceRoleQuotaExceededFault.struct_class = Types::DBInstanceRoleQuotaExceededFault
 
     DBInstanceRoles.member = Shapes::ShapeRef.new(shape: DBInstanceRole, location_name: "DBInstanceRole")
 
@@ -1294,11 +1350,15 @@ module Aws::RDS
 
     DBInstanceStatusInfoList.member = Shapes::ShapeRef.new(shape: DBInstanceStatusInfo, location_name: "DBInstanceStatusInfo")
 
+    DBLogFileNotFoundFault.struct_class = Types::DBLogFileNotFoundFault
+
     DBParameterGroup.add_member(:db_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupName"))
     DBParameterGroup.add_member(:db_parameter_group_family, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupFamily"))
     DBParameterGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
     DBParameterGroup.add_member(:db_parameter_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupArn"))
     DBParameterGroup.struct_class = Types::DBParameterGroup
+
+    DBParameterGroupAlreadyExistsFault.struct_class = Types::DBParameterGroupAlreadyExistsFault
 
     DBParameterGroupDetails.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     DBParameterGroupDetails.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -1308,6 +1368,10 @@ module Aws::RDS
 
     DBParameterGroupNameMessage.add_member(:db_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupName"))
     DBParameterGroupNameMessage.struct_class = Types::DBParameterGroupNameMessage
+
+    DBParameterGroupNotFoundFault.struct_class = Types::DBParameterGroupNotFoundFault
+
+    DBParameterGroupQuotaExceededFault.struct_class = Types::DBParameterGroupQuotaExceededFault
 
     DBParameterGroupStatus.add_member(:db_parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBParameterGroupName"))
     DBParameterGroupStatus.add_member(:parameter_apply_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterApplyStatus"))
@@ -1335,7 +1399,13 @@ module Aws::RDS
     DBProxy.add_member(:updated_date, Shapes::ShapeRef.new(shape: TStamp, location_name: "UpdatedDate"))
     DBProxy.struct_class = Types::DBProxy
 
+    DBProxyAlreadyExistsFault.struct_class = Types::DBProxyAlreadyExistsFault
+
     DBProxyList.member = Shapes::ShapeRef.new(shape: DBProxy)
+
+    DBProxyNotFoundFault.struct_class = Types::DBProxyNotFoundFault
+
+    DBProxyQuotaExceededFault.struct_class = Types::DBProxyQuotaExceededFault
 
     DBProxyTarget.add_member(:target_arn, Shapes::ShapeRef.new(shape: String, location_name: "TargetArn"))
     DBProxyTarget.add_member(:endpoint, Shapes::ShapeRef.new(shape: String, location_name: "Endpoint"))
@@ -1344,6 +1414,8 @@ module Aws::RDS
     DBProxyTarget.add_member(:port, Shapes::ShapeRef.new(shape: Integer, location_name: "Port"))
     DBProxyTarget.add_member(:type, Shapes::ShapeRef.new(shape: TargetType, location_name: "Type"))
     DBProxyTarget.struct_class = Types::DBProxyTarget
+
+    DBProxyTargetAlreadyRegisteredFault.struct_class = Types::DBProxyTargetAlreadyRegisteredFault
 
     DBProxyTargetGroup.add_member(:db_proxy_name, Shapes::ShapeRef.new(shape: String, location_name: "DBProxyName"))
     DBProxyTargetGroup.add_member(:target_group_name, Shapes::ShapeRef.new(shape: String, location_name: "TargetGroupName"))
@@ -1355,6 +1427,10 @@ module Aws::RDS
     DBProxyTargetGroup.add_member(:updated_date, Shapes::ShapeRef.new(shape: TStamp, location_name: "UpdatedDate"))
     DBProxyTargetGroup.struct_class = Types::DBProxyTargetGroup
 
+    DBProxyTargetGroupNotFoundFault.struct_class = Types::DBProxyTargetGroupNotFoundFault
+
+    DBProxyTargetNotFoundFault.struct_class = Types::DBProxyTargetNotFoundFault
+
     DBSecurityGroup.add_member(:owner_id, Shapes::ShapeRef.new(shape: String, location_name: "OwnerId"))
     DBSecurityGroup.add_member(:db_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupName"))
     DBSecurityGroup.add_member(:db_security_group_description, Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupDescription"))
@@ -1363,6 +1439,8 @@ module Aws::RDS
     DBSecurityGroup.add_member(:ip_ranges, Shapes::ShapeRef.new(shape: IPRangeList, location_name: "IPRanges"))
     DBSecurityGroup.add_member(:db_security_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupArn"))
     DBSecurityGroup.struct_class = Types::DBSecurityGroup
+
+    DBSecurityGroupAlreadyExistsFault.struct_class = Types::DBSecurityGroupAlreadyExistsFault
 
     DBSecurityGroupMembership.add_member(:db_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupName"))
     DBSecurityGroupMembership.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
@@ -1375,6 +1453,12 @@ module Aws::RDS
     DBSecurityGroupMessage.struct_class = Types::DBSecurityGroupMessage
 
     DBSecurityGroupNameList.member = Shapes::ShapeRef.new(shape: String, location_name: "DBSecurityGroupName")
+
+    DBSecurityGroupNotFoundFault.struct_class = Types::DBSecurityGroupNotFoundFault
+
+    DBSecurityGroupNotSupportedFault.struct_class = Types::DBSecurityGroupNotSupportedFault
+
+    DBSecurityGroupQuotaExceededFault.struct_class = Types::DBSecurityGroupQuotaExceededFault
 
     DBSecurityGroups.member = Shapes::ShapeRef.new(shape: DBSecurityGroup, location_name: "DBSecurityGroup")
 
@@ -1408,6 +1492,8 @@ module Aws::RDS
     DBSnapshot.add_member(:dbi_resource_id, Shapes::ShapeRef.new(shape: String, location_name: "DbiResourceId"))
     DBSnapshot.struct_class = Types::DBSnapshot
 
+    DBSnapshotAlreadyExistsFault.struct_class = Types::DBSnapshotAlreadyExistsFault
+
     DBSnapshotAttribute.add_member(:attribute_name, Shapes::ShapeRef.new(shape: String, location_name: "AttributeName"))
     DBSnapshotAttribute.add_member(:attribute_values, Shapes::ShapeRef.new(shape: AttributeValueList, location_name: "AttributeValues"))
     DBSnapshotAttribute.struct_class = Types::DBSnapshotAttribute
@@ -1424,6 +1510,8 @@ module Aws::RDS
     DBSnapshotMessage.add_member(:db_snapshots, Shapes::ShapeRef.new(shape: DBSnapshotList, location_name: "DBSnapshots"))
     DBSnapshotMessage.struct_class = Types::DBSnapshotMessage
 
+    DBSnapshotNotFoundFault.struct_class = Types::DBSnapshotNotFoundFault
+
     DBSubnetGroup.add_member(:db_subnet_group_name, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupName"))
     DBSubnetGroup.add_member(:db_subnet_group_description, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupDescription"))
     DBSubnetGroup.add_member(:vpc_id, Shapes::ShapeRef.new(shape: String, location_name: "VpcId"))
@@ -1432,11 +1520,25 @@ module Aws::RDS
     DBSubnetGroup.add_member(:db_subnet_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBSubnetGroupArn"))
     DBSubnetGroup.struct_class = Types::DBSubnetGroup
 
+    DBSubnetGroupAlreadyExistsFault.struct_class = Types::DBSubnetGroupAlreadyExistsFault
+
+    DBSubnetGroupDoesNotCoverEnoughAZs.struct_class = Types::DBSubnetGroupDoesNotCoverEnoughAZs
+
     DBSubnetGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     DBSubnetGroupMessage.add_member(:db_subnet_groups, Shapes::ShapeRef.new(shape: DBSubnetGroups, location_name: "DBSubnetGroups"))
     DBSubnetGroupMessage.struct_class = Types::DBSubnetGroupMessage
 
+    DBSubnetGroupNotAllowedFault.struct_class = Types::DBSubnetGroupNotAllowedFault
+
+    DBSubnetGroupNotFoundFault.struct_class = Types::DBSubnetGroupNotFoundFault
+
+    DBSubnetGroupQuotaExceededFault.struct_class = Types::DBSubnetGroupQuotaExceededFault
+
     DBSubnetGroups.member = Shapes::ShapeRef.new(shape: DBSubnetGroup, location_name: "DBSubnetGroup")
+
+    DBSubnetQuotaExceededFault.struct_class = Types::DBSubnetQuotaExceededFault
+
+    DBUpgradeDependencyFailureFault.struct_class = Types::DBUpgradeDependencyFailureFault
 
     DeleteCustomAvailabilityZoneMessage.add_member(:custom_availability_zone_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "CustomAvailabilityZoneId"))
     DeleteCustomAvailabilityZoneMessage.struct_class = Types::DeleteCustomAvailabilityZoneMessage
@@ -1842,6 +1944,8 @@ module Aws::RDS
 
     DomainMembershipList.member = Shapes::ShapeRef.new(shape: DomainMembership, location_name: "DomainMembership")
 
+    DomainNotFoundFault.struct_class = Types::DomainNotFoundFault
+
     DoubleRange.add_member(:from, Shapes::ShapeRef.new(shape: Double, location_name: "From"))
     DoubleRange.add_member(:to, Shapes::ShapeRef.new(shape: Double, location_name: "To"))
     DoubleRange.struct_class = Types::DoubleRange
@@ -1912,6 +2016,8 @@ module Aws::RDS
     EventSubscription.add_member(:event_subscription_arn, Shapes::ShapeRef.new(shape: String, location_name: "EventSubscriptionArn"))
     EventSubscription.struct_class = Types::EventSubscription
 
+    EventSubscriptionQuotaExceededFault.struct_class = Types::EventSubscriptionQuotaExceededFault
+
     EventSubscriptionsList.member = Shapes::ShapeRef.new(shape: EventSubscription, location_name: "EventSubscription")
 
     EventSubscriptionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -1938,6 +2044,10 @@ module Aws::RDS
     ExportTask.add_member(:failure_cause, Shapes::ShapeRef.new(shape: String, location_name: "FailureCause"))
     ExportTask.add_member(:warning_message, Shapes::ShapeRef.new(shape: String, location_name: "WarningMessage"))
     ExportTask.struct_class = Types::ExportTask
+
+    ExportTaskAlreadyExistsFault.struct_class = Types::ExportTaskAlreadyExistsFault
+
+    ExportTaskNotFoundFault.struct_class = Types::ExportTaskNotFoundFault
 
     ExportTasksList.member = Shapes::ShapeRef.new(shape: ExportTask, location_name: "ExportTask")
 
@@ -1974,6 +2084,8 @@ module Aws::RDS
     GlobalCluster.add_member(:global_cluster_members, Shapes::ShapeRef.new(shape: GlobalClusterMemberList, location_name: "GlobalClusterMembers"))
     GlobalCluster.struct_class = Types::GlobalCluster
 
+    GlobalClusterAlreadyExistsFault.struct_class = Types::GlobalClusterAlreadyExistsFault
+
     GlobalClusterList.member = Shapes::ShapeRef.new(shape: GlobalCluster, location_name: "GlobalClusterMember")
 
     GlobalClusterMember.add_member(:db_cluster_arn, Shapes::ShapeRef.new(shape: String, location_name: "DBClusterArn"))
@@ -1982,6 +2094,10 @@ module Aws::RDS
     GlobalClusterMember.struct_class = Types::GlobalClusterMember
 
     GlobalClusterMemberList.member = Shapes::ShapeRef.new(shape: GlobalClusterMember, location_name: "GlobalClusterMember")
+
+    GlobalClusterNotFoundFault.struct_class = Types::GlobalClusterNotFoundFault
+
+    GlobalClusterQuotaExceededFault.struct_class = Types::GlobalClusterQuotaExceededFault
 
     GlobalClustersMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     GlobalClustersMessage.add_member(:global_clusters, Shapes::ShapeRef.new(shape: GlobalClusterList, location_name: "GlobalClusters"))
@@ -1992,6 +2108,10 @@ module Aws::RDS
     IPRange.struct_class = Types::IPRange
 
     IPRangeList.member = Shapes::ShapeRef.new(shape: IPRange, location_name: "IPRange")
+
+    IamRoleMissingPermissionsFault.struct_class = Types::IamRoleMissingPermissionsFault
+
+    IamRoleNotFoundFault.struct_class = Types::IamRoleNotFoundFault
 
     ImportInstallationMediaMessage.add_member(:custom_availability_zone_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "CustomAvailabilityZoneId"))
     ImportInstallationMediaMessage.add_member(:engine, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Engine"))
@@ -2010,6 +2130,8 @@ module Aws::RDS
     InstallationMedia.add_member(:failure_cause, Shapes::ShapeRef.new(shape: InstallationMediaFailureCause, location_name: "FailureCause"))
     InstallationMedia.struct_class = Types::InstallationMedia
 
+    InstallationMediaAlreadyExistsFault.struct_class = Types::InstallationMediaAlreadyExistsFault
+
     InstallationMediaFailureCause.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InstallationMediaFailureCause.struct_class = Types::InstallationMediaFailureCause
 
@@ -2018,6 +2140,64 @@ module Aws::RDS
     InstallationMediaMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     InstallationMediaMessage.add_member(:installation_media, Shapes::ShapeRef.new(shape: InstallationMediaList, location_name: "InstallationMedia"))
     InstallationMediaMessage.struct_class = Types::InstallationMediaMessage
+
+    InstallationMediaNotFoundFault.struct_class = Types::InstallationMediaNotFoundFault
+
+    InstanceQuotaExceededFault.struct_class = Types::InstanceQuotaExceededFault
+
+    InsufficientDBClusterCapacityFault.struct_class = Types::InsufficientDBClusterCapacityFault
+
+    InsufficientDBInstanceCapacityFault.struct_class = Types::InsufficientDBInstanceCapacityFault
+
+    InsufficientStorageClusterCapacityFault.struct_class = Types::InsufficientStorageClusterCapacityFault
+
+    InvalidDBClusterCapacityFault.struct_class = Types::InvalidDBClusterCapacityFault
+
+    InvalidDBClusterEndpointStateFault.struct_class = Types::InvalidDBClusterEndpointStateFault
+
+    InvalidDBClusterSnapshotStateFault.struct_class = Types::InvalidDBClusterSnapshotStateFault
+
+    InvalidDBClusterStateFault.struct_class = Types::InvalidDBClusterStateFault
+
+    InvalidDBInstanceAutomatedBackupStateFault.struct_class = Types::InvalidDBInstanceAutomatedBackupStateFault
+
+    InvalidDBInstanceStateFault.struct_class = Types::InvalidDBInstanceStateFault
+
+    InvalidDBParameterGroupStateFault.struct_class = Types::InvalidDBParameterGroupStateFault
+
+    InvalidDBProxyStateFault.struct_class = Types::InvalidDBProxyStateFault
+
+    InvalidDBSecurityGroupStateFault.struct_class = Types::InvalidDBSecurityGroupStateFault
+
+    InvalidDBSnapshotStateFault.struct_class = Types::InvalidDBSnapshotStateFault
+
+    InvalidDBSubnetGroupFault.struct_class = Types::InvalidDBSubnetGroupFault
+
+    InvalidDBSubnetGroupStateFault.struct_class = Types::InvalidDBSubnetGroupStateFault
+
+    InvalidDBSubnetStateFault.struct_class = Types::InvalidDBSubnetStateFault
+
+    InvalidEventSubscriptionStateFault.struct_class = Types::InvalidEventSubscriptionStateFault
+
+    InvalidExportOnlyFault.struct_class = Types::InvalidExportOnlyFault
+
+    InvalidExportSourceStateFault.struct_class = Types::InvalidExportSourceStateFault
+
+    InvalidExportTaskStateFault.struct_class = Types::InvalidExportTaskStateFault
+
+    InvalidGlobalClusterStateFault.struct_class = Types::InvalidGlobalClusterStateFault
+
+    InvalidOptionGroupStateFault.struct_class = Types::InvalidOptionGroupStateFault
+
+    InvalidRestoreFault.struct_class = Types::InvalidRestoreFault
+
+    InvalidS3BucketFault.struct_class = Types::InvalidS3BucketFault
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
+
+    KMSKeyNotAccessibleFault.struct_class = Types::KMSKeyNotAccessibleFault
 
     KeyList.member = Shapes::ShapeRef.new(shape: String)
 
@@ -2249,11 +2429,15 @@ module Aws::RDS
     OptionGroup.add_member(:option_group_arn, Shapes::ShapeRef.new(shape: String, location_name: "OptionGroupArn"))
     OptionGroup.struct_class = Types::OptionGroup
 
+    OptionGroupAlreadyExistsFault.struct_class = Types::OptionGroupAlreadyExistsFault
+
     OptionGroupMembership.add_member(:option_group_name, Shapes::ShapeRef.new(shape: String, location_name: "OptionGroupName"))
     OptionGroupMembership.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
     OptionGroupMembership.struct_class = Types::OptionGroupMembership
 
     OptionGroupMembershipList.member = Shapes::ShapeRef.new(shape: OptionGroupMembership, location_name: "OptionGroupMembership")
+
+    OptionGroupNotFoundFault.struct_class = Types::OptionGroupNotFoundFault
 
     OptionGroupOption.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     OptionGroupOption.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
@@ -2292,6 +2476,8 @@ module Aws::RDS
     OptionGroupOptionsMessage.add_member(:option_group_options, Shapes::ShapeRef.new(shape: OptionGroupOptionsList, location_name: "OptionGroupOptions"))
     OptionGroupOptionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     OptionGroupOptionsMessage.struct_class = Types::OptionGroupOptionsMessage
+
+    OptionGroupQuotaExceededFault.struct_class = Types::OptionGroupQuotaExceededFault
 
     OptionGroups.add_member(:option_groups_list, Shapes::ShapeRef.new(shape: OptionGroupsList, location_name: "OptionGroupsList"))
     OptionGroups.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -2410,6 +2596,8 @@ module Aws::RDS
     PendingModifiedValues.add_member(:processor_features, Shapes::ShapeRef.new(shape: ProcessorFeatureList, location_name: "ProcessorFeatures"))
     PendingModifiedValues.struct_class = Types::PendingModifiedValues
 
+    PointInTimeRestoreNotEnabledFault.struct_class = Types::PointInTimeRestoreNotEnabledFault
+
     ProcessorFeature.add_member(:name, Shapes::ShapeRef.new(shape: String, location_name: "Name"))
     ProcessorFeature.add_member(:value, Shapes::ShapeRef.new(shape: String, location_name: "Value"))
     ProcessorFeature.struct_class = Types::ProcessorFeature
@@ -2429,6 +2617,8 @@ module Aws::RDS
 
     PromoteReadReplicaResult.add_member(:db_instance, Shapes::ShapeRef.new(shape: DBInstance, location_name: "DBInstance"))
     PromoteReadReplicaResult.struct_class = Types::PromoteReadReplicaResult
+
+    ProvisionedIopsNotAvailableInAZFault.struct_class = Types::ProvisionedIopsNotAvailableInAZFault
 
     PurchaseReservedDBInstancesOfferingMessage.add_member(:reserved_db_instances_offering_id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ReservedDBInstancesOfferingId"))
     PurchaseReservedDBInstancesOfferingMessage.add_member(:reserved_db_instance_id, Shapes::ShapeRef.new(shape: String, location_name: "ReservedDBInstanceId"))
@@ -2522,11 +2712,17 @@ module Aws::RDS
     ReservedDBInstance.add_member(:lease_id, Shapes::ShapeRef.new(shape: String, location_name: "LeaseId"))
     ReservedDBInstance.struct_class = Types::ReservedDBInstance
 
+    ReservedDBInstanceAlreadyExistsFault.struct_class = Types::ReservedDBInstanceAlreadyExistsFault
+
     ReservedDBInstanceList.member = Shapes::ShapeRef.new(shape: ReservedDBInstance, location_name: "ReservedDBInstance")
 
     ReservedDBInstanceMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReservedDBInstanceMessage.add_member(:reserved_db_instances, Shapes::ShapeRef.new(shape: ReservedDBInstanceList, location_name: "ReservedDBInstances"))
     ReservedDBInstanceMessage.struct_class = Types::ReservedDBInstanceMessage
+
+    ReservedDBInstanceNotFoundFault.struct_class = Types::ReservedDBInstanceNotFoundFault
+
+    ReservedDBInstanceQuotaExceededFault.struct_class = Types::ReservedDBInstanceQuotaExceededFault
 
     ReservedDBInstancesOffering.add_member(:reserved_db_instances_offering_id, Shapes::ShapeRef.new(shape: String, location_name: "ReservedDBInstancesOfferingId"))
     ReservedDBInstancesOffering.add_member(:db_instance_class, Shapes::ShapeRef.new(shape: String, location_name: "DBInstanceClass"))
@@ -2546,6 +2742,8 @@ module Aws::RDS
     ReservedDBInstancesOfferingMessage.add_member(:reserved_db_instances_offerings, Shapes::ShapeRef.new(shape: ReservedDBInstancesOfferingList, location_name: "ReservedDBInstancesOfferings"))
     ReservedDBInstancesOfferingMessage.struct_class = Types::ReservedDBInstancesOfferingMessage
 
+    ReservedDBInstancesOfferingNotFoundFault.struct_class = Types::ReservedDBInstancesOfferingNotFoundFault
+
     ResetDBClusterParameterGroupMessage.add_member(:db_cluster_parameter_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DBClusterParameterGroupName"))
     ResetDBClusterParameterGroupMessage.add_member(:reset_all_parameters, Shapes::ShapeRef.new(shape: Boolean, location_name: "ResetAllParameters"))
     ResetDBClusterParameterGroupMessage.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
@@ -2555,6 +2753,8 @@ module Aws::RDS
     ResetDBParameterGroupMessage.add_member(:reset_all_parameters, Shapes::ShapeRef.new(shape: Boolean, location_name: "ResetAllParameters"))
     ResetDBParameterGroupMessage.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     ResetDBParameterGroupMessage.struct_class = Types::ResetDBParameterGroupMessage
+
+    ResourceNotFoundFault.struct_class = Types::ResourceNotFoundFault
 
     ResourcePendingMaintenanceActions.add_member(:resource_identifier, Shapes::ShapeRef.new(shape: String, location_name: "ResourceIdentifier"))
     ResourcePendingMaintenanceActions.add_member(:pending_maintenance_action_details, Shapes::ShapeRef.new(shape: PendingMaintenanceActionDetails, location_name: "PendingMaintenanceActionDetails"))
@@ -2778,6 +2978,12 @@ module Aws::RDS
     RevokeDBSecurityGroupIngressResult.add_member(:db_security_group, Shapes::ShapeRef.new(shape: DBSecurityGroup, location_name: "DBSecurityGroup"))
     RevokeDBSecurityGroupIngressResult.struct_class = Types::RevokeDBSecurityGroupIngressResult
 
+    SNSInvalidTopicFault.struct_class = Types::SNSInvalidTopicFault
+
+    SNSNoAuthorizationFault.struct_class = Types::SNSNoAuthorizationFault
+
+    SNSTopicArnNotFoundFault.struct_class = Types::SNSTopicArnNotFoundFault
+
     ScalingConfiguration.add_member(:min_capacity, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "MinCapacity"))
     ScalingConfiguration.add_member(:max_capacity, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "MaxCapacity"))
     ScalingConfiguration.add_member(:auto_pause, Shapes::ShapeRef.new(shape: BooleanOptional, location_name: "AutoPause"))
@@ -2792,7 +2998,13 @@ module Aws::RDS
     ScalingConfigurationInfo.add_member(:timeout_action, Shapes::ShapeRef.new(shape: String, location_name: "TimeoutAction"))
     ScalingConfigurationInfo.struct_class = Types::ScalingConfigurationInfo
 
+    SharedSnapshotQuotaExceededFault.struct_class = Types::SharedSnapshotQuotaExceededFault
+
+    SnapshotQuotaExceededFault.struct_class = Types::SnapshotQuotaExceededFault
+
     SourceIdsList.member = Shapes::ShapeRef.new(shape: String, location_name: "SourceId")
+
+    SourceNotFoundFault.struct_class = Types::SourceNotFoundFault
 
     SourceRegion.add_member(:region_name, Shapes::ShapeRef.new(shape: String, location_name: "RegionName"))
     SourceRegion.add_member(:endpoint, Shapes::ShapeRef.new(shape: String, location_name: "Endpoint"))
@@ -2861,6 +3073,10 @@ module Aws::RDS
     StopDBInstanceResult.add_member(:db_instance, Shapes::ShapeRef.new(shape: DBInstance, location_name: "DBInstance"))
     StopDBInstanceResult.struct_class = Types::StopDBInstanceResult
 
+    StorageQuotaExceededFault.struct_class = Types::StorageQuotaExceededFault
+
+    StorageTypeNotSupportedFault.struct_class = Types::StorageTypeNotSupportedFault
+
     StringList.member = Shapes::ShapeRef.new(shape: String)
 
     Subnet.add_member(:subnet_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier"))
@@ -2868,9 +3084,17 @@ module Aws::RDS
     Subnet.add_member(:subnet_status, Shapes::ShapeRef.new(shape: String, location_name: "SubnetStatus"))
     Subnet.struct_class = Types::Subnet
 
+    SubnetAlreadyInUse.struct_class = Types::SubnetAlreadyInUse
+
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier")
 
     SubnetList.member = Shapes::ShapeRef.new(shape: Subnet, location_name: "Subnet")
+
+    SubscriptionAlreadyExistFault.struct_class = Types::SubscriptionAlreadyExistFault
+
+    SubscriptionCategoryNotFoundFault.struct_class = Types::SubscriptionCategoryNotFoundFault
+
+    SubscriptionNotFoundFault.struct_class = Types::SubscriptionNotFoundFault
 
     SupportedCharacterSetsList.member = Shapes::ShapeRef.new(shape: CharacterSet, location_name: "CharacterSet")
 

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
@@ -10,5 +10,1237 @@ module Aws::RDS
 
     extend Aws::Errors::DynamicErrors
 
+    class AuthorizationAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::AuthorizationAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::AuthorizationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::AuthorizationQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BackupPolicyNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::BackupPolicyNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CertificateNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::CertificateNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CustomAvailabilityZoneAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::CustomAvailabilityZoneAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CustomAvailabilityZoneNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::CustomAvailabilityZoneNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CustomAvailabilityZoneQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::CustomAvailabilityZoneQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterBacktrackNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterBacktrackNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterEndpointAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterEndpointAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterEndpointNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterEndpointNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterEndpointQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterEndpointQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterRoleAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterRoleQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterRoleQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBClusterSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBClusterSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceAutomatedBackupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceAutomatedBackupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceAutomatedBackupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceAutomatedBackupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceRoleAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceRoleAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBInstanceRoleQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBInstanceRoleQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBLogFileNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBLogFileNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyTargetAlreadyRegisteredFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyTargetAlreadyRegisteredFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyTargetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyTargetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBProxyTargetNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBProxyTargetNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSecurityGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSecurityGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupNotSupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSecurityGroupNotSupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSecurityGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSecurityGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupDoesNotCoverEnoughAZs < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetGroupDoesNotCoverEnoughAZs] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupNotAllowedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetGroupNotAllowedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBSubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBSubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DBUpgradeDependencyFailureFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DBUpgradeDependencyFailureFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DomainNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::DomainNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EventSubscriptionQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::EventSubscriptionQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ExportTaskAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ExportTaskAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ExportTaskNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ExportTaskNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GlobalClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::GlobalClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GlobalClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::GlobalClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class GlobalClusterQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::GlobalClusterQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamRoleMissingPermissionsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::IamRoleMissingPermissionsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IamRoleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::IamRoleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstallationMediaAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InstallationMediaAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstallationMediaNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InstallationMediaNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InstanceQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InstanceQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InsufficientDBClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientDBInstanceCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InsufficientDBInstanceCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientStorageClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InsufficientStorageClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterEndpointStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBClusterEndpointStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBClusterSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBInstanceAutomatedBackupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBInstanceAutomatedBackupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBInstanceStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBInstanceStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBProxyStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBProxyStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSecurityGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBSecurityGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetGroupFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBSubnetGroupFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBSubnetGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDBSubnetStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidDBSubnetStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidEventSubscriptionStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidEventSubscriptionStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidExportOnlyFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidExportOnlyFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidExportSourceStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidExportSourceStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidExportTaskStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidExportTaskStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidGlobalClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidGlobalClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOptionGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidOptionGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRestoreFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidRestoreFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3BucketFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidS3BucketFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class KMSKeyNotAccessibleFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::KMSKeyNotAccessibleFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OptionGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::OptionGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OptionGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::OptionGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OptionGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::OptionGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PointInTimeRestoreNotEnabledFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::PointInTimeRestoreNotEnabledFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProvisionedIopsNotAvailableInAZFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ProvisionedIopsNotAvailableInAZFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedDBInstanceAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ReservedDBInstanceAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedDBInstanceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ReservedDBInstanceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedDBInstanceQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ReservedDBInstanceQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedDBInstancesOfferingNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ReservedDBInstancesOfferingNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::ResourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSInvalidTopicFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SNSInvalidTopicFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSNoAuthorizationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SNSNoAuthorizationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSTopicArnNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SNSTopicArnNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SharedSnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SharedSnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::StorageQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class StorageTypeNotSupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::StorageTypeNotSupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetAlreadyInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SubnetAlreadyInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionAlreadyExistFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SubscriptionAlreadyExistFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionCategoryNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SubscriptionCategoryNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDS::Types::SubscriptionNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
@@ -350,6 +350,29 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified CIDR IP range or Amazon EC2 security group is already
+    # authorized for the specified DB security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/AuthorizationAlreadyExistsFault AWS API Documentation
+    #
+    class AuthorizationAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified CIDR IP range or Amazon EC2 security group might not be
+    # authorized for the specified DB security group.
+    #
+    # Or, RDS might not be authorized to perform necessary actions using IAM
+    # on your behalf.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/AuthorizationNotFoundFault AWS API Documentation
+    #
+    class AuthorizationNotFoundFault < Aws::EmptyStructure; end
+
+    # The DB security group authorization quota has been reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/AuthorizationQuotaExceededFault AWS API Documentation
+    #
+    class AuthorizationQuotaExceededFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass AuthorizeDBSecurityGroupIngressMessage
     #   data as a hash:
     #
@@ -540,6 +563,10 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/BackupPolicyNotFoundFault AWS API Documentation
+    #
+    class BackupPolicyNotFoundFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass CancelExportTaskMessage
     #   data as a hash:
     #
@@ -627,6 +654,12 @@ module Aws::RDS
       :marker)
       include Aws::Structure
     end
+
+    # `CertificateIdentifier` doesn't refer to an existing certificate.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/CertificateNotFoundFault AWS API Documentation
+    #
+    class CertificateNotFoundFault < Aws::EmptyStructure; end
 
     # This data type is used as a response element in the action
     # `DescribeDBEngineVersions`.
@@ -4506,6 +4539,13 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `CustomAvailabilityZoneName` is already used by an existing custom
+    # Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/CustomAvailabilityZoneAlreadyExistsFault AWS API Documentation
+    #
+    class CustomAvailabilityZoneAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
     #   `DescribeCustomAvailabilityZones` request. If this parameter is
@@ -4524,6 +4564,19 @@ module Aws::RDS
       :custom_availability_zones)
       include Aws::Structure
     end
+
+    # `CustomAvailabilityZoneId` doesn't refer to an existing custom
+    # Availability Zone identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/CustomAvailabilityZoneNotFoundFault AWS API Documentation
+    #
+    class CustomAvailabilityZoneNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of custom Availability Zones.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/CustomAvailabilityZoneQuotaExceededFault AWS API Documentation
+    #
+    class CustomAvailabilityZoneQuotaExceededFault < Aws::EmptyStructure; end
 
     # Contains the details of an Amazon Aurora DB cluster.
     #
@@ -4892,6 +4945,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The user already has a DB cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # This data type is used as a response element in the
     # `DescribeDBClusterBacktracks` action.
     #
@@ -4964,6 +5023,12 @@ module Aws::RDS
       :db_cluster_backtracks)
       include Aws::Structure
     end
+
+    # `BacktrackIdentifier` doesn't refer to an existing backtrack.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterBacktrackNotFoundFault AWS API Documentation
+    #
+    class DBClusterBacktrackNotFoundFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] db_cluster_identifier
     #   A user-supplied DB cluster identifier. This identifier is the unique
@@ -5080,6 +5145,13 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified custom endpoint can't be created because it already
+    # exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterEndpointAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterEndpointAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
     #   `DescribeDBClusterEndpoints` request. If this parameter is
@@ -5099,6 +5171,18 @@ module Aws::RDS
       :db_cluster_endpoints)
       include Aws::Structure
     end
+
+    # The specified custom endpoint doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterEndpointNotFoundFault AWS API Documentation
+    #
+    class DBClusterEndpointNotFoundFault < Aws::EmptyStructure; end
+
+    # The cluster already has the maximum number of custom endpoints.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterEndpointQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterEndpointQuotaExceededFault < Aws::EmptyStructure; end
 
     # Contains information about an instance that is part of a DB cluster.
     #
@@ -5156,6 +5240,12 @@ module Aws::RDS
       :db_clusters)
       include Aws::Structure
     end
+
+    # `DBClusterIdentifier` doesn't refer to an existing DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterNotFoundFault AWS API Documentation
+    #
+    class DBClusterNotFoundFault < Aws::EmptyStructure; end
 
     # Contains status information for a DB cluster option group.
     #
@@ -5253,6 +5343,13 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `DBClusterParameterGroupName` doesn't refer to an existing DB cluster
+    # parameter group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBClusterParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
     #   `DescribeDBClusterParameterGroups` request. If this parameter is
@@ -5271,6 +5368,13 @@ module Aws::RDS
       :db_cluster_parameter_groups)
       include Aws::Structure
     end
+
+    # The user attempted to create a new DB cluster and the user has already
+    # reached the maximum allowed DB cluster quota.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes an AWS Identity and Access Management (IAM) role that is
     # associated with a DB cluster.
@@ -5309,6 +5413,27 @@ module Aws::RDS
       :feature_name)
       include Aws::Structure
     end
+
+    # The specified IAM role Amazon Resource Name (ARN) is already
+    # associated with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterRoleAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterRoleAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified IAM role Amazon Resource Name (ARN) isn't associated
+    # with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterRoleNotFoundFault AWS API Documentation
+    #
+    class DBClusterRoleNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the maximum number of IAM roles that can be
+    # associated with the specified DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterRoleQuotaExceededFault AWS API Documentation
+    #
+    class DBClusterRoleQuotaExceededFault < Aws::EmptyStructure; end
 
     # Contains the details for an Amazon RDS DB cluster snapshot
     #
@@ -5432,6 +5557,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The user already has a DB cluster snapshot with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBClusterSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the name and values of a manual DB cluster snapshot
     # attribute.
     #
@@ -5512,6 +5643,13 @@ module Aws::RDS
       :db_cluster_snapshots)
       include Aws::Structure
     end
+
+    # `DBClusterSnapshotIdentifier` doesn't refer to an existing DB cluster
+    # snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBClusterSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBClusterSnapshotNotFoundFault < Aws::EmptyStructure; end
 
     # This data type is used as a response element in the action
     # `DescribeDBEngineVersions`.
@@ -6045,6 +6183,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The user already has a DB instance with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceAlreadyExistsFault AWS API Documentation
+    #
+    class DBInstanceAlreadyExistsFault < Aws::EmptyStructure; end
+
     # An automated backup of a DB instance. It it consists of system
     # backups, transaction logs, and the database instance properties that
     # existed at the time you deleted the source instance.
@@ -6217,6 +6361,20 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # No automated backup for this DB instance was found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceAutomatedBackupNotFoundFault AWS API Documentation
+    #
+    class DBInstanceAutomatedBackupNotFoundFault < Aws::EmptyStructure; end
+
+    # The quota for retained automated backups was exceeded. This prevents
+    # you from retaining any additional automated backups. The retained
+    # automated backups quota is the same as your DB Instance quota.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceAutomatedBackupQuotaExceededFault AWS API Documentation
+    #
+    class DBInstanceAutomatedBackupQuotaExceededFault < Aws::EmptyStructure; end
+
     # Contains the result of a successful invocation of the
     # `DescribeDBInstances` action.
     #
@@ -6237,6 +6395,12 @@ module Aws::RDS
       :db_instances)
       include Aws::Structure
     end
+
+    # `DBInstanceIdentifier` doesn't refer to an existing DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceNotFoundFault AWS API Documentation
+    #
+    class DBInstanceNotFoundFault < Aws::EmptyStructure; end
 
     # Describes an AWS Identity and Access Management (IAM) role that is
     # associated with a DB instance.
@@ -6276,6 +6440,27 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified `RoleArn` or `FeatureName` value is already associated
+    # with the DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceRoleAlreadyExistsFault AWS API Documentation
+    #
+    class DBInstanceRoleAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified `RoleArn` value doesn't match the specified feature for
+    # the DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceRoleNotFoundFault AWS API Documentation
+    #
+    class DBInstanceRoleNotFoundFault < Aws::EmptyStructure; end
+
+    # You can't associate any more AWS Identity and Access Management (IAM)
+    # roles with the DB instance because the quota has been reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstanceRoleQuotaExceededFault AWS API Documentation
+    #
+    class DBInstanceRoleQuotaExceededFault < Aws::EmptyStructure; end
+
     # Provides a list of status information for a DB instance.
     #
     # @!attribute [rw] status_type
@@ -6307,6 +6492,12 @@ module Aws::RDS
       :message)
       include Aws::Structure
     end
+
+    # `LogFileName` doesn't refer to an existing DB log file.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBLogFileNotFoundFault AWS API Documentation
+    #
+    class DBLogFileNotFoundFault < Aws::EmptyStructure; end
 
     # Contains the details of an Amazon RDS DB parameter group.
     #
@@ -6340,6 +6531,12 @@ module Aws::RDS
       :db_parameter_group_arn)
       include Aws::Structure
     end
+
+    # A DB parameter group with the same name exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
 
     # Contains the result of a successful invocation of the
     # `DescribeDBParameters` action.
@@ -6375,6 +6572,20 @@ module Aws::RDS
       :db_parameter_group_name)
       include Aws::Structure
     end
+
+    # `DBParameterGroupName` doesn't refer to an existing DB parameter
+    # group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBParameterGroupNotFoundFault AWS API Documentation
+    #
+    class DBParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # DB parameter groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # The status of the DB parameter group.
     #
@@ -6539,6 +6750,27 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified proxy name must be unique for all proxies owned by your
+    # AWS account in the specified AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyAlreadyExistsFault AWS API Documentation
+    #
+    class DBProxyAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified proxy name doesn't correspond to a proxy owned by your
+    # AWS accoutn in the specified AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyNotFoundFault AWS API Documentation
+    #
+    class DBProxyNotFoundFault < Aws::EmptyStructure; end
+
+    # Your AWS account already has the maximum number of proxies in the
+    # specified AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyQuotaExceededFault AWS API Documentation
+    #
+    class DBProxyQuotaExceededFault < Aws::EmptyStructure; end
+
     # <note markdown="1"> This is prerelease documentation for the RDS Database Proxy feature in
     # preview release. It is subject to change.
     #
@@ -6593,6 +6825,13 @@ module Aws::RDS
       :type)
       include Aws::Structure
     end
+
+    # The proxy is already associated with the specified RDS DB instance or
+    # Aurora DB cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyTargetAlreadyRegisteredFault AWS API Documentation
+    #
+    class DBProxyTargetAlreadyRegisteredFault < Aws::EmptyStructure; end
 
     # <note markdown="1"> This is prerelease documentation for the RDS Database Proxy feature in
     # preview release. It is subject to change.
@@ -6661,6 +6900,20 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified target group isn't available for a proxy owned by your
+    # AWS account in the specified AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyTargetGroupNotFoundFault AWS API Documentation
+    #
+    class DBProxyTargetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The specified RDS DB instance or Aurora DB cluster isn't available
+    # for a proxy owned by your AWS account in the specified AWS Region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBProxyTargetNotFoundFault AWS API Documentation
+    #
+    class DBProxyTargetNotFoundFault < Aws::EmptyStructure; end
+
     # Contains the details for an Amazon RDS DB security group.
     #
     # This data type is used as a response element in the
@@ -6706,6 +6959,13 @@ module Aws::RDS
       :db_security_group_arn)
       include Aws::Structure
     end
+
+    # A DB security group with the name specified in `DBSecurityGroupName`
+    # already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSecurityGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBSecurityGroupAlreadyExistsFault < Aws::EmptyStructure; end
 
     # This data type is used as a response element in the following actions:
     #
@@ -6753,6 +7013,25 @@ module Aws::RDS
       :db_security_groups)
       include Aws::Structure
     end
+
+    # `DBSecurityGroupName` doesn't refer to an existing DB security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSecurityGroupNotFoundFault AWS API Documentation
+    #
+    class DBSecurityGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # A DB security group isn't allowed for this action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSecurityGroupNotSupportedFault AWS API Documentation
+    #
+    class DBSecurityGroupNotSupportedFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # DB security groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSecurityGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBSecurityGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # Contains the details of an Amazon RDS DB snapshot.
     #
@@ -6922,6 +7201,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `DBSnapshotIdentifier` is already used by an existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class DBSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the name and values of a manual DB snapshot attribute
     #
     # Manual DB snapshot attributes are used to authorize other AWS accounts
@@ -7000,6 +7285,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `DBSnapshotIdentifier` doesn't refer to an existing DB snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSnapshotNotFoundFault AWS API Documentation
+    #
+    class DBSnapshotNotFoundFault < Aws::EmptyStructure; end
+
     # Contains the details of an Amazon RDS DB subnet group.
     #
     # This data type is used as a response element in the
@@ -7041,6 +7332,19 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `DBSubnetGroupName` is already used by an existing DB subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class DBSubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # Subnets in the DB subnet group should cover at least two Availability
+    # Zones unless there is only one Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetGroupDoesNotCoverEnoughAZs AWS API Documentation
+    #
+    class DBSubnetGroupDoesNotCoverEnoughAZs < Aws::EmptyStructure; end
+
     # Contains the result of a successful invocation of the
     # `DescribeDBSubnetGroups` action.
     #
@@ -7061,6 +7365,40 @@ module Aws::RDS
       :db_subnet_groups)
       include Aws::Structure
     end
+
+    # The DBSubnetGroup shouldn't be specified while creating read replicas
+    # that lie in the same region as the source instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetGroupNotAllowedFault AWS API Documentation
+    #
+    class DBSubnetGroupNotAllowedFault < Aws::EmptyStructure; end
+
+    # `DBSubnetGroupName` doesn't refer to an existing DB subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetGroupNotFoundFault AWS API Documentation
+    #
+    class DBSubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # DB subnet groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # subnets in a DB subnet groups.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBSubnetQuotaExceededFault AWS API Documentation
+    #
+    class DBSubnetQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The DB upgrade failed because a resource the DB depends on can't be
+    # modified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBUpgradeDependencyFailureFault AWS API Documentation
+    #
+    class DBUpgradeDependencyFailureFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass DeleteCustomAvailabilityZoneMessage
     #   data as a hash:
@@ -10501,6 +10839,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `Domain` doesn't refer to an existing Active Directory domain.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DomainNotFoundFault AWS API Documentation
+    #
+    class DomainNotFoundFault < Aws::EmptyStructure; end
+
     # A range of double values.
     #
     # @!attribute [rw] from
@@ -10855,6 +11199,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # You have reached the maximum number of event subscriptions.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/EventSubscriptionQuotaExceededFault AWS API Documentation
+    #
+    class EventSubscriptionQuotaExceededFault < Aws::EmptyStructure; end
+
     # Data returned by the **DescribeEventSubscriptions** action.
     #
     # @!attribute [rw] marker
@@ -11003,6 +11353,18 @@ module Aws::RDS
       :warning_message)
       include Aws::Structure
     end
+
+    # You can't start an export task that's already running.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ExportTaskAlreadyExistsFault AWS API Documentation
+    #
+    class ExportTaskAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The export task doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ExportTaskNotFoundFault AWS API Documentation
+    #
+    class ExportTaskNotFoundFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] marker
     #   A pagination token that can be used in a later `DescribeExportTasks`
@@ -11179,6 +11541,10 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/GlobalClusterAlreadyExistsFault AWS API Documentation
+    #
+    class GlobalClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # A data structure with information about any primary and secondary
     # clusters associated with an Aurora global database.
     #
@@ -11205,6 +11571,14 @@ module Aws::RDS
       :is_writer)
       include Aws::Structure
     end
+
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/GlobalClusterNotFoundFault AWS API Documentation
+    #
+    class GlobalClusterNotFoundFault < Aws::EmptyStructure; end
+
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/GlobalClusterQuotaExceededFault AWS API Documentation
+    #
+    class GlobalClusterQuotaExceededFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] marker
     #   An optional pagination token provided by a previous
@@ -11244,6 +11618,19 @@ module Aws::RDS
       :cidrip)
       include Aws::Structure
     end
+
+    # The IAM role requires additional permissions to export to an Amazon S3
+    # bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/IamRoleMissingPermissionsFault AWS API Documentation
+    #
+    class IamRoleMissingPermissionsFault < Aws::EmptyStructure; end
+
+    # The IAM role is missing for exporting to an Amazon S3 bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/IamRoleNotFoundFault AWS API Documentation
+    #
+    class IamRoleNotFoundFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ImportInstallationMediaMessage
     #   data as a hash:
@@ -11373,6 +11760,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The specified installation medium has already been imported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InstallationMediaAlreadyExistsFault AWS API Documentation
+    #
+    class InstallationMediaAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the cause of an installation media failure. Installation
     # media is used for a DB engine that requires an on-premises customer
     # provided license, such as Microsoft SQL Server.
@@ -11406,6 +11799,199 @@ module Aws::RDS
       :installation_media)
       include Aws::Structure
     end
+
+    # `InstallationMediaID` doesn't refer to an existing installation
+    # medium.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InstallationMediaNotFoundFault AWS API Documentation
+    #
+    class InstallationMediaNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # DB instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InstanceQuotaExceededFault AWS API Documentation
+    #
+    class InstanceQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The DB cluster doesn't have enough capacity for the current
+    # operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InsufficientDBClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientDBClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The specified DB instance class isn't available in the specified
+    # Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InsufficientDBInstanceCapacityFault AWS API Documentation
+    #
+    class InsufficientDBInstanceCapacityFault < Aws::EmptyStructure; end
+
+    # There is insufficient storage available for the current action. You
+    # might be able to resolve this error by updating your subnet group to
+    # use different Availability Zones that have more storage available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InsufficientStorageClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientStorageClusterCapacityFault < Aws::EmptyStructure; end
+
+    # `Capacity` isn't a valid Aurora Serverless DB cluster capacity. Valid
+    # capacity values are `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBClusterCapacityFault AWS API Documentation
+    #
+    class InvalidDBClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The requested operation can't be performed on the endpoint while the
+    # endpoint is in this state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBClusterEndpointStateFault AWS API Documentation
+    #
+    class InvalidDBClusterEndpointStateFault < Aws::EmptyStructure; end
+
+    # The supplied value isn't a valid DB cluster snapshot state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBClusterSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBClusterSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The requested operation can't be performed while the cluster is in
+    # this state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBClusterStateFault AWS API Documentation
+    #
+    class InvalidDBClusterStateFault < Aws::EmptyStructure; end
+
+    # The automated backup is in an invalid state. For example, this
+    # automated backup is associated with an active instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBInstanceAutomatedBackupStateFault AWS API Documentation
+    #
+    class InvalidDBInstanceAutomatedBackupStateFault < Aws::EmptyStructure; end
+
+    # The DB instance isn't in a valid state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBInstanceStateFault AWS API Documentation
+    #
+    class InvalidDBInstanceStateFault < Aws::EmptyStructure; end
+
+    # The DB parameter group is in use or is in an invalid state. If you are
+    # attempting to delete the parameter group, you can't delete it when
+    # the parameter group is in this state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidDBParameterGroupStateFault < Aws::EmptyStructure; end
+
+    # The requested operation can't be performed while the proxy is in this
+    # state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBProxyStateFault AWS API Documentation
+    #
+    class InvalidDBProxyStateFault < Aws::EmptyStructure; end
+
+    # The state of the DB security group doesn't allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBSecurityGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSecurityGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the DB snapshot doesn't allow deletion.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBSnapshotStateFault AWS API Documentation
+    #
+    class InvalidDBSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The DBSubnetGroup doesn't belong to the same VPC as that of an
+    # existing cross-region read replica of the same source instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBSubnetGroupFault AWS API Documentation
+    #
+    class InvalidDBSubnetGroupFault < Aws::EmptyStructure; end
+
+    # The DB subnet group cannot be deleted because it's in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBSubnetGroupStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetGroupStateFault < Aws::EmptyStructure; end
+
+    # The DB subnet isn't in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidDBSubnetStateFault AWS API Documentation
+    #
+    class InvalidDBSubnetStateFault < Aws::EmptyStructure; end
+
+    # This error can occur if someone else is modifying a subscription. You
+    # should retry the action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidEventSubscriptionStateFault AWS API Documentation
+    #
+    class InvalidEventSubscriptionStateFault < Aws::EmptyStructure; end
+
+    # The export is invalid for exporting to an Amazon S3 bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidExportOnlyFault AWS API Documentation
+    #
+    class InvalidExportOnlyFault < Aws::EmptyStructure; end
+
+    # The state of the export snapshot is invalid for exporting to an Amazon
+    # S3 bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidExportSourceStateFault AWS API Documentation
+    #
+    class InvalidExportSourceStateFault < Aws::EmptyStructure; end
+
+    # You can't cancel an export task that has completed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidExportTaskStateFault AWS API Documentation
+    #
+    class InvalidExportTaskStateFault < Aws::EmptyStructure; end
+
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidGlobalClusterStateFault AWS API Documentation
+    #
+    class InvalidGlobalClusterStateFault < Aws::EmptyStructure; end
+
+    # The option group isn't in the *available* state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidOptionGroupStateFault AWS API Documentation
+    #
+    class InvalidOptionGroupStateFault < Aws::EmptyStructure; end
+
+    # Cannot restore from VPC backup to non-VPC DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidRestoreFault AWS API Documentation
+    #
+    class InvalidRestoreFault < Aws::EmptyStructure; end
+
+    # The specified Amazon S3 bucket name can't be found or Amazon RDS
+    # isn't authorized to access the specified Amazon S3 bucket. Verify the
+    # **SourceS3BucketName** and **S3IngestionRoleArn** values and try
+    # again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidS3BucketFault AWS API Documentation
+    #
+    class InvalidS3BucketFault < Aws::EmptyStructure; end
+
+    # The requested subnet is invalid, or multiple subnets were requested
+    # that are not all in a common VPC.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # The DB subnet group doesn't cover all Availability Zones after it's
+    # created because of users' change.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
+
+    # An error occurred accessing an AWS KMS key.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/KMSKeyNotAccessibleFault AWS API Documentation
+    #
+    class KMSKeyNotAccessibleFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListTagsForResourceMessage
     #   data as a hash:
@@ -13653,6 +14239,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The option group you are trying to create already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/OptionGroupAlreadyExistsFault AWS API Documentation
+    #
+    class OptionGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Provides information on the option groups the DB instance is a member
     # of.
     #
@@ -13674,6 +14266,12 @@ module Aws::RDS
       :status)
       include Aws::Structure
     end
+
+    # The specified option group could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/OptionGroupNotFoundFault AWS API Documentation
+    #
+    class OptionGroupNotFoundFault < Aws::EmptyStructure; end
 
     # Available option.
     #
@@ -13846,6 +14444,12 @@ module Aws::RDS
       :marker)
       include Aws::Structure
     end
+
+    # The quota of 20 option groups was exceeded for this AWS account.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/OptionGroupQuotaExceededFault AWS API Documentation
+    #
+    class OptionGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # List of option groups.
     #
@@ -14397,6 +15001,13 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # `SourceDBInstanceIdentifier` refers to a DB instance with
+    # `BackupRetentionPeriod` equal to 0.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/PointInTimeRestoreNotEnabledFault AWS API Documentation
+    #
+    class PointInTimeRestoreNotEnabledFault < Aws::EmptyStructure; end
+
     # Contains the processor features of a DB instance class.
     #
     # To specify the number of CPU cores, use the `coreCount` feature name
@@ -14586,6 +15197,12 @@ module Aws::RDS
       :db_instance)
       include Aws::Structure
     end
+
+    # Provisioned IOPS not available in the specified Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ProvisionedIopsNotAvailableInAZFault AWS API Documentation
+    #
+    class ProvisionedIopsNotAvailableInAZFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass PurchaseReservedDBInstancesOfferingMessage
     #   data as a hash:
@@ -15068,6 +15685,12 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # User already has a reservation with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ReservedDBInstanceAlreadyExistsFault AWS API Documentation
+    #
+    class ReservedDBInstanceAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the result of a successful invocation of the
     # `DescribeReservedDBInstances` action.
     #
@@ -15088,6 +15711,18 @@ module Aws::RDS
       :reserved_db_instances)
       include Aws::Structure
     end
+
+    # The specified reserved DB Instance not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ReservedDBInstanceNotFoundFault AWS API Documentation
+    #
+    class ReservedDBInstanceNotFoundFault < Aws::EmptyStructure; end
+
+    # Request would exceed the user's DB Instance quota.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ReservedDBInstanceQuotaExceededFault AWS API Documentation
+    #
+    class ReservedDBInstanceQuotaExceededFault < Aws::EmptyStructure; end
 
     # This data type is used as a response element in the
     # `DescribeReservedDBInstancesOfferings` action.
@@ -15168,6 +15803,12 @@ module Aws::RDS
       :reserved_db_instances_offerings)
       include Aws::Structure
     end
+
+    # Specified offering does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ReservedDBInstancesOfferingNotFoundFault AWS API Documentation
+    #
+    class ReservedDBInstancesOfferingNotFoundFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ResetDBClusterParameterGroupMessage
     #   data as a hash:
@@ -15293,6 +15934,12 @@ module Aws::RDS
       :parameters)
       include Aws::Structure
     end
+
+    # The specified resource ID was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ResourceNotFoundFault AWS API Documentation
+    #
+    class ResourceNotFoundFault < Aws::EmptyStructure; end
 
     # Describes the pending maintenance actions for a resource.
     #
@@ -17746,6 +18393,25 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # SNS has responded that there is a problem with the SND topic
+    # specified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SNSInvalidTopicFault AWS API Documentation
+    #
+    class SNSInvalidTopicFault < Aws::EmptyStructure; end
+
+    # You do not have permission to publish to the SNS topic ARN.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SNSNoAuthorizationFault AWS API Documentation
+    #
+    class SNSNoAuthorizationFault < Aws::EmptyStructure; end
+
+    # The SNS topic ARN does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SNSTopicArnNotFoundFault AWS API Documentation
+    #
+    class SNSTopicArnNotFoundFault < Aws::EmptyStructure; end
+
     # Contains the scaling configuration of an Aurora Serverless DB cluster.
     #
     # For more information, see [Using Amazon Aurora Serverless][1] in the
@@ -17892,6 +18558,26 @@ module Aws::RDS
       :timeout_action)
       include Aws::Structure
     end
+
+    # You have exceeded the maximum number of accounts that you can share a
+    # manual DB snapshot with.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SharedSnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SharedSnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # DB snapshots.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SnapshotQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The requested source could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SourceNotFoundFault AWS API Documentation
+    #
+    class SourceNotFoundFault < Aws::EmptyStructure; end
 
     # Contains an AWS Region name as the result of a successful call to the
     # `DescribeSourceRegions` action.
@@ -18284,6 +18970,20 @@ module Aws::RDS
       include Aws::Structure
     end
 
+    # The request would result in the user exceeding the allowed amount of
+    # storage available across all DB instances.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/StorageQuotaExceededFault AWS API Documentation
+    #
+    class StorageQuotaExceededFault < Aws::EmptyStructure; end
+
+    # Storage of the `StorageType` specified can't be associated with the
+    # DB instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/StorageTypeNotSupportedFault AWS API Documentation
+    #
+    class StorageTypeNotSupportedFault < Aws::EmptyStructure; end
+
     # This data type is used as a response element in the
     # `DescribeDBSubnetGroups` action.
     #
@@ -18310,6 +19010,30 @@ module Aws::RDS
       :subnet_status)
       include Aws::Structure
     end
+
+    # The DB subnet is already in use in the Availability Zone.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SubnetAlreadyInUse AWS API Documentation
+    #
+    class SubnetAlreadyInUse < Aws::EmptyStructure; end
+
+    # The supplied subscription name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SubscriptionAlreadyExistFault AWS API Documentation
+    #
+    class SubscriptionAlreadyExistFault < Aws::EmptyStructure; end
+
+    # The supplied category does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SubscriptionCategoryNotFoundFault AWS API Documentation
+    #
+    class SubscriptionCategoryNotFoundFault < Aws::EmptyStructure; end
+
+    # The subscription name does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/SubscriptionNotFoundFault AWS API Documentation
+    #
+    class SubscriptionNotFoundFault < Aws::EmptyStructure; end
 
     # Metadata assigned to an Amazon RDS resource consisting of a key-value
     # pair.

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client_api.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client_api.rb
@@ -182,6 +182,8 @@ module Aws::RDSDataService
     ForbiddenException.add_member(:message, Shapes::ShapeRef.new(shape: ErrorMessage, location_name: "message"))
     ForbiddenException.struct_class = Types::ForbiddenException
 
+    InternalServerErrorException.struct_class = Types::InternalServerErrorException
+
     LongArray.member = Shapes::ShapeRef.new(shape: BoxedLong)
 
     Metadata.member = Shapes::ShapeRef.new(shape: ColumnMetadata)
@@ -214,6 +216,8 @@ module Aws::RDSDataService
     RollbackTransactionResponse.struct_class = Types::RollbackTransactionResponse
 
     Row.member = Shapes::ShapeRef.new(shape: Value)
+
+    ServiceUnavailableError.struct_class = Types::ServiceUnavailableError
 
     SqlParameter.add_member(:name, Shapes::ShapeRef.new(shape: ParameterName, location_name: "name"))
     SqlParameter.add_member(:type_hint, Shapes::ShapeRef.new(shape: TypeHint, location_name: "typeHint"))

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/errors.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/errors.rb
@@ -42,6 +42,17 @@ module Aws::RDSDataService
 
     end
 
+    class InternalServerErrorException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDSDataService::Types::InternalServerErrorException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class NotFoundException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -54,6 +65,17 @@ module Aws::RDSDataService
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class ServiceUnavailableError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::RDSDataService::Types::ServiceUnavailableError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/types.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/types.rb
@@ -644,6 +644,12 @@ module Aws::RDSDataService
       include Aws::Structure
     end
 
+    # An internal error occurred.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-data-2018-08-01/InternalServerErrorException AWS API Documentation
+    #
+    class InternalServerErrorException < Aws::EmptyStructure; end
+
     # The `resourceArn`, `secretArn`, or `transactionId` value can't be
     # found.
     #
@@ -781,6 +787,12 @@ module Aws::RDSDataService
       :transaction_status)
       include Aws::Structure
     end
+
+    # The service specified by the `resourceArn` parameter is not available.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/rds-data-2018-08-01/ServiceUnavailableError AWS API Documentation
+    #
+    class ServiceUnavailableError < Aws::EmptyStructure; end
 
     # A parameter used in a SQL statement.
     #

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
@@ -429,6 +429,8 @@ module Aws::Redshift
     AcceptReservedNodeExchangeOutputMessage.add_member(:exchanged_reserved_node, Shapes::ShapeRef.new(shape: ReservedNode, location_name: "ExchangedReservedNode"))
     AcceptReservedNodeExchangeOutputMessage.struct_class = Types::AcceptReservedNodeExchangeOutputMessage
 
+    AccessToSnapshotDeniedFault.struct_class = Types::AccessToSnapshotDeniedFault
+
     AccountAttribute.add_member(:attribute_name, Shapes::ShapeRef.new(shape: String, location_name: "AttributeName"))
     AccountAttribute.add_member(:attribute_values, Shapes::ShapeRef.new(shape: AttributeValueList, location_name: "AttributeValues"))
     AccountAttribute.struct_class = Types::AccountAttribute
@@ -452,6 +454,12 @@ module Aws::Redshift
 
     AttributeValueTarget.add_member(:attribute_value, Shapes::ShapeRef.new(shape: String, location_name: "AttributeValue"))
     AttributeValueTarget.struct_class = Types::AttributeValueTarget
+
+    AuthorizationAlreadyExistsFault.struct_class = Types::AuthorizationAlreadyExistsFault
+
+    AuthorizationNotFoundFault.struct_class = Types::AuthorizationNotFoundFault
+
+    AuthorizationQuotaExceededFault.struct_class = Types::AuthorizationQuotaExceededFault
 
     AuthorizeClusterSecurityGroupIngressMessage.add_member(:cluster_security_group_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ClusterSecurityGroupName"))
     AuthorizeClusterSecurityGroupIngressMessage.add_member(:cidrip, Shapes::ShapeRef.new(shape: String, location_name: "CIDRIP"))
@@ -483,6 +491,10 @@ module Aws::Redshift
     BatchDeleteClusterSnapshotsResult.add_member(:errors, Shapes::ShapeRef.new(shape: BatchSnapshotOperationErrorList, location_name: "Errors"))
     BatchDeleteClusterSnapshotsResult.struct_class = Types::BatchDeleteClusterSnapshotsResult
 
+    BatchDeleteRequestSizeExceededFault.struct_class = Types::BatchDeleteRequestSizeExceededFault
+
+    BatchModifyClusterSnapshotsLimitExceededFault.struct_class = Types::BatchModifyClusterSnapshotsLimitExceededFault
+
     BatchModifyClusterSnapshotsMessage.add_member(:snapshot_identifier_list, Shapes::ShapeRef.new(shape: SnapshotIdentifierList, required: true, location_name: "SnapshotIdentifierList"))
     BatchModifyClusterSnapshotsMessage.add_member(:manual_snapshot_retention_period, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "ManualSnapshotRetentionPeriod"))
     BatchModifyClusterSnapshotsMessage.add_member(:force, Shapes::ShapeRef.new(shape: Boolean, location_name: "Force"))
@@ -495,6 +507,8 @@ module Aws::Redshift
     BatchSnapshotOperationErrorList.member = Shapes::ShapeRef.new(shape: SnapshotErrorMessage, location_name: "SnapshotErrorMessage")
 
     BatchSnapshotOperationErrors.member = Shapes::ShapeRef.new(shape: SnapshotErrorMessage, location_name: "SnapshotErrorMessage")
+
+    BucketNotFoundFault.struct_class = Types::BucketNotFoundFault
 
     CancelResizeMessage.add_member(:cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ClusterIdentifier"))
     CancelResizeMessage.struct_class = Types::CancelResizeMessage
@@ -547,6 +561,8 @@ module Aws::Redshift
     Cluster.add_member(:resize_info, Shapes::ShapeRef.new(shape: ResizeInfo, location_name: "ResizeInfo"))
     Cluster.struct_class = Types::Cluster
 
+    ClusterAlreadyExistsFault.struct_class = Types::ClusterAlreadyExistsFault
+
     ClusterAssociatedToSchedule.add_member(:cluster_identifier, Shapes::ShapeRef.new(shape: String, location_name: "ClusterIdentifier"))
     ClusterAssociatedToSchedule.add_member(:schedule_association_state, Shapes::ShapeRef.new(shape: ScheduleState, location_name: "ScheduleAssociationState"))
     ClusterAssociatedToSchedule.struct_class = Types::ClusterAssociatedToSchedule
@@ -583,11 +599,17 @@ module Aws::Redshift
 
     ClusterNodesList.member = Shapes::ShapeRef.new(shape: ClusterNode)
 
+    ClusterNotFoundFault.struct_class = Types::ClusterNotFoundFault
+
+    ClusterOnLatestRevisionFault.struct_class = Types::ClusterOnLatestRevisionFault
+
     ClusterParameterGroup.add_member(:parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupName"))
     ClusterParameterGroup.add_member(:parameter_group_family, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupFamily"))
     ClusterParameterGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
     ClusterParameterGroup.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     ClusterParameterGroup.struct_class = Types::ClusterParameterGroup
+
+    ClusterParameterGroupAlreadyExistsFault.struct_class = Types::ClusterParameterGroupAlreadyExistsFault
 
     ClusterParameterGroupDetails.add_member(:parameters, Shapes::ShapeRef.new(shape: ParametersList, location_name: "Parameters"))
     ClusterParameterGroupDetails.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -596,6 +618,10 @@ module Aws::Redshift
     ClusterParameterGroupNameMessage.add_member(:parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupName"))
     ClusterParameterGroupNameMessage.add_member(:parameter_group_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupStatus"))
     ClusterParameterGroupNameMessage.struct_class = Types::ClusterParameterGroupNameMessage
+
+    ClusterParameterGroupNotFoundFault.struct_class = Types::ClusterParameterGroupNotFoundFault
+
+    ClusterParameterGroupQuotaExceededFault.struct_class = Types::ClusterParameterGroupQuotaExceededFault
 
     ClusterParameterGroupStatus.add_member(:parameter_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ParameterGroupName"))
     ClusterParameterGroupStatus.add_member(:parameter_apply_status, Shapes::ShapeRef.new(shape: String, location_name: "ParameterApplyStatus"))
@@ -615,12 +641,16 @@ module Aws::Redshift
 
     ClusterParameterStatusList.member = Shapes::ShapeRef.new(shape: ClusterParameterStatus)
 
+    ClusterQuotaExceededFault.struct_class = Types::ClusterQuotaExceededFault
+
     ClusterSecurityGroup.add_member(:cluster_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ClusterSecurityGroupName"))
     ClusterSecurityGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
     ClusterSecurityGroup.add_member(:ec2_security_groups, Shapes::ShapeRef.new(shape: EC2SecurityGroupList, location_name: "EC2SecurityGroups"))
     ClusterSecurityGroup.add_member(:ip_ranges, Shapes::ShapeRef.new(shape: IPRangeList, location_name: "IPRanges"))
     ClusterSecurityGroup.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     ClusterSecurityGroup.struct_class = Types::ClusterSecurityGroup
+
+    ClusterSecurityGroupAlreadyExistsFault.struct_class = Types::ClusterSecurityGroupAlreadyExistsFault
 
     ClusterSecurityGroupMembership.add_member(:cluster_security_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ClusterSecurityGroupName"))
     ClusterSecurityGroupMembership.add_member(:status, Shapes::ShapeRef.new(shape: String, location_name: "Status"))
@@ -634,13 +664,23 @@ module Aws::Redshift
 
     ClusterSecurityGroupNameList.member = Shapes::ShapeRef.new(shape: String, location_name: "ClusterSecurityGroupName")
 
+    ClusterSecurityGroupNotFoundFault.struct_class = Types::ClusterSecurityGroupNotFoundFault
+
+    ClusterSecurityGroupQuotaExceededFault.struct_class = Types::ClusterSecurityGroupQuotaExceededFault
+
     ClusterSecurityGroups.member = Shapes::ShapeRef.new(shape: ClusterSecurityGroup, location_name: "ClusterSecurityGroup")
+
+    ClusterSnapshotAlreadyExistsFault.struct_class = Types::ClusterSnapshotAlreadyExistsFault
 
     ClusterSnapshotCopyStatus.add_member(:destination_region, Shapes::ShapeRef.new(shape: String, location_name: "DestinationRegion"))
     ClusterSnapshotCopyStatus.add_member(:retention_period, Shapes::ShapeRef.new(shape: Long, location_name: "RetentionPeriod"))
     ClusterSnapshotCopyStatus.add_member(:manual_snapshot_retention_period, Shapes::ShapeRef.new(shape: Integer, location_name: "ManualSnapshotRetentionPeriod"))
     ClusterSnapshotCopyStatus.add_member(:snapshot_copy_grant_name, Shapes::ShapeRef.new(shape: String, location_name: "SnapshotCopyGrantName"))
     ClusterSnapshotCopyStatus.struct_class = Types::ClusterSnapshotCopyStatus
+
+    ClusterSnapshotNotFoundFault.struct_class = Types::ClusterSnapshotNotFoundFault
+
+    ClusterSnapshotQuotaExceededFault.struct_class = Types::ClusterSnapshotQuotaExceededFault
 
     ClusterSubnetGroup.add_member(:cluster_subnet_group_name, Shapes::ShapeRef.new(shape: String, location_name: "ClusterSubnetGroupName"))
     ClusterSubnetGroup.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
@@ -650,11 +690,19 @@ module Aws::Redshift
     ClusterSubnetGroup.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     ClusterSubnetGroup.struct_class = Types::ClusterSubnetGroup
 
+    ClusterSubnetGroupAlreadyExistsFault.struct_class = Types::ClusterSubnetGroupAlreadyExistsFault
+
     ClusterSubnetGroupMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ClusterSubnetGroupMessage.add_member(:cluster_subnet_groups, Shapes::ShapeRef.new(shape: ClusterSubnetGroups, location_name: "ClusterSubnetGroups"))
     ClusterSubnetGroupMessage.struct_class = Types::ClusterSubnetGroupMessage
 
+    ClusterSubnetGroupNotFoundFault.struct_class = Types::ClusterSubnetGroupNotFoundFault
+
+    ClusterSubnetGroupQuotaExceededFault.struct_class = Types::ClusterSubnetGroupQuotaExceededFault
+
     ClusterSubnetGroups.member = Shapes::ShapeRef.new(shape: ClusterSubnetGroup, location_name: "ClusterSubnetGroup")
+
+    ClusterSubnetQuotaExceededFault.struct_class = Types::ClusterSubnetQuotaExceededFault
 
     ClusterVersion.add_member(:cluster_version, Shapes::ShapeRef.new(shape: String, location_name: "ClusterVersion"))
     ClusterVersion.add_member(:cluster_parameter_group_family, Shapes::ShapeRef.new(shape: String, location_name: "ClusterParameterGroupFamily"))
@@ -679,6 +727,8 @@ module Aws::Redshift
 
     CopyClusterSnapshotResult.add_member(:snapshot, Shapes::ShapeRef.new(shape: Snapshot, location_name: "Snapshot"))
     CopyClusterSnapshotResult.struct_class = Types::CopyClusterSnapshotResult
+
+    CopyToRegionDisabledFault.struct_class = Types::CopyToRegionDisabledFault
 
     CreateClusterMessage.add_member(:db_name, Shapes::ShapeRef.new(shape: String, location_name: "DBName"))
     CreateClusterMessage.add_member(:cluster_identifier, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ClusterIdentifier"))
@@ -886,6 +936,10 @@ module Aws::Redshift
     DeleteTagsMessage.add_member(:resource_name, Shapes::ShapeRef.new(shape: String, required: true, location_name: "ResourceName"))
     DeleteTagsMessage.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "TagKeys"))
     DeleteTagsMessage.struct_class = Types::DeleteTagsMessage
+
+    DependentServiceRequestThrottlingFault.struct_class = Types::DependentServiceRequestThrottlingFault
+
+    DependentServiceUnavailableFault.struct_class = Types::DependentServiceUnavailableFault
 
     DescribeAccountAttributesMessage.add_member(:attribute_names, Shapes::ShapeRef.new(shape: AttributeNameList, location_name: "AttributeNames"))
     DescribeAccountAttributesMessage.struct_class = Types::DescribeAccountAttributesMessage
@@ -1154,6 +1208,8 @@ module Aws::Redshift
     EventSubscription.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     EventSubscription.struct_class = Types::EventSubscription
 
+    EventSubscriptionQuotaExceededFault.struct_class = Types::EventSubscriptionQuotaExceededFault
+
     EventSubscriptionsList.member = Shapes::ShapeRef.new(shape: EventSubscription, location_name: "EventSubscription")
 
     EventSubscriptionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
@@ -1186,11 +1242,17 @@ module Aws::Redshift
     HsmClientCertificate.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     HsmClientCertificate.struct_class = Types::HsmClientCertificate
 
+    HsmClientCertificateAlreadyExistsFault.struct_class = Types::HsmClientCertificateAlreadyExistsFault
+
     HsmClientCertificateList.member = Shapes::ShapeRef.new(shape: HsmClientCertificate, location_name: "HsmClientCertificate")
 
     HsmClientCertificateMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     HsmClientCertificateMessage.add_member(:hsm_client_certificates, Shapes::ShapeRef.new(shape: HsmClientCertificateList, location_name: "HsmClientCertificates"))
     HsmClientCertificateMessage.struct_class = Types::HsmClientCertificateMessage
+
+    HsmClientCertificateNotFoundFault.struct_class = Types::HsmClientCertificateNotFoundFault
+
+    HsmClientCertificateQuotaExceededFault.struct_class = Types::HsmClientCertificateQuotaExceededFault
 
     HsmConfiguration.add_member(:hsm_configuration_identifier, Shapes::ShapeRef.new(shape: String, location_name: "HsmConfigurationIdentifier"))
     HsmConfiguration.add_member(:description, Shapes::ShapeRef.new(shape: String, location_name: "Description"))
@@ -1199,11 +1261,17 @@ module Aws::Redshift
     HsmConfiguration.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     HsmConfiguration.struct_class = Types::HsmConfiguration
 
+    HsmConfigurationAlreadyExistsFault.struct_class = Types::HsmConfigurationAlreadyExistsFault
+
     HsmConfigurationList.member = Shapes::ShapeRef.new(shape: HsmConfiguration, location_name: "HsmConfiguration")
 
     HsmConfigurationMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     HsmConfigurationMessage.add_member(:hsm_configurations, Shapes::ShapeRef.new(shape: HsmConfigurationList, location_name: "HsmConfigurations"))
     HsmConfigurationMessage.struct_class = Types::HsmConfigurationMessage
+
+    HsmConfigurationNotFoundFault.struct_class = Types::HsmConfigurationNotFoundFault
+
+    HsmConfigurationQuotaExceededFault.struct_class = Types::HsmConfigurationQuotaExceededFault
 
     HsmStatus.add_member(:hsm_client_certificate_identifier, Shapes::ShapeRef.new(shape: String, location_name: "HsmClientCertificateIdentifier"))
     HsmStatus.add_member(:hsm_configuration_identifier, Shapes::ShapeRef.new(shape: String, location_name: "HsmConfigurationIdentifier"))
@@ -1224,6 +1292,64 @@ module Aws::Redshift
     ImportTablesInProgress.member = Shapes::ShapeRef.new(shape: String)
 
     ImportTablesNotStarted.member = Shapes::ShapeRef.new(shape: String)
+
+    InProgressTableRestoreQuotaExceededFault.struct_class = Types::InProgressTableRestoreQuotaExceededFault
+
+    IncompatibleOrderableOptions.struct_class = Types::IncompatibleOrderableOptions
+
+    InsufficientClusterCapacityFault.struct_class = Types::InsufficientClusterCapacityFault
+
+    InsufficientS3BucketPolicyFault.struct_class = Types::InsufficientS3BucketPolicyFault
+
+    InvalidClusterParameterGroupStateFault.struct_class = Types::InvalidClusterParameterGroupStateFault
+
+    InvalidClusterSecurityGroupStateFault.struct_class = Types::InvalidClusterSecurityGroupStateFault
+
+    InvalidClusterSnapshotScheduleStateFault.struct_class = Types::InvalidClusterSnapshotScheduleStateFault
+
+    InvalidClusterSnapshotStateFault.struct_class = Types::InvalidClusterSnapshotStateFault
+
+    InvalidClusterStateFault.struct_class = Types::InvalidClusterStateFault
+
+    InvalidClusterSubnetGroupStateFault.struct_class = Types::InvalidClusterSubnetGroupStateFault
+
+    InvalidClusterSubnetStateFault.struct_class = Types::InvalidClusterSubnetStateFault
+
+    InvalidClusterTrackFault.struct_class = Types::InvalidClusterTrackFault
+
+    InvalidElasticIpFault.struct_class = Types::InvalidElasticIpFault
+
+    InvalidHsmClientCertificateStateFault.struct_class = Types::InvalidHsmClientCertificateStateFault
+
+    InvalidHsmConfigurationStateFault.struct_class = Types::InvalidHsmConfigurationStateFault
+
+    InvalidReservedNodeStateFault.struct_class = Types::InvalidReservedNodeStateFault
+
+    InvalidRestoreFault.struct_class = Types::InvalidRestoreFault
+
+    InvalidRetentionPeriodFault.struct_class = Types::InvalidRetentionPeriodFault
+
+    InvalidS3BucketNameFault.struct_class = Types::InvalidS3BucketNameFault
+
+    InvalidS3KeyPrefixFault.struct_class = Types::InvalidS3KeyPrefixFault
+
+    InvalidScheduleFault.struct_class = Types::InvalidScheduleFault
+
+    InvalidScheduledActionFault.struct_class = Types::InvalidScheduledActionFault
+
+    InvalidSnapshotCopyGrantStateFault.struct_class = Types::InvalidSnapshotCopyGrantStateFault
+
+    InvalidSubnet.struct_class = Types::InvalidSubnet
+
+    InvalidSubscriptionStateFault.struct_class = Types::InvalidSubscriptionStateFault
+
+    InvalidTableRestoreArgumentFault.struct_class = Types::InvalidTableRestoreArgumentFault
+
+    InvalidTagFault.struct_class = Types::InvalidTagFault
+
+    InvalidVPCNetworkStateFault.struct_class = Types::InvalidVPCNetworkStateFault
+
+    LimitExceededFault.struct_class = Types::LimitExceededFault
 
     LoggingStatus.add_member(:logging_enabled, Shapes::ShapeRef.new(shape: Boolean, location_name: "LoggingEnabled"))
     LoggingStatus.add_member(:bucket_name, Shapes::ShapeRef.new(shape: String, location_name: "BucketName"))
@@ -1369,6 +1495,10 @@ module Aws::Redshift
     NodeConfigurationOptionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     NodeConfigurationOptionsMessage.struct_class = Types::NodeConfigurationOptionsMessage
 
+    NumberOfNodesPerClusterLimitExceededFault.struct_class = Types::NumberOfNodesPerClusterLimitExceededFault
+
+    NumberOfNodesQuotaExceededFault.struct_class = Types::NumberOfNodesQuotaExceededFault
+
     OrderableClusterOption.add_member(:cluster_version, Shapes::ShapeRef.new(shape: String, location_name: "ClusterVersion"))
     OrderableClusterOption.add_member(:cluster_type, Shapes::ShapeRef.new(shape: String, location_name: "ClusterType"))
     OrderableClusterOption.add_member(:node_type, Shapes::ShapeRef.new(shape: String, location_name: "NodeType"))
@@ -1445,7 +1575,13 @@ module Aws::Redshift
     ReservedNode.add_member(:reserved_node_offering_type, Shapes::ShapeRef.new(shape: ReservedNodeOfferingType, location_name: "ReservedNodeOfferingType"))
     ReservedNode.struct_class = Types::ReservedNode
 
+    ReservedNodeAlreadyExistsFault.struct_class = Types::ReservedNodeAlreadyExistsFault
+
+    ReservedNodeAlreadyMigratedFault.struct_class = Types::ReservedNodeAlreadyMigratedFault
+
     ReservedNodeList.member = Shapes::ShapeRef.new(shape: ReservedNode, location_name: "ReservedNode")
+
+    ReservedNodeNotFoundFault.struct_class = Types::ReservedNodeNotFoundFault
 
     ReservedNodeOffering.add_member(:reserved_node_offering_id, Shapes::ShapeRef.new(shape: String, location_name: "ReservedNodeOfferingId"))
     ReservedNodeOffering.add_member(:node_type, Shapes::ShapeRef.new(shape: String, location_name: "NodeType"))
@@ -1460,9 +1596,13 @@ module Aws::Redshift
 
     ReservedNodeOfferingList.member = Shapes::ShapeRef.new(shape: ReservedNodeOffering, location_name: "ReservedNodeOffering")
 
+    ReservedNodeOfferingNotFoundFault.struct_class = Types::ReservedNodeOfferingNotFoundFault
+
     ReservedNodeOfferingsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReservedNodeOfferingsMessage.add_member(:reserved_node_offerings, Shapes::ShapeRef.new(shape: ReservedNodeOfferingList, location_name: "ReservedNodeOfferings"))
     ReservedNodeOfferingsMessage.struct_class = Types::ReservedNodeOfferingsMessage
+
+    ReservedNodeQuotaExceededFault.struct_class = Types::ReservedNodeQuotaExceededFault
 
     ReservedNodesMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ReservedNodesMessage.add_member(:reserved_nodes, Shapes::ShapeRef.new(shape: ReservedNodeList, location_name: "ReservedNodes"))
@@ -1487,6 +1627,8 @@ module Aws::Redshift
     ResizeInfo.add_member(:allow_cancel_resize, Shapes::ShapeRef.new(shape: Boolean, location_name: "AllowCancelResize"))
     ResizeInfo.struct_class = Types::ResizeInfo
 
+    ResizeNotFoundFault.struct_class = Types::ResizeNotFoundFault
+
     ResizeProgressMessage.add_member(:target_node_type, Shapes::ShapeRef.new(shape: String, location_name: "TargetNodeType"))
     ResizeProgressMessage.add_member(:target_number_of_nodes, Shapes::ShapeRef.new(shape: IntegerOptional, location_name: "TargetNumberOfNodes"))
     ResizeProgressMessage.add_member(:target_cluster_type, Shapes::ShapeRef.new(shape: String, location_name: "TargetClusterType"))
@@ -1504,6 +1646,8 @@ module Aws::Redshift
     ResizeProgressMessage.add_member(:target_encryption_type, Shapes::ShapeRef.new(shape: String, location_name: "TargetEncryptionType"))
     ResizeProgressMessage.add_member(:data_transfer_progress_percent, Shapes::ShapeRef.new(shape: DoubleOptional, location_name: "DataTransferProgressPercent"))
     ResizeProgressMessage.struct_class = Types::ResizeProgressMessage
+
+    ResourceNotFoundFault.struct_class = Types::ResourceNotFoundFault
 
     RestorableNodeTypeList.member = Shapes::ShapeRef.new(shape: String, location_name: "NodeType")
 
@@ -1589,7 +1733,15 @@ module Aws::Redshift
     RotateEncryptionKeyResult.add_member(:cluster, Shapes::ShapeRef.new(shape: Cluster, location_name: "Cluster"))
     RotateEncryptionKeyResult.struct_class = Types::RotateEncryptionKeyResult
 
+    SNSInvalidTopicFault.struct_class = Types::SNSInvalidTopicFault
+
+    SNSNoAuthorizationFault.struct_class = Types::SNSNoAuthorizationFault
+
+    SNSTopicArnNotFoundFault.struct_class = Types::SNSTopicArnNotFoundFault
+
     ScheduleDefinitionList.member = Shapes::ShapeRef.new(shape: String, location_name: "ScheduleDefinition")
+
+    ScheduleDefinitionTypeUnsupportedFault.struct_class = Types::ScheduleDefinitionTypeUnsupportedFault
 
     ScheduledAction.add_member(:scheduled_action_name, Shapes::ShapeRef.new(shape: String, location_name: "ScheduledActionName"))
     ScheduledAction.add_member(:target_action, Shapes::ShapeRef.new(shape: ScheduledActionType, location_name: "TargetAction"))
@@ -1602,6 +1754,8 @@ module Aws::Redshift
     ScheduledAction.add_member(:end_time, Shapes::ShapeRef.new(shape: TStamp, location_name: "EndTime"))
     ScheduledAction.struct_class = Types::ScheduledAction
 
+    ScheduledActionAlreadyExistsFault.struct_class = Types::ScheduledActionAlreadyExistsFault
+
     ScheduledActionFilter.add_member(:name, Shapes::ShapeRef.new(shape: ScheduledActionFilterName, required: true, location_name: "Name"))
     ScheduledActionFilter.add_member(:values, Shapes::ShapeRef.new(shape: ValueStringList, required: true, location_name: "Values"))
     ScheduledActionFilter.struct_class = Types::ScheduledActionFilter
@@ -1610,10 +1764,16 @@ module Aws::Redshift
 
     ScheduledActionList.member = Shapes::ShapeRef.new(shape: ScheduledAction, location_name: "ScheduledAction")
 
+    ScheduledActionNotFoundFault.struct_class = Types::ScheduledActionNotFoundFault
+
+    ScheduledActionQuotaExceededFault.struct_class = Types::ScheduledActionQuotaExceededFault
+
     ScheduledActionTimeList.member = Shapes::ShapeRef.new(shape: TStamp, location_name: "ScheduledActionTime")
 
     ScheduledActionType.add_member(:resize_cluster, Shapes::ShapeRef.new(shape: ResizeClusterMessage, location_name: "ResizeCluster"))
     ScheduledActionType.struct_class = Types::ScheduledActionType
+
+    ScheduledActionTypeUnsupportedFault.struct_class = Types::ScheduledActionTypeUnsupportedFault
 
     ScheduledActionsMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     ScheduledActionsMessage.add_member(:scheduled_actions, Shapes::ShapeRef.new(shape: ScheduledActionList, location_name: "ScheduledActions"))
@@ -1656,16 +1816,28 @@ module Aws::Redshift
     Snapshot.add_member(:snapshot_retention_start_time, Shapes::ShapeRef.new(shape: TStamp, location_name: "SnapshotRetentionStartTime"))
     Snapshot.struct_class = Types::Snapshot
 
+    SnapshotCopyAlreadyDisabledFault.struct_class = Types::SnapshotCopyAlreadyDisabledFault
+
+    SnapshotCopyAlreadyEnabledFault.struct_class = Types::SnapshotCopyAlreadyEnabledFault
+
+    SnapshotCopyDisabledFault.struct_class = Types::SnapshotCopyDisabledFault
+
     SnapshotCopyGrant.add_member(:snapshot_copy_grant_name, Shapes::ShapeRef.new(shape: String, location_name: "SnapshotCopyGrantName"))
     SnapshotCopyGrant.add_member(:kms_key_id, Shapes::ShapeRef.new(shape: String, location_name: "KmsKeyId"))
     SnapshotCopyGrant.add_member(:tags, Shapes::ShapeRef.new(shape: TagList, location_name: "Tags"))
     SnapshotCopyGrant.struct_class = Types::SnapshotCopyGrant
+
+    SnapshotCopyGrantAlreadyExistsFault.struct_class = Types::SnapshotCopyGrantAlreadyExistsFault
 
     SnapshotCopyGrantList.member = Shapes::ShapeRef.new(shape: SnapshotCopyGrant, location_name: "SnapshotCopyGrant")
 
     SnapshotCopyGrantMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     SnapshotCopyGrantMessage.add_member(:snapshot_copy_grants, Shapes::ShapeRef.new(shape: SnapshotCopyGrantList, location_name: "SnapshotCopyGrants"))
     SnapshotCopyGrantMessage.struct_class = Types::SnapshotCopyGrantMessage
+
+    SnapshotCopyGrantNotFoundFault.struct_class = Types::SnapshotCopyGrantNotFoundFault
+
+    SnapshotCopyGrantQuotaExceededFault.struct_class = Types::SnapshotCopyGrantQuotaExceededFault
 
     SnapshotErrorMessage.add_member(:snapshot_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SnapshotIdentifier"))
     SnapshotErrorMessage.add_member(:snapshot_cluster_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SnapshotClusterIdentifier"))
@@ -1690,7 +1862,15 @@ module Aws::Redshift
     SnapshotSchedule.add_member(:associated_clusters, Shapes::ShapeRef.new(shape: AssociatedClusterList, location_name: "AssociatedClusters"))
     SnapshotSchedule.struct_class = Types::SnapshotSchedule
 
+    SnapshotScheduleAlreadyExistsFault.struct_class = Types::SnapshotScheduleAlreadyExistsFault
+
     SnapshotScheduleList.member = Shapes::ShapeRef.new(shape: SnapshotSchedule, location_name: "SnapshotSchedule")
+
+    SnapshotScheduleNotFoundFault.struct_class = Types::SnapshotScheduleNotFoundFault
+
+    SnapshotScheduleQuotaExceededFault.struct_class = Types::SnapshotScheduleQuotaExceededFault
+
+    SnapshotScheduleUpdateInProgressFault.struct_class = Types::SnapshotScheduleUpdateInProgressFault
 
     SnapshotSortingEntity.add_member(:attribute, Shapes::ShapeRef.new(shape: SnapshotAttributeToSortBy, required: true, location_name: "Attribute"))
     SnapshotSortingEntity.add_member(:sort_order, Shapes::ShapeRef.new(shape: SortByOrder, location_name: "SortOrder"))
@@ -1700,14 +1880,28 @@ module Aws::Redshift
 
     SourceIdsList.member = Shapes::ShapeRef.new(shape: String, location_name: "SourceId")
 
+    SourceNotFoundFault.struct_class = Types::SourceNotFoundFault
+
     Subnet.add_member(:subnet_identifier, Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier"))
     Subnet.add_member(:subnet_availability_zone, Shapes::ShapeRef.new(shape: AvailabilityZone, location_name: "SubnetAvailabilityZone"))
     Subnet.add_member(:subnet_status, Shapes::ShapeRef.new(shape: String, location_name: "SubnetStatus"))
     Subnet.struct_class = Types::Subnet
 
+    SubnetAlreadyInUse.struct_class = Types::SubnetAlreadyInUse
+
     SubnetIdentifierList.member = Shapes::ShapeRef.new(shape: String, location_name: "SubnetIdentifier")
 
     SubnetList.member = Shapes::ShapeRef.new(shape: Subnet, location_name: "Subnet")
+
+    SubscriptionAlreadyExistFault.struct_class = Types::SubscriptionAlreadyExistFault
+
+    SubscriptionCategoryNotFoundFault.struct_class = Types::SubscriptionCategoryNotFoundFault
+
+    SubscriptionEventIdNotFoundFault.struct_class = Types::SubscriptionEventIdNotFoundFault
+
+    SubscriptionNotFoundFault.struct_class = Types::SubscriptionNotFoundFault
+
+    SubscriptionSeverityNotFoundFault.struct_class = Types::SubscriptionSeverityNotFoundFault
 
     SupportedOperation.add_member(:operation_name, Shapes::ShapeRef.new(shape: String, location_name: "OperationName"))
     SupportedOperation.struct_class = Types::SupportedOperation
@@ -1718,6 +1912,10 @@ module Aws::Redshift
     SupportedPlatform.struct_class = Types::SupportedPlatform
 
     SupportedPlatformsList.member = Shapes::ShapeRef.new(shape: SupportedPlatform, location_name: "SupportedPlatform")
+
+    TableLimitExceededFault.struct_class = Types::TableLimitExceededFault
+
+    TableRestoreNotFoundFault.struct_class = Types::TableRestoreNotFoundFault
 
     TableRestoreStatus.add_member(:table_restore_request_id, Shapes::ShapeRef.new(shape: String, location_name: "TableRestoreRequestId"))
     TableRestoreStatus.add_member(:status, Shapes::ShapeRef.new(shape: TableRestoreStatusType, location_name: "Status"))
@@ -1747,6 +1945,8 @@ module Aws::Redshift
 
     TagKeyList.member = Shapes::ShapeRef.new(shape: String, location_name: "TagKey")
 
+    TagLimitExceededFault.struct_class = Types::TagLimitExceededFault
+
     TagList.member = Shapes::ShapeRef.new(shape: Tag, location_name: "Tag")
 
     TagValueList.member = Shapes::ShapeRef.new(shape: String, location_name: "TagValue")
@@ -1767,6 +1967,14 @@ module Aws::Redshift
     TrackListMessage.add_member(:maintenance_tracks, Shapes::ShapeRef.new(shape: TrackList, location_name: "MaintenanceTracks"))
     TrackListMessage.add_member(:marker, Shapes::ShapeRef.new(shape: String, location_name: "Marker"))
     TrackListMessage.struct_class = Types::TrackListMessage
+
+    UnauthorizedOperation.struct_class = Types::UnauthorizedOperation
+
+    UnknownSnapshotCopyRegionFault.struct_class = Types::UnknownSnapshotCopyRegionFault
+
+    UnsupportedOperationFault.struct_class = Types::UnsupportedOperationFault
+
+    UnsupportedOptionFault.struct_class = Types::UnsupportedOptionFault
 
     UpdateTarget.add_member(:maintenance_track_name, Shapes::ShapeRef.new(shape: String, location_name: "MaintenanceTrackName"))
     UpdateTarget.add_member(:database_version, Shapes::ShapeRef.new(shape: String, location_name: "DatabaseVersion"))

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
@@ -10,5 +10,1149 @@ module Aws::Redshift
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessToSnapshotDeniedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::AccessToSnapshotDeniedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::AuthorizationAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::AuthorizationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AuthorizationQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::AuthorizationQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BatchDeleteRequestSizeExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::BatchDeleteRequestSizeExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BatchModifyClusterSnapshotsLimitExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::BatchModifyClusterSnapshotsLimitExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BucketNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::BucketNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterOnLatestRevisionFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterOnLatestRevisionFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterParameterGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterParameterGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterParameterGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterParameterGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterParameterGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterParameterGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSecurityGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSecurityGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSecurityGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSecurityGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSecurityGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSecurityGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSnapshotAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSnapshotAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSnapshotNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSnapshotNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSnapshotQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSnapshotQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSubnetGroupAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSubnetGroupAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSubnetGroupNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSubnetGroupNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSubnetGroupQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSubnetGroupQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ClusterSubnetQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ClusterSubnetQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class CopyToRegionDisabledFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::CopyToRegionDisabledFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DependentServiceRequestThrottlingFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::DependentServiceRequestThrottlingFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DependentServiceUnavailableFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::DependentServiceUnavailableFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EventSubscriptionQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::EventSubscriptionQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmClientCertificateAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmClientCertificateAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmClientCertificateNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmClientCertificateNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmClientCertificateQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmClientCertificateQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmConfigurationAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmConfigurationAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmConfigurationNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmConfigurationNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class HsmConfigurationQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::HsmConfigurationQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InProgressTableRestoreQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InProgressTableRestoreQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class IncompatibleOrderableOptions < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::IncompatibleOrderableOptions] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientClusterCapacityFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InsufficientClusterCapacityFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InsufficientS3BucketPolicyFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InsufficientS3BucketPolicyFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterParameterGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterParameterGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterSecurityGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterSecurityGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterSnapshotScheduleStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterSnapshotScheduleStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterSnapshotStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterSnapshotStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterSubnetGroupStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterSubnetGroupStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterSubnetStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterSubnetStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidClusterTrackFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidClusterTrackFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidElasticIpFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidElasticIpFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidHsmClientCertificateStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidHsmClientCertificateStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidHsmConfigurationStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidHsmConfigurationStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidReservedNodeStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidReservedNodeStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRestoreFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidRestoreFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidRetentionPeriodFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidRetentionPeriodFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3BucketNameFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidS3BucketNameFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3KeyPrefixFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidS3KeyPrefixFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidScheduleFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidScheduleFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidScheduledActionFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidScheduledActionFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSnapshotCopyGrantStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidSnapshotCopyGrantStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubnet < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidSubnet] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidSubscriptionStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidSubscriptionStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTableRestoreArgumentFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidTableRestoreArgumentFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidTagFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidTagFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidVPCNetworkStateFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::InvalidVPCNetworkStateFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::LimitExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NumberOfNodesPerClusterLimitExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::NumberOfNodesPerClusterLimitExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NumberOfNodesQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::NumberOfNodesQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedNodeAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ReservedNodeAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedNodeAlreadyMigratedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ReservedNodeAlreadyMigratedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedNodeNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ReservedNodeNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedNodeOfferingNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ReservedNodeOfferingNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReservedNodeQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ReservedNodeQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResizeNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ResizeNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ResourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSInvalidTopicFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SNSInvalidTopicFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSNoAuthorizationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SNSNoAuthorizationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SNSTopicArnNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SNSTopicArnNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ScheduleDefinitionTypeUnsupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ScheduleDefinitionTypeUnsupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ScheduledActionAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ScheduledActionAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ScheduledActionNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ScheduledActionNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ScheduledActionQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ScheduledActionQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ScheduledActionTypeUnsupportedFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::ScheduledActionTypeUnsupportedFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyAlreadyDisabledFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyAlreadyDisabledFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyAlreadyEnabledFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyAlreadyEnabledFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyDisabledFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyDisabledFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyGrantAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyGrantAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyGrantNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyGrantNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotCopyGrantQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotCopyGrantQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotScheduleAlreadyExistsFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotScheduleAlreadyExistsFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotScheduleNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotScheduleNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotScheduleQuotaExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotScheduleQuotaExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SnapshotScheduleUpdateInProgressFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SnapshotScheduleUpdateInProgressFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SourceNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SourceNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubnetAlreadyInUse < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubnetAlreadyInUse] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionAlreadyExistFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubscriptionAlreadyExistFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionCategoryNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubscriptionCategoryNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionEventIdNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubscriptionEventIdNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubscriptionNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SubscriptionSeverityNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::SubscriptionSeverityNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TableLimitExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::TableLimitExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TableRestoreNotFoundFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::TableRestoreNotFoundFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagLimitExceededFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::TagLimitExceededFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnauthorizedOperation < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::UnauthorizedOperation] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnknownSnapshotCopyRegionFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::UnknownSnapshotCopyRegionFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedOperationFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::UnsupportedOperationFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedOptionFault < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Redshift::Types::UnsupportedOptionFault] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
@@ -45,6 +45,13 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The owner of the specified snapshot has not authorized your account to
+    # access the snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/AccessToSnapshotDeniedFault AWS API Documentation
+    #
+    class AccessToSnapshotDeniedFault < Aws::EmptyStructure; end
+
     # A name value pair that describes an aspect of an account.
     #
     # @!attribute [rw] attribute_name
@@ -107,6 +114,27 @@ module Aws::Redshift
       :attribute_value)
       include Aws::Structure
     end
+
+    # The specified CIDR block or EC2 security group is already authorized
+    # for the specified cluster security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/AuthorizationAlreadyExistsFault AWS API Documentation
+    #
+    class AuthorizationAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # The specified CIDR IP range or EC2 security group is not authorized
+    # for the specified cluster security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/AuthorizationNotFoundFault AWS API Documentation
+    #
+    class AuthorizationNotFoundFault < Aws::EmptyStructure; end
+
+    # The authorization quota for the cluster security group has been
+    # reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/AuthorizationQuotaExceededFault AWS API Documentation
+    #
+    class AuthorizationQuotaExceededFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass AuthorizeClusterSecurityGroupIngressMessage
     #   data as a hash:
@@ -264,6 +292,20 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The maximum number for a batch delete of snapshots has been reached.
+    # The limit is 100.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/BatchDeleteRequestSizeExceededFault AWS API Documentation
+    #
+    class BatchDeleteRequestSizeExceededFault < Aws::EmptyStructure; end
+
+    # The maximum number for snapshot identifiers has been reached. The
+    # limit is 100.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/BatchModifyClusterSnapshotsLimitExceededFault AWS API Documentation
+    #
+    class BatchModifyClusterSnapshotsLimitExceededFault < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass BatchModifyClusterSnapshotsMessage
     #   data as a hash:
     #
@@ -318,6 +360,12 @@ module Aws::Redshift
       :errors)
       include Aws::Structure
     end
+
+    # Could not find the specified S3 bucket.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/BucketNotFoundFault AWS API Documentation
+    #
+    class BucketNotFoundFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass CancelResizeMessage
     #   data as a hash:
@@ -689,6 +737,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The account already has a cluster with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] cluster_identifier
     #   @return [String]
     #
@@ -837,6 +891,19 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The `ClusterIdentifier` parameter does not refer to an existing
+    # cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterNotFoundFault AWS API Documentation
+    #
+    class ClusterNotFoundFault < Aws::EmptyStructure; end
+
+    # Cluster is already on the latest database revision.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterOnLatestRevisionFault AWS API Documentation
+    #
+    class ClusterOnLatestRevisionFault < Aws::EmptyStructure; end
+
     # Describes a parameter group.
     #
     # @!attribute [rw] parameter_group_name
@@ -865,6 +932,12 @@ module Aws::Redshift
       :tags)
       include Aws::Structure
     end
+
+    # A cluster parameter group with the same name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterParameterGroupAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterParameterGroupAlreadyExistsFault < Aws::EmptyStructure; end
 
     # Contains the output from the DescribeClusterParameters action.
     #
@@ -907,6 +980,26 @@ module Aws::Redshift
       :parameter_group_status)
       include Aws::Structure
     end
+
+    # The parameter group name does not refer to an existing parameter
+    # group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterParameterGroupNotFoundFault AWS API Documentation
+    #
+    class ClusterParameterGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # cluster parameter groups. For information about increasing your quota,
+    # go to [Limits in Amazon Redshift][1] in the *Amazon Redshift Cluster
+    # Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterParameterGroupQuotaExceededFault AWS API Documentation
+    #
+    class ClusterParameterGroupQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes the status of a parameter group.
     #
@@ -1010,6 +1103,19 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The request would exceed the allowed number of cluster instances for
+    # this account. For information about increasing your quota, go to
+    # [Limits in Amazon Redshift][1] in the *Amazon Redshift Cluster
+    # Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterQuotaExceededFault AWS API Documentation
+    #
+    class ClusterQuotaExceededFault < Aws::EmptyStructure; end
+
     # Describes a security group.
     #
     # @!attribute [rw] cluster_security_group_name
@@ -1045,6 +1151,12 @@ module Aws::Redshift
       :tags)
       include Aws::Structure
     end
+
+    # A cluster security group with the same name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSecurityGroupAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterSecurityGroupAlreadyExistsFault < Aws::EmptyStructure; end
 
     # Describes a cluster security group.
     #
@@ -1085,6 +1197,33 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The cluster security group name does not refer to an existing cluster
+    # security group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSecurityGroupNotFoundFault AWS API Documentation
+    #
+    class ClusterSecurityGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # cluster security groups. For information about increasing your quota,
+    # go to [Limits in Amazon Redshift][1] in the *Amazon Redshift Cluster
+    # Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSecurityGroupQuotaExceededFault AWS API Documentation
+    #
+    class ClusterSecurityGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The value specified as a snapshot identifier is already used by an
+    # existing snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSnapshotAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterSnapshotAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Returns the destination region and retention period that are
     # configured for cross-region snapshot copy.
     #
@@ -1119,6 +1258,20 @@ module Aws::Redshift
       :snapshot_copy_grant_name)
       include Aws::Structure
     end
+
+    # The snapshot identifier does not refer to an existing cluster
+    # snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSnapshotNotFoundFault AWS API Documentation
+    #
+    class ClusterSnapshotNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in the user exceeding the allowed number of
+    # cluster snapshots.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSnapshotQuotaExceededFault AWS API Documentation
+    #
+    class ClusterSnapshotQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes a subnet group.
     #
@@ -1159,6 +1312,13 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # A *ClusterSubnetGroupName* is already used by an existing cluster
+    # subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSubnetGroupAlreadyExistsFault AWS API Documentation
+    #
+    class ClusterSubnetGroupAlreadyExistsFault < Aws::EmptyStructure; end
+
     # Contains the output from the DescribeClusterSubnetGroups action.
     #
     # @!attribute [rw] marker
@@ -1181,6 +1341,39 @@ module Aws::Redshift
       :cluster_subnet_groups)
       include Aws::Structure
     end
+
+    # The cluster subnet group name does not refer to an existing cluster
+    # subnet group.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSubnetGroupNotFoundFault AWS API Documentation
+    #
+    class ClusterSubnetGroupNotFoundFault < Aws::EmptyStructure; end
+
+    # The request would result in user exceeding the allowed number of
+    # cluster subnet groups. For information about increasing your quota, go
+    # to [Limits in Amazon Redshift][1] in the *Amazon Redshift Cluster
+    # Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSubnetGroupQuotaExceededFault AWS API Documentation
+    #
+    class ClusterSubnetGroupQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The request would result in user exceeding the allowed number of
+    # subnets in a cluster subnet groups. For information about increasing
+    # your quota, go to [Limits in Amazon Redshift][1] in the *Amazon
+    # Redshift Cluster Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterSubnetQuotaExceededFault AWS API Documentation
+    #
+    class ClusterSubnetQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes a cluster version, including the parameter group family and
     # description of the version.
@@ -1332,6 +1525,13 @@ module Aws::Redshift
       :snapshot)
       include Aws::Structure
     end
+
+    # Cross-region snapshot copy was temporarily disabled. Try your request
+    # again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/CopyToRegionDisabledFault AWS API Documentation
+    #
+    class CopyToRegionDisabledFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass CreateClusterMessage
     #   data as a hash:
@@ -2956,6 +3156,21 @@ module Aws::Redshift
       :tag_keys)
       include Aws::Structure
     end
+
+    # The request cannot be completed because a dependent service is
+    # throttling requests made by Amazon Redshift on your behalf. Wait and
+    # retry the request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/DependentServiceRequestThrottlingFault AWS API Documentation
+    #
+    class DependentServiceRequestThrottlingFault < Aws::EmptyStructure; end
+
+    # Your request cannot be completed because a dependent internal service
+    # is temporarily unavailable. Wait 30 to 60 seconds and try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/DependentServiceUnavailableFault AWS API Documentation
+    #
+    class DependentServiceUnavailableFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass DescribeAccountAttributesMessage
     #   data as a hash:
@@ -5128,6 +5343,19 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The request would exceed the allowed number of event subscriptions for
+    # this account. For information about increasing your quota, go to
+    # [Limits in Amazon Redshift][1] in the *Amazon Redshift Cluster
+    # Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/EventSubscriptionQuotaExceededFault AWS API Documentation
+    #
+    class EventSubscriptionQuotaExceededFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   A value that indicates the starting point for the next set of
     #   response records in a subsequent request. If a value is returned in
@@ -5382,6 +5610,13 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # There is already an existing Amazon Redshift HSM client certificate
+    # with the specified identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmClientCertificateAlreadyExistsFault AWS API Documentation
+    #
+    class HsmClientCertificateAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   A value that indicates the starting point for the next set of
     #   response records in a subsequent request. If a value is returned in
@@ -5404,6 +5639,25 @@ module Aws::Redshift
       :hsm_client_certificates)
       include Aws::Structure
     end
+
+    # There is no Amazon Redshift HSM client certificate with the specified
+    # identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmClientCertificateNotFoundFault AWS API Documentation
+    #
+    class HsmClientCertificateNotFoundFault < Aws::EmptyStructure; end
+
+    # The quota for HSM client certificates has been reached. For
+    # information about increasing your quota, go to [Limits in Amazon
+    # Redshift][1] in the *Amazon Redshift Cluster Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmClientCertificateQuotaExceededFault AWS API Documentation
+    #
+    class HsmClientCertificateQuotaExceededFault < Aws::EmptyStructure; end
 
     # Returns information about an HSM configuration, which is an object
     # that describes to Amazon Redshift clusters the information they
@@ -5443,6 +5697,13 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # There is already an existing Amazon Redshift HSM configuration with
+    # the specified identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmConfigurationAlreadyExistsFault AWS API Documentation
+    #
+    class HsmConfigurationAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   A value that indicates the starting point for the next set of
     #   response records in a subsequent request. If a value is returned in
@@ -5463,6 +5724,25 @@ module Aws::Redshift
       :hsm_configurations)
       include Aws::Structure
     end
+
+    # There is no Amazon Redshift HSM configuration with the specified
+    # identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmConfigurationNotFoundFault AWS API Documentation
+    #
+    class HsmConfigurationNotFoundFault < Aws::EmptyStructure; end
+
+    # The quota for HSM configurations has been reached. For information
+    # about increasing your quota, go to [Limits in Amazon Redshift][1] in
+    # the *Amazon Redshift Cluster Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/HsmConfigurationQuotaExceededFault AWS API Documentation
+    #
+    class HsmConfigurationQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes the status of changes to HSM settings.
     #
@@ -5515,6 +5795,205 @@ module Aws::Redshift
       :tags)
       include Aws::Structure
     end
+
+    # You have exceeded the allowed number of table restore requests. Wait
+    # for your current table restore requests to complete before making a
+    # new request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InProgressTableRestoreQuotaExceededFault AWS API Documentation
+    #
+    class InProgressTableRestoreQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The specified options are incompatible.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/IncompatibleOrderableOptions AWS API Documentation
+    #
+    class IncompatibleOrderableOptions < Aws::EmptyStructure; end
+
+    # The number of nodes specified exceeds the allotted capacity of the
+    # cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InsufficientClusterCapacityFault AWS API Documentation
+    #
+    class InsufficientClusterCapacityFault < Aws::EmptyStructure; end
+
+    # The cluster does not have read bucket or put object permissions on the
+    # S3 bucket specified when enabling logging.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InsufficientS3BucketPolicyFault AWS API Documentation
+    #
+    class InsufficientS3BucketPolicyFault < Aws::EmptyStructure; end
+
+    # The cluster parameter group action can not be completed because
+    # another task is in progress that involves the parameter group. Wait a
+    # few moments and try the operation again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterParameterGroupStateFault AWS API Documentation
+    #
+    class InvalidClusterParameterGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the cluster security group is not `available`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterSecurityGroupStateFault AWS API Documentation
+    #
+    class InvalidClusterSecurityGroupStateFault < Aws::EmptyStructure; end
+
+    # The cluster snapshot schedule state is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterSnapshotScheduleStateFault AWS API Documentation
+    #
+    class InvalidClusterSnapshotScheduleStateFault < Aws::EmptyStructure; end
+
+    # The specified cluster snapshot is not in the `available` state, or
+    # other accounts are authorized to access the snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterSnapshotStateFault AWS API Documentation
+    #
+    class InvalidClusterSnapshotStateFault < Aws::EmptyStructure; end
+
+    # The specified cluster is not in the `available` state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterStateFault AWS API Documentation
+    #
+    class InvalidClusterStateFault < Aws::EmptyStructure; end
+
+    # The cluster subnet group cannot be deleted because it is in use.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterSubnetGroupStateFault AWS API Documentation
+    #
+    class InvalidClusterSubnetGroupStateFault < Aws::EmptyStructure; end
+
+    # The state of the subnet is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterSubnetStateFault AWS API Documentation
+    #
+    class InvalidClusterSubnetStateFault < Aws::EmptyStructure; end
+
+    # The provided cluster track name is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidClusterTrackFault AWS API Documentation
+    #
+    class InvalidClusterTrackFault < Aws::EmptyStructure; end
+
+    # The Elastic IP (EIP) is invalid or cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidElasticIpFault AWS API Documentation
+    #
+    class InvalidElasticIpFault < Aws::EmptyStructure; end
+
+    # The specified HSM client certificate is not in the `available` state,
+    # or it is still in use by one or more Amazon Redshift clusters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidHsmClientCertificateStateFault AWS API Documentation
+    #
+    class InvalidHsmClientCertificateStateFault < Aws::EmptyStructure; end
+
+    # The specified HSM configuration is not in the `available` state, or it
+    # is still in use by one or more Amazon Redshift clusters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidHsmConfigurationStateFault AWS API Documentation
+    #
+    class InvalidHsmConfigurationStateFault < Aws::EmptyStructure; end
+
+    # Indicates that the Reserved Node being exchanged is not in an active
+    # state.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidReservedNodeStateFault AWS API Documentation
+    #
+    class InvalidReservedNodeStateFault < Aws::EmptyStructure; end
+
+    # The restore is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidRestoreFault AWS API Documentation
+    #
+    class InvalidRestoreFault < Aws::EmptyStructure; end
+
+    # The retention period specified is either in the past or is not a valid
+    # value.
+    #
+    # The value must be either -1 or an integer between 1 and 3,653.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidRetentionPeriodFault AWS API Documentation
+    #
+    class InvalidRetentionPeriodFault < Aws::EmptyStructure; end
+
+    # The S3 bucket name is invalid. For more information about naming
+    # rules, go to [Bucket Restrictions and Limitations][1] in the Amazon
+    # Simple Storage Service (S3) Developer Guide.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidS3BucketNameFault AWS API Documentation
+    #
+    class InvalidS3BucketNameFault < Aws::EmptyStructure; end
+
+    # The string specified for the logging S3 key prefix does not comply
+    # with the documented constraints.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidS3KeyPrefixFault AWS API Documentation
+    #
+    class InvalidS3KeyPrefixFault < Aws::EmptyStructure; end
+
+    # The schedule you submitted isn't valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidScheduleFault AWS API Documentation
+    #
+    class InvalidScheduleFault < Aws::EmptyStructure; end
+
+    # The scheduled action is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidScheduledActionFault AWS API Documentation
+    #
+    class InvalidScheduledActionFault < Aws::EmptyStructure; end
+
+    # The snapshot copy grant can't be deleted because it is used by one or
+    # more clusters.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidSnapshotCopyGrantStateFault AWS API Documentation
+    #
+    class InvalidSnapshotCopyGrantStateFault < Aws::EmptyStructure; end
+
+    # The requested subnet is not valid, or not all of the subnets are in
+    # the same VPC.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidSubnet AWS API Documentation
+    #
+    class InvalidSubnet < Aws::EmptyStructure; end
+
+    # The subscription request is invalid because it is a duplicate request.
+    # This subscription request is already in progress.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidSubscriptionStateFault AWS API Documentation
+    #
+    class InvalidSubscriptionStateFault < Aws::EmptyStructure; end
+
+    # The value specified for the `sourceDatabaseName`, `sourceSchemaName`,
+    # or `sourceTableName` parameter, or a combination of these, doesn't
+    # exist in the snapshot.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidTableRestoreArgumentFault AWS API Documentation
+    #
+    class InvalidTableRestoreArgumentFault < Aws::EmptyStructure; end
+
+    # The tag is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidTagFault AWS API Documentation
+    #
+    class InvalidTagFault < Aws::EmptyStructure; end
+
+    # The cluster subnet group does not cover all Availability Zones.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/InvalidVPCNetworkStateFault AWS API Documentation
+    #
+    class InvalidVPCNetworkStateFault < Aws::EmptyStructure; end
+
+    # The encryption key has exceeded its grant limit in AWS KMS.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/LimitExceededFault AWS API Documentation
+    #
+    class LimitExceededFault < Aws::EmptyStructure; end
 
     # Describes the status of logging for a cluster.
     #
@@ -6588,6 +7067,24 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The operation would exceed the number of nodes allowed for a cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/NumberOfNodesPerClusterLimitExceededFault AWS API Documentation
+    #
+    class NumberOfNodesPerClusterLimitExceededFault < Aws::EmptyStructure; end
+
+    # The operation would exceed the number of nodes allotted to the
+    # account. For information about increasing your quota, go to [Limits in
+    # Amazon Redshift][1] in the *Amazon Redshift Cluster Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/NumberOfNodesQuotaExceededFault AWS API Documentation
+    #
+    class NumberOfNodesQuotaExceededFault < Aws::EmptyStructure; end
+
     # Describes an orderable cluster option.
     #
     # @!attribute [rw] cluster_version
@@ -6984,6 +7481,24 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # User already has a reservation with the given identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ReservedNodeAlreadyExistsFault AWS API Documentation
+    #
+    class ReservedNodeAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # Indicates that the reserved node has already been exchanged.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ReservedNodeAlreadyMigratedFault AWS API Documentation
+    #
+    class ReservedNodeAlreadyMigratedFault < Aws::EmptyStructure; end
+
+    # The specified reserved compute node not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ReservedNodeNotFoundFault AWS API Documentation
+    #
+    class ReservedNodeNotFoundFault < Aws::EmptyStructure; end
+
     # Describes a reserved node offering.
     #
     # @!attribute [rw] reserved_node_offering_id
@@ -7042,6 +7557,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # Specified offering does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ReservedNodeOfferingNotFoundFault AWS API Documentation
+    #
+    class ReservedNodeOfferingNotFoundFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   A value that indicates the starting point for the next set of
     #   response records in a subsequent request. If a value is returned in
@@ -7062,6 +7583,18 @@ module Aws::Redshift
       :reserved_node_offerings)
       include Aws::Structure
     end
+
+    # Request would exceed the user's compute node quota. For information
+    # about increasing your quota, go to [Limits in Amazon Redshift][1] in
+    # the *Amazon Redshift Cluster Management Guide*.
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ReservedNodeQuotaExceededFault AWS API Documentation
+    #
+    class ReservedNodeQuotaExceededFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] marker
     #   A value that indicates the starting point for the next set of
@@ -7208,6 +7741,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # A resize operation for the specified cluster is not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ResizeNotFoundFault AWS API Documentation
+    #
+    class ResizeNotFoundFault < Aws::EmptyStructure; end
+
     # Describes the result of a cluster resize operation.
     #
     # @!attribute [rw] target_node_type
@@ -7328,6 +7867,12 @@ module Aws::Redshift
       :data_transfer_progress_percent)
       include Aws::Structure
     end
+
+    # The resource could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ResourceNotFoundFault AWS API Documentation
+    #
+    class ResourceNotFoundFault < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass RestoreFromClusterSnapshotMessage
     #   data as a hash:
@@ -7937,6 +8482,33 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # Amazon SNS has responded that there is a problem with the specified
+    # Amazon SNS topic.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SNSInvalidTopicFault AWS API Documentation
+    #
+    class SNSInvalidTopicFault < Aws::EmptyStructure; end
+
+    # You do not have permission to publish to the specified Amazon SNS
+    # topic.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SNSNoAuthorizationFault AWS API Documentation
+    #
+    class SNSNoAuthorizationFault < Aws::EmptyStructure; end
+
+    # An Amazon SNS topic with the specified Amazon Resource Name (ARN) does
+    # not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SNSTopicArnNotFoundFault AWS API Documentation
+    #
+    class SNSTopicArnNotFoundFault < Aws::EmptyStructure; end
+
+    # The definition you submitted is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ScheduleDefinitionTypeUnsupportedFault AWS API Documentation
+    #
+    class ScheduleDefinitionTypeUnsupportedFault < Aws::EmptyStructure; end
+
     # Describes a scheduled action. You can use a scheduled action to
     # trigger some Amazon Redshift API operations on a schedule. For
     # information about which API operations can be scheduled, see
@@ -8023,6 +8595,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The scheduled action already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ScheduledActionAlreadyExistsFault AWS API Documentation
+    #
+    class ScheduledActionAlreadyExistsFault < Aws::EmptyStructure; end
+
     # A set of elements to filter the returned scheduled actions.
     #
     # @note When making an API call, you may pass ScheduledActionFilter
@@ -8050,6 +8628,18 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The scheduled action cannot be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ScheduledActionNotFoundFault AWS API Documentation
+    #
+    class ScheduledActionNotFoundFault < Aws::EmptyStructure; end
+
+    # The quota for scheduled actions exceeded.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ScheduledActionQuotaExceededFault AWS API Documentation
+    #
+    class ScheduledActionQuotaExceededFault < Aws::EmptyStructure; end
+
     # The action type that specifies an Amazon Redshift API operation that
     # is supported by the Amazon Redshift scheduler.
     #
@@ -8076,6 +8666,12 @@ module Aws::Redshift
       :resize_cluster)
       include Aws::Structure
     end
+
+    # The action type specified for a scheduled action is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ScheduledActionTypeUnsupportedFault AWS API Documentation
+    #
+    class ScheduledActionTypeUnsupportedFault < Aws::EmptyStructure; end
 
     # @!attribute [rw] marker
     #   An optional parameter that specifies the starting point to return a
@@ -8318,6 +8914,25 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The cluster already has cross-region snapshot copy disabled.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyAlreadyDisabledFault AWS API Documentation
+    #
+    class SnapshotCopyAlreadyDisabledFault < Aws::EmptyStructure; end
+
+    # The cluster already has cross-region snapshot copy enabled.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyAlreadyEnabledFault AWS API Documentation
+    #
+    class SnapshotCopyAlreadyEnabledFault < Aws::EmptyStructure; end
+
+    # Cross-region snapshot copy was temporarily disabled. Try your request
+    # again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyDisabledFault AWS API Documentation
+    #
+    class SnapshotCopyDisabledFault < Aws::EmptyStructure; end
+
     # The snapshot copy grant that grants Amazon Redshift permission to
     # encrypt copied snapshots with the specified customer master key (CMK)
     # from AWS KMS in the destination region.
@@ -8352,6 +8967,13 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The snapshot copy grant can't be created because a grant with the
+    # same name already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyGrantAlreadyExistsFault AWS API Documentation
+    #
+    class SnapshotCopyGrantAlreadyExistsFault < Aws::EmptyStructure; end
+
     # @!attribute [rw] marker
     #   An optional parameter that specifies the starting point to return a
     #   set of response records. When the results of a
@@ -8376,6 +8998,21 @@ module Aws::Redshift
       :snapshot_copy_grants)
       include Aws::Structure
     end
+
+    # The specified snapshot copy grant can't be found. Make sure that the
+    # name is typed correctly and that the grant exists in the destination
+    # region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyGrantNotFoundFault AWS API Documentation
+    #
+    class SnapshotCopyGrantNotFoundFault < Aws::EmptyStructure; end
+
+    # The AWS account has exceeded the maximum number of snapshot copy
+    # grants in this region.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotCopyGrantQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotCopyGrantQuotaExceededFault < Aws::EmptyStructure; end
 
     # Describes the errors returned by a snapshot.
     #
@@ -8473,6 +9110,30 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The specified snapshot schedule already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotScheduleAlreadyExistsFault AWS API Documentation
+    #
+    class SnapshotScheduleAlreadyExistsFault < Aws::EmptyStructure; end
+
+    # We could not find the specified snapshot schedule.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotScheduleNotFoundFault AWS API Documentation
+    #
+    class SnapshotScheduleNotFoundFault < Aws::EmptyStructure; end
+
+    # You have exceeded the quota of snapshot schedules.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotScheduleQuotaExceededFault AWS API Documentation
+    #
+    class SnapshotScheduleQuotaExceededFault < Aws::EmptyStructure; end
+
+    # The specified snapshot schedule is already being updated.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SnapshotScheduleUpdateInProgressFault AWS API Documentation
+    #
+    class SnapshotScheduleUpdateInProgressFault < Aws::EmptyStructure; end
+
     # Describes a sorting entity
     #
     # @note When making an API call, you may pass SnapshotSortingEntity
@@ -8499,6 +9160,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # The specified Amazon Redshift event source could not be found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SourceNotFoundFault AWS API Documentation
+    #
+    class SourceNotFoundFault < Aws::EmptyStructure; end
+
     # Describes a subnet.
     #
     # @!attribute [rw] subnet_identifier
@@ -8520,6 +9187,49 @@ module Aws::Redshift
       :subnet_status)
       include Aws::Structure
     end
+
+    # A specified subnet is already in use by another cluster.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubnetAlreadyInUse AWS API Documentation
+    #
+    class SubnetAlreadyInUse < Aws::EmptyStructure; end
+
+    # There is already an existing event notification subscription with the
+    # specified name.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubscriptionAlreadyExistFault AWS API Documentation
+    #
+    class SubscriptionAlreadyExistFault < Aws::EmptyStructure; end
+
+    # The value specified for the event category was not one of the allowed
+    # values, or it specified a category that does not apply to the
+    # specified source type. The allowed values are Configuration,
+    # Management, Monitoring, and Security.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubscriptionCategoryNotFoundFault AWS API Documentation
+    #
+    class SubscriptionCategoryNotFoundFault < Aws::EmptyStructure; end
+
+    # An Amazon Redshift event with the specified event ID does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubscriptionEventIdNotFoundFault AWS API Documentation
+    #
+    class SubscriptionEventIdNotFoundFault < Aws::EmptyStructure; end
+
+    # An Amazon Redshift event notification subscription with the specified
+    # name does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubscriptionNotFoundFault AWS API Documentation
+    #
+    class SubscriptionNotFoundFault < Aws::EmptyStructure; end
+
+    # The value specified for the event severity was not one of the allowed
+    # values, or it specified a severity that does not apply to the
+    # specified source type. The allowed values are ERROR and INFO.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/SubscriptionSeverityNotFoundFault AWS API Documentation
+    #
+    class SubscriptionSeverityNotFoundFault < Aws::EmptyStructure; end
 
     # Describes the operations that are allowed on a maintenance track.
     #
@@ -8545,6 +9255,19 @@ module Aws::Redshift
       :name)
       include Aws::Structure
     end
+
+    # The number of tables in the cluster exceeds the limit for the
+    # requested new cluster node type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/TableLimitExceededFault AWS API Documentation
+    #
+    class TableLimitExceededFault < Aws::EmptyStructure; end
+
+    # The specified `TableRestoreRequestId` value was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/TableRestoreNotFoundFault AWS API Documentation
+    #
+    class TableRestoreNotFoundFault < Aws::EmptyStructure; end
 
     # Describes the status of a RestoreTableFromClusterSnapshot operation.
     #
@@ -8681,6 +9404,12 @@ module Aws::Redshift
       include Aws::Structure
     end
 
+    # You have exceeded the number of tags allowed.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/TagLimitExceededFault AWS API Documentation
+    #
+    class TagLimitExceededFault < Aws::EmptyStructure; end
+
     # A tag and its associated resource.
     #
     # @!attribute [rw] tag
@@ -8773,6 +9502,30 @@ module Aws::Redshift
       :marker)
       include Aws::Structure
     end
+
+    # Your account is not authorized to perform the requested operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/UnauthorizedOperation AWS API Documentation
+    #
+    class UnauthorizedOperation < Aws::EmptyStructure; end
+
+    # The specified region is incorrect or does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/UnknownSnapshotCopyRegionFault AWS API Documentation
+    #
+    class UnknownSnapshotCopyRegionFault < Aws::EmptyStructure; end
+
+    # The requested operation isn't supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/UnsupportedOperationFault AWS API Documentation
+    #
+    class UnsupportedOperationFault < Aws::EmptyStructure; end
+
+    # A request option was specified that is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/UnsupportedOptionFault AWS API Documentation
+    #
+    class UnsupportedOptionFault < Aws::EmptyStructure; end
 
     # A maintenance track that you can switch the current track to.
     #

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
@@ -294,6 +294,8 @@ module Aws::Rekognition
     VideoMetadata = Shapes::StructureShape.new(name: 'VideoMetadata')
     VideoTooLargeException = Shapes::StructureShape.new(name: 'VideoTooLargeException')
 
+    AccessDeniedException.struct_class = Types::AccessDeniedException
+
     AgeRange.add_member(:low, Shapes::ShapeRef.new(shape: UInteger, location_name: "Low"))
     AgeRange.add_member(:high, Shapes::ShapeRef.new(shape: UInteger, location_name: "High"))
     AgeRange.struct_class = Types::AgeRange
@@ -739,6 +741,8 @@ module Aws::Rekognition
     HumanLoopQuotaExceededException.add_member(:service_code, Shapes::ShapeRef.new(shape: String, location_name: "ServiceCode"))
     HumanLoopQuotaExceededException.struct_class = Types::HumanLoopQuotaExceededException
 
+    IdempotentParameterMismatchException.struct_class = Types::IdempotentParameterMismatchException
+
     Image.add_member(:bytes, Shapes::ShapeRef.new(shape: ImageBlob, location_name: "Bytes"))
     Image.add_member(:s3_object, Shapes::ShapeRef.new(shape: S3Object, location_name: "S3Object"))
     Image.struct_class = Types::Image
@@ -746,6 +750,8 @@ module Aws::Rekognition
     ImageQuality.add_member(:brightness, Shapes::ShapeRef.new(shape: Float, location_name: "Brightness"))
     ImageQuality.add_member(:sharpness, Shapes::ShapeRef.new(shape: Float, location_name: "Sharpness"))
     ImageQuality.struct_class = Types::ImageQuality
+
+    ImageTooLargeException.struct_class = Types::ImageTooLargeException
 
     IndexFacesRequest.add_member(:collection_id, Shapes::ShapeRef.new(shape: CollectionId, required: true, location_name: "CollectionId"))
     IndexFacesRequest.add_member(:image, Shapes::ShapeRef.new(shape: Image, required: true, location_name: "Image"))
@@ -766,6 +772,16 @@ module Aws::Rekognition
     Instance.struct_class = Types::Instance
 
     Instances.member = Shapes::ShapeRef.new(shape: Instance)
+
+    InternalServerError.struct_class = Types::InternalServerError
+
+    InvalidImageFormatException.struct_class = Types::InvalidImageFormatException
+
+    InvalidPaginationTokenException.struct_class = Types::InvalidPaginationTokenException
+
+    InvalidParameterException.struct_class = Types::InvalidParameterException
+
+    InvalidS3ObjectException.struct_class = Types::InvalidS3ObjectException
 
     KinesisDataStream.add_member(:arn, Shapes::ShapeRef.new(shape: KinesisDataArn, location_name: "Arn"))
     KinesisDataStream.struct_class = Types::KinesisDataStream
@@ -793,6 +809,8 @@ module Aws::Rekognition
     Landmark.struct_class = Types::Landmark
 
     Landmarks.member = Shapes::ShapeRef.new(shape: Landmark)
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListCollectionsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: PaginationToken, location_name: "NextToken"))
     ListCollectionsRequest.add_member(:max_results, Shapes::ShapeRef.new(shape: PageSize, location_name: "MaxResults"))
@@ -900,6 +918,8 @@ module Aws::Rekognition
 
     ProjectVersionDescriptions.member = Shapes::ShapeRef.new(shape: ProjectVersionDescription)
 
+    ProvisionedThroughputExceededException.struct_class = Types::ProvisionedThroughputExceededException
+
     Reasons.member = Shapes::ShapeRef.new(shape: Reason)
 
     RecognizeCelebritiesRequest.add_member(:image, Shapes::ShapeRef.new(shape: Image, required: true, location_name: "Image"))
@@ -914,6 +934,14 @@ module Aws::Rekognition
     RegionOfInterest.struct_class = Types::RegionOfInterest
 
     RegionsOfInterest.member = Shapes::ShapeRef.new(shape: RegionOfInterest)
+
+    ResourceAlreadyExistsException.struct_class = Types::ResourceAlreadyExistsException
+
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
+    ResourceNotReadyException.struct_class = Types::ResourceNotReadyException
 
     S3Object.add_member(:bucket, Shapes::ShapeRef.new(shape: S3Bucket, location_name: "Bucket"))
     S3Object.add_member(:name, Shapes::ShapeRef.new(shape: S3ObjectName, location_name: "Name"))
@@ -1090,6 +1118,8 @@ module Aws::Rekognition
 
     TextDetectionResults.member = Shapes::ShapeRef.new(shape: TextDetectionResult)
 
+    ThrottlingException.struct_class = Types::ThrottlingException
+
     TrainingData.add_member(:assets, Shapes::ShapeRef.new(shape: Assets, location_name: "Assets"))
     TrainingData.struct_class = Types::TrainingData
 
@@ -1117,6 +1147,8 @@ module Aws::Rekognition
     VideoMetadata.add_member(:frame_height, Shapes::ShapeRef.new(shape: ULong, location_name: "FrameHeight"))
     VideoMetadata.add_member(:frame_width, Shapes::ShapeRef.new(shape: ULong, location_name: "FrameWidth"))
     VideoMetadata.struct_class = Types::VideoMetadata
+
+    VideoTooLargeException.struct_class = Types::VideoTooLargeException
 
 
     # @api private

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
@@ -10,6 +10,17 @@ module Aws::Rekognition
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::AccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class HumanLoopQuotaExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -32,6 +43,171 @@ module Aws::Rekognition
       # @return [String]
       def service_code
         @data[:service_code]
+      end
+
+    end
+
+    class IdempotentParameterMismatchException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::IdempotentParameterMismatchException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ImageTooLargeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ImageTooLargeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalServerError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::InternalServerError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidImageFormatException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::InvalidImageFormatException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidPaginationTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::InvalidPaginationTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::InvalidParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3ObjectException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::InvalidS3ObjectException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProvisionedThroughputExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ProvisionedThroughputExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceAlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ResourceAlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotReadyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ResourceNotReadyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ThrottlingException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::ThrottlingException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class VideoTooLargeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Rekognition::Types::VideoTooLargeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
@@ -8,6 +8,10 @@
 module Aws::Rekognition
   module Types
 
+    # You are not authorized to perform the action.
+    #
+    class AccessDeniedException < Aws::EmptyStructure; end
+
     # Structure containing the estimated age range, in years, for a face.
     #
     # Amazon Rekognition estimates an age range for faces detected in the
@@ -2543,6 +2547,12 @@ module Aws::Rekognition
       include Aws::Structure
     end
 
+    # A `ClientRequestToken` input parameter was reused with an operation,
+    # but at least one of the other input parameters is different from the
+    # previous call to the operation.
+    #
+    class IdempotentParameterMismatchException < Aws::EmptyStructure; end
+
     # Provides the input image either as bytes or an S3 object.
     #
     # You pass image bytes to an Amazon Rekognition API operation by using
@@ -2616,6 +2626,12 @@ module Aws::Rekognition
       :sharpness)
       include Aws::Structure
     end
+
+    # The input image size exceeds the allowed limit. For more information,
+    # see Limits in Amazon Rekognition in the Amazon Rekognition Developer
+    # Guide.
+    #
+    class ImageTooLargeException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass IndexFacesRequest
     #   data as a hash:
@@ -2791,6 +2807,28 @@ module Aws::Rekognition
       include Aws::Structure
     end
 
+    # Amazon Rekognition experienced a service issue. Try your call again.
+    #
+    class InternalServerError < Aws::EmptyStructure; end
+
+    # The provided image format is not supported.
+    #
+    class InvalidImageFormatException < Aws::EmptyStructure; end
+
+    # Pagination token in the request is not valid.
+    #
+    class InvalidPaginationTokenException < Aws::EmptyStructure; end
+
+    # Input parameter violated a constraint. Validate your parameter before
+    # calling the API operation again.
+    #
+    class InvalidParameterException < Aws::EmptyStructure; end
+
+    # Amazon Rekognition is unable to access the S3 object specified in the
+    # request.
+    #
+    class InvalidS3ObjectException < Aws::EmptyStructure; end
+
     # The Kinesis data stream Amazon Rekognition to which the analysis
     # results of a Amazon Rekognition stream processor are streamed. For
     # more information, see CreateStreamProcessor in the Amazon Rekognition
@@ -2908,6 +2946,15 @@ module Aws::Rekognition
       :y)
       include Aws::Structure
     end
+
+    # An Amazon Rekognition service limit was exceeded. For example, if you
+    # start too many Amazon Rekognition Video jobs concurrently, calls to
+    # start operations (`StartLabelDetection`, for example) will raise a
+    # `LimitExceededException` exception (HTTP status code: 400) until the
+    # number of concurrently running jobs is below the Amazon Rekognition
+    # service limit.
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListCollectionsRequest
     #   data as a hash:
@@ -3385,6 +3432,11 @@ module Aws::Rekognition
       include Aws::Structure
     end
 
+    # The number of requests exceeded your throughput limit. If you want to
+    # increase this limit, contact Amazon Rekognition.
+    #
+    class ProvisionedThroughputExceededException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass RecognizeCelebritiesRequest
     #   data as a hash:
     #
@@ -3478,6 +3530,22 @@ module Aws::Rekognition
       :bounding_box)
       include Aws::Structure
     end
+
+    # A collection with the specified ID already exists.
+    #
+    class ResourceAlreadyExistsException < Aws::EmptyStructure; end
+
+    class ResourceInUseException < Aws::EmptyStructure; end
+
+    # The collection specified in the request cannot be found.
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
+    # The requested resource isn't ready. For example, this exception
+    # occurs when you call `DetectCustomLabels` with a model version that
+    # isn't deployed.
+    #
+    class ResourceNotReadyException < Aws::EmptyStructure; end
 
     # Provides the S3 bucket name and object name.
     #
@@ -4598,6 +4666,11 @@ module Aws::Rekognition
       include Aws::Structure
     end
 
+    # Amazon Rekognition is temporarily unable to process the request. Try
+    # your call again.
+    #
+    class ThrottlingException < Aws::EmptyStructure; end
+
     # The dataset used for training.
     #
     # @note When making an API call, you may pass TrainingData
@@ -4741,6 +4814,11 @@ module Aws::Rekognition
       :frame_width)
       include Aws::Structure
     end
+
+    # The file size or duration of the supplied media is too large. The
+    # maximum file size is 10GB. The maximum duration is 6 hours.
+    #
+    class VideoTooLargeException < Aws::EmptyStructure; end
 
   end
 end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
@@ -587,6 +587,10 @@ module Aws::S3
     Bucket.add_member(:creation_date, Shapes::ShapeRef.new(shape: CreationDate, location_name: "CreationDate"))
     Bucket.struct_class = Types::Bucket
 
+    BucketAlreadyExists.struct_class = Types::BucketAlreadyExists
+
+    BucketAlreadyOwnedByYou.struct_class = Types::BucketAlreadyOwnedByYou
+
     BucketLifecycleConfiguration.add_member(:rules, Shapes::ShapeRef.new(shape: LifecycleRules, required: true, location_name: "Rule"))
     BucketLifecycleConfiguration.struct_class = Types::BucketLifecycleConfiguration
 
@@ -1544,6 +1548,12 @@ module Aws::S3
 
     MultipartUploadList.member = Shapes::ShapeRef.new(shape: MultipartUpload)
 
+    NoSuchBucket.struct_class = Types::NoSuchBucket
+
+    NoSuchKey.struct_class = Types::NoSuchKey
+
+    NoSuchUpload.struct_class = Types::NoSuchUpload
+
     NoncurrentVersionExpiration.add_member(:noncurrent_days, Shapes::ShapeRef.new(shape: Days, location_name: "NoncurrentDays"))
     NoncurrentVersionExpiration.struct_class = Types::NoncurrentVersionExpiration
 
@@ -1574,6 +1584,8 @@ module Aws::S3
     Object.add_member(:owner, Shapes::ShapeRef.new(shape: Owner, location_name: "Owner"))
     Object.struct_class = Types::Object
 
+    ObjectAlreadyInActiveTierError.struct_class = Types::ObjectAlreadyInActiveTierError
+
     ObjectIdentifier.add_member(:key, Shapes::ShapeRef.new(shape: ObjectKey, required: true, location_name: "Key"))
     ObjectIdentifier.add_member(:version_id, Shapes::ShapeRef.new(shape: ObjectVersionId, location_name: "VersionId"))
     ObjectIdentifier.struct_class = Types::ObjectIdentifier
@@ -1595,6 +1607,8 @@ module Aws::S3
 
     ObjectLockRule.add_member(:default_retention, Shapes::ShapeRef.new(shape: DefaultRetention, location_name: "DefaultRetention"))
     ObjectLockRule.struct_class = Types::ObjectLockRule
+
+    ObjectNotInActiveTierError.struct_class = Types::ObjectNotInActiveTierError
 
     ObjectVersion.add_member(:etag, Shapes::ShapeRef.new(shape: ETag, location_name: "ETag"))
     ObjectVersion.add_member(:size, Shapes::ShapeRef.new(shape: Size, location_name: "Size"))

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
@@ -10,5 +10,82 @@ module Aws::S3
 
     extend Aws::Errors::DynamicErrors
 
+    class BucketAlreadyExists < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::BucketAlreadyExists] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BucketAlreadyOwnedByYou < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::BucketAlreadyOwnedByYou] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchBucket < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::NoSuchBucket] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchKey < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::NoSuchKey] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NoSuchUpload < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::NoSuchUpload] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ObjectAlreadyInActiveTierError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::ObjectAlreadyInActiveTierError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ObjectNotInActiveTierError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::S3::Types::ObjectNotInActiveTierError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
@@ -433,6 +433,24 @@ module Aws::S3
       include Aws::Structure
     end
 
+    # The requested bucket name is not available. The bucket namespace is
+    # shared by all users of the system. Please select a different name and
+    # try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketAlreadyExists AWS API Documentation
+    #
+    class BucketAlreadyExists < Aws::EmptyStructure; end
+
+    # The bucket you tried to create already exists, and you own it. Amazon
+    # S3 returns this error in all AWS Regions except in the North Virginia
+    # Region. For legacy compatibility, if you re-create an existing bucket
+    # that you already own in the North Virginia Region, Amazon S3 returns
+    # 200 OK and resets the bucket access control lists (ACLs).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketAlreadyOwnedByYou AWS API Documentation
+    #
+    class BucketAlreadyOwnedByYou < Aws::EmptyStructure; end
+
     # Specifies the lifecycle configuration for objects in an Amazon S3
     # bucket. For more information, see [Object Lifecycle Management][1] in
     # the *Amazon Simple Storage Service Developer Guide*.
@@ -7614,6 +7632,24 @@ module Aws::S3
       include Aws::Structure
     end
 
+    # The specified bucket does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NoSuchBucket AWS API Documentation
+    #
+    class NoSuchBucket < Aws::EmptyStructure; end
+
+    # The specified key does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NoSuchKey AWS API Documentation
+    #
+    class NoSuchKey < Aws::EmptyStructure; end
+
+    # The specified multipart upload does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NoSuchUpload AWS API Documentation
+    #
+    class NoSuchUpload < Aws::EmptyStructure; end
+
     # Specifies when noncurrent object versions expire. Upon expiration,
     # Amazon S3 permanently deletes the noncurrent object versions. You set
     # this lifecycle configuration action on a bucket that has versioning
@@ -7896,6 +7932,12 @@ module Aws::S3
       include Aws::Structure
     end
 
+    # This operation is not allowed against this storage tier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectAlreadyInActiveTierError AWS API Documentation
+    #
+    class ObjectAlreadyInActiveTierError < Aws::EmptyStructure; end
+
     # Object Identifier is unique value to identify objects.
     #
     # @note When making an API call, you may pass ObjectIdentifier
@@ -8025,6 +8067,13 @@ module Aws::S3
       :default_retention)
       include Aws::Structure
     end
+
+    # The source object of the COPY operation is not in the active tier and
+    # is only stored in Amazon S3 Glacier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectNotInActiveTierError AWS API Documentation
+    #
+    class ObjectNotInActiveTierError < Aws::EmptyStructure; end
 
     # The version of an object.
     #

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
@@ -884,6 +884,8 @@ module Aws::ServiceCatalog
 
     DisassociateTagOptionFromResourceOutput.struct_class = Types::DisassociateTagOptionFromResourceOutput
 
+    DuplicateResourceException.struct_class = Types::DuplicateResourceException
+
     EnableAWSOrganizationsAccessInput.struct_class = Types::EnableAWSOrganizationsAccessInput
 
     EnableAWSOrganizationsAccessOutput.struct_class = Types::EnableAWSOrganizationsAccessOutput
@@ -932,6 +934,10 @@ module Aws::ServiceCatalog
     GetAWSOrganizationsAccessStatusOutput.add_member(:access_status, Shapes::ShapeRef.new(shape: AccessStatus, location_name: "AccessStatus"))
     GetAWSOrganizationsAccessStatusOutput.struct_class = Types::GetAWSOrganizationsAccessStatusOutput
 
+    InvalidParametersException.struct_class = Types::InvalidParametersException
+
+    InvalidStateException.struct_class = Types::InvalidStateException
+
     LaunchPathSummaries.member = Shapes::ShapeRef.new(shape: LaunchPathSummary)
 
     LaunchPathSummary.add_member(:id, Shapes::ShapeRef.new(shape: Id, location_name: "Id"))
@@ -939,6 +945,8 @@ module Aws::ServiceCatalog
     LaunchPathSummary.add_member(:tags, Shapes::ShapeRef.new(shape: Tags, location_name: "Tags"))
     LaunchPathSummary.add_member(:name, Shapes::ShapeRef.new(shape: PortfolioName, location_name: "Name"))
     LaunchPathSummary.struct_class = Types::LaunchPathSummary
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListAcceptedPortfolioSharesInput.add_member(:accept_language, Shapes::ShapeRef.new(shape: AcceptLanguage, location_name: "AcceptLanguage"))
     ListAcceptedPortfolioSharesInput.add_member(:page_token, Shapes::ShapeRef.new(shape: PageToken, location_name: "PageToken"))
@@ -1133,6 +1141,8 @@ module Aws::ServiceCatalog
     Namespaces.member = Shapes::ShapeRef.new(shape: AccountId)
 
     NotificationArns.member = Shapes::ShapeRef.new(shape: NotificationArn)
+
+    OperationNotSupportedException.struct_class = Types::OperationNotSupportedException
 
     OrganizationNode.add_member(:type, Shapes::ShapeRef.new(shape: OrganizationNodeType, location_name: "Type"))
     OrganizationNode.add_member(:value, Shapes::ShapeRef.new(shape: OrganizationNodeValue, location_name: "Value"))
@@ -1423,6 +1433,10 @@ module Aws::ServiceCatalog
 
     ResourceDetails.member = Shapes::ShapeRef.new(shape: ResourceDetail)
 
+    ResourceInUseException.struct_class = Types::ResourceInUseException
+
+    ResourceNotFoundException.struct_class = Types::ResourceNotFoundException
+
     ResourceTargetDefinition.add_member(:attribute, Shapes::ShapeRef.new(shape: ResourceAttribute, location_name: "Attribute"))
     ResourceTargetDefinition.add_member(:name, Shapes::ShapeRef.new(shape: PropertyName, location_name: "Name"))
     ResourceTargetDefinition.add_member(:requires_recreation, Shapes::ShapeRef.new(shape: RequiresRecreation, location_name: "RequiresRecreation"))
@@ -1545,6 +1559,8 @@ module Aws::ServiceCatalog
     TagOptionDetail.struct_class = Types::TagOptionDetail
 
     TagOptionDetails.member = Shapes::ShapeRef.new(shape: TagOptionDetail)
+
+    TagOptionNotMigratedException.struct_class = Types::TagOptionNotMigratedException
 
     TagOptionSummaries.member = Shapes::ShapeRef.new(shape: TagOptionSummary)
 

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
@@ -10,5 +10,93 @@ module Aws::ServiceCatalog
 
     extend Aws::Errors::DynamicErrors
 
+    class DuplicateResourceException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::DuplicateResourceException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParametersException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::InvalidParametersException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidStateException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::InvalidStateException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OperationNotSupportedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::OperationNotSupportedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceInUseException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::ResourceInUseException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ResourceNotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::ResourceNotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TagOptionNotMigratedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::ServiceCatalog::Types::TagOptionNotMigratedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
@@ -2636,6 +2636,12 @@ module Aws::ServiceCatalog
     #
     class DisassociateTagOptionFromResourceOutput < Aws::EmptyStructure; end
 
+    # The specified resource is a duplicate.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DuplicateResourceException AWS API Documentation
+    #
+    class DuplicateResourceException < Aws::EmptyStructure; end
+
     # @api private
     #
     # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/EnableAWSOrganizationsAccessInput AWS API Documentation
@@ -2847,6 +2853,20 @@ module Aws::ServiceCatalog
       include Aws::Structure
     end
 
+    # One or more parameters provided to the operation are not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/InvalidParametersException AWS API Documentation
+    #
+    class InvalidParametersException < Aws::EmptyStructure; end
+
+    # An attempt was made to modify a resource that is in a state that is
+    # not valid. Check your resources to ensure that they are in valid
+    # states before retrying the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/InvalidStateException AWS API Documentation
+    #
+    class InvalidStateException < Aws::EmptyStructure; end
+
     # Summary information about a product path for a user.
     #
     # @!attribute [rw] id
@@ -2874,6 +2894,14 @@ module Aws::ServiceCatalog
       :name)
       include Aws::Structure
     end
+
+    # The current limits of the service would have been exceeded by this
+    # operation. Decrease your resource use or increase your service limits
+    # and retry the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListAcceptedPortfolioSharesInput
     #   data as a hash:
@@ -4052,6 +4080,12 @@ module Aws::ServiceCatalog
       :page_token)
       include Aws::Structure
     end
+
+    # The operation is not supported.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/OperationNotSupportedException AWS API Documentation
+    #
+    class OperationNotSupportedException < Aws::EmptyStructure; end
 
     # Information about the organization node.
     #
@@ -5460,6 +5494,19 @@ module Aws::ServiceCatalog
       include Aws::Structure
     end
 
+    # A resource that is currently in use. Ensure that the resource is not
+    # in use and retry the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ResourceInUseException AWS API Documentation
+    #
+    class ResourceInUseException < Aws::EmptyStructure; end
+
+    # The specified resource was not found.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ResourceNotFoundException AWS API Documentation
+    #
+    class ResourceNotFoundException < Aws::EmptyStructure; end
+
     # Information about a change to a resource attribute.
     #
     # @!attribute [rw] attribute
@@ -6043,6 +6090,15 @@ module Aws::ServiceCatalog
       :id)
       include Aws::Structure
     end
+
+    # An operation requiring TagOptions failed because the TagOptions
+    # migration process has not been performed for this account. Please use
+    # the AWS console to perform the migration process before retrying the
+    # operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/TagOptionNotMigratedException AWS API Documentation
+    #
+    class TagOptionNotMigratedException < Aws::EmptyStructure; end
 
     # Summary information about a TagOption.
     #

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
@@ -325,6 +325,8 @@ module Aws::SES
     VerifyEmailIdentityResponse = Shapes::StructureShape.new(name: 'VerifyEmailIdentityResponse')
     WorkmailAction = Shapes::StructureShape.new(name: 'WorkmailAction')
 
+    AccountSendingPausedException.struct_class = Types::AccountSendingPausedException
+
     AddHeaderAction.add_member(:header_name, Shapes::ShapeRef.new(shape: HeaderName, required: true, location_name: "HeaderName"))
     AddHeaderAction.add_member(:header_value, Shapes::ShapeRef.new(shape: HeaderValue, required: true, location_name: "HeaderValue"))
     AddHeaderAction.struct_class = Types::AddHeaderAction
@@ -452,6 +454,8 @@ module Aws::SES
     CreateTemplateRequest.struct_class = Types::CreateTemplateRequest
 
     CreateTemplateResponse.struct_class = Types::CreateTemplateResponse
+
+    CustomVerificationEmailInvalidContentException.struct_class = Types::CustomVerificationEmailInvalidContentException
 
     CustomVerificationEmailTemplate.add_member(:template_name, Shapes::ShapeRef.new(shape: TemplateName, location_name: "TemplateName"))
     CustomVerificationEmailTemplate.add_member(:from_email_address, Shapes::ShapeRef.new(shape: FromAddress, location_name: "FromEmailAddress"))
@@ -681,12 +685,18 @@ module Aws::SES
     InvalidCloudWatchDestinationException.add_member(:event_destination_name, Shapes::ShapeRef.new(shape: EventDestinationName, location_name: "EventDestinationName"))
     InvalidCloudWatchDestinationException.struct_class = Types::InvalidCloudWatchDestinationException
 
+    InvalidConfigurationSetException.struct_class = Types::InvalidConfigurationSetException
+
+    InvalidDeliveryOptionsException.struct_class = Types::InvalidDeliveryOptionsException
+
     InvalidFirehoseDestinationException.add_member(:configuration_set_name, Shapes::ShapeRef.new(shape: ConfigurationSetName, location_name: "ConfigurationSetName"))
     InvalidFirehoseDestinationException.add_member(:event_destination_name, Shapes::ShapeRef.new(shape: EventDestinationName, location_name: "EventDestinationName"))
     InvalidFirehoseDestinationException.struct_class = Types::InvalidFirehoseDestinationException
 
     InvalidLambdaFunctionException.add_member(:function_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, location_name: "FunctionArn"))
     InvalidLambdaFunctionException.struct_class = Types::InvalidLambdaFunctionException
+
+    InvalidPolicyException.struct_class = Types::InvalidPolicyException
 
     InvalidRenderingParameterException.add_member(:template_name, Shapes::ShapeRef.new(shape: TemplateName, location_name: "TemplateName"))
     InvalidRenderingParameterException.struct_class = Types::InvalidRenderingParameterException
@@ -704,6 +714,8 @@ module Aws::SES
     InvalidTemplateException.add_member(:template_name, Shapes::ShapeRef.new(shape: TemplateName, location_name: "TemplateName"))
     InvalidTemplateException.struct_class = Types::InvalidTemplateException
 
+    InvalidTrackingOptionsException.struct_class = Types::InvalidTrackingOptionsException
+
     KinesisFirehoseDestination.add_member(:iam_role_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "IAMRoleARN"))
     KinesisFirehoseDestination.add_member(:delivery_stream_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "DeliveryStreamARN"))
     KinesisFirehoseDestination.struct_class = Types::KinesisFirehoseDestination
@@ -712,6 +724,8 @@ module Aws::SES
     LambdaAction.add_member(:function_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "FunctionArn"))
     LambdaAction.add_member(:invocation_type, Shapes::ShapeRef.new(shape: InvocationType, location_name: "InvocationType"))
     LambdaAction.struct_class = Types::LambdaAction
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListConfigurationSetsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location_name: "NextToken"))
     ListConfigurationSetsRequest.add_member(:max_items, Shapes::ShapeRef.new(shape: MaxItems, location_name: "MaxItems"))
@@ -770,6 +784,8 @@ module Aws::SES
     MailFromDomainAttributes.key = Shapes::ShapeRef.new(shape: Identity)
     MailFromDomainAttributes.value = Shapes::ShapeRef.new(shape: IdentityMailFromDomainAttributes)
 
+    MailFromDomainNotVerifiedException.struct_class = Types::MailFromDomainNotVerifiedException
+
     Message.add_member(:subject, Shapes::ShapeRef.new(shape: Content, required: true, location_name: "Subject"))
     Message.add_member(:body, Shapes::ShapeRef.new(shape: Body, required: true, location_name: "Body"))
     Message.struct_class = Types::Message
@@ -778,6 +794,8 @@ module Aws::SES
     MessageDsn.add_member(:arrival_date, Shapes::ShapeRef.new(shape: ArrivalDate, location_name: "ArrivalDate"))
     MessageDsn.add_member(:extension_fields, Shapes::ShapeRef.new(shape: ExtensionFieldList, location_name: "ExtensionFields"))
     MessageDsn.struct_class = Types::MessageDsn
+
+    MessageRejected.struct_class = Types::MessageRejected
 
     MessageTag.add_member(:name, Shapes::ShapeRef.new(shape: MessageTagName, required: true, location_name: "Name"))
     MessageTag.add_member(:value, Shapes::ShapeRef.new(shape: MessageTagValue, required: true, location_name: "Value"))
@@ -795,6 +813,8 @@ module Aws::SES
     PolicyMap.value = Shapes::ShapeRef.new(shape: Policy)
 
     PolicyNameList.member = Shapes::ShapeRef.new(shape: PolicyName)
+
+    ProductionAccessNotGrantedException.struct_class = Types::ProductionAccessNotGrantedException
 
     PutConfigurationSetDeliveryOptionsRequest.add_member(:configuration_set_name, Shapes::ShapeRef.new(shape: ConfigurationSetName, required: true, location_name: "ConfigurationSetName"))
     PutConfigurationSetDeliveryOptionsRequest.add_member(:delivery_options, Shapes::ShapeRef.new(shape: DeliveryOptions, location_name: "DeliveryOptions"))

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
@@ -10,6 +10,17 @@ module Aws::SES
 
     extend Aws::Errors::DynamicErrors
 
+    class AccountSendingPausedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::AccountSendingPausedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class AlreadyExistsException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -86,6 +97,17 @@ module Aws::SES
       # @return [String]
       def configuration_set_name
         @data[:configuration_set_name]
+      end
+
+    end
+
+    class CustomVerificationEmailInvalidContentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::CustomVerificationEmailInvalidContentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -201,6 +223,28 @@ module Aws::SES
 
     end
 
+    class InvalidConfigurationSetException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::InvalidConfigurationSetException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidDeliveryOptionsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::InvalidDeliveryOptionsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidFirehoseDestinationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -234,6 +278,17 @@ module Aws::SES
       # @return [String]
       def function_arn
         @data[:function_arn]
+      end
+
+    end
+
+    class InvalidPolicyException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::InvalidPolicyException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -323,6 +378,50 @@ module Aws::SES
 
     end
 
+    class InvalidTrackingOptionsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::InvalidTrackingOptionsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MailFromDomainNotVerifiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::MailFromDomainNotVerifiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MessageRejected < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::MessageRejected] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class MissingRenderingAttributeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -335,6 +434,17 @@ module Aws::SES
       # @return [String]
       def template_name
         @data[:template_name]
+      end
+
+    end
+
+    class ProductionAccessNotGrantedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SES::Types::ProductionAccessNotGrantedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
@@ -8,6 +8,16 @@
 module Aws::SES
   module Types
 
+    # Indicates that email sending is disabled for your entire Amazon SES
+    # account.
+    #
+    # You can enable or disable email sending for your Amazon SES account
+    # using UpdateAccountSendingEnabled.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/AccountSendingPausedException AWS API Documentation
+    #
+    class AccountSendingPausedException < Aws::EmptyStructure; end
+
     # When included in a receipt rule, this action adds a header to the
     # received email.
     #
@@ -1050,6 +1060,13 @@ module Aws::SES
     # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/CreateTemplateResponse AWS API Documentation
     #
     class CreateTemplateResponse < Aws::EmptyStructure; end
+
+    # Indicates that custom verification email template provided content is
+    # invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/CustomVerificationEmailInvalidContentException AWS API Documentation
+    #
+    class CustomVerificationEmailInvalidContentException < Aws::EmptyStructure; end
 
     # Contains information about a custom verification email template.
     #
@@ -2488,6 +2505,19 @@ module Aws::SES
       include Aws::Structure
     end
 
+    # Indicates that the configuration set is invalid. See the error message
+    # for details.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/InvalidConfigurationSetException AWS API Documentation
+    #
+    class InvalidConfigurationSetException < Aws::EmptyStructure; end
+
+    # Indicates that provided delivery option is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/InvalidDeliveryOptionsException AWS API Documentation
+    #
+    class InvalidDeliveryOptionsException < Aws::EmptyStructure; end
+
     # Indicates that the Amazon Kinesis Firehose destination is invalid. See
     # the error message for details.
     #
@@ -2526,6 +2556,13 @@ module Aws::SES
       :function_arn)
       include Aws::Structure
     end
+
+    # Indicates that the provided policy is invalid. Check the error stack
+    # for more information about what caused the error.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/InvalidPolicyException AWS API Documentation
+    #
+    class InvalidPolicyException < Aws::EmptyStructure; end
 
     # Indicates that one or more of the replacement values you provided is
     # invalid. This error may occur when the TemplateData object contains
@@ -2613,6 +2650,20 @@ module Aws::SES
       :template_name)
       include Aws::Structure
     end
+
+    # Indicates that the custom domain to be used for open and click
+    # tracking redirects is invalid. This error appears most often in the
+    # following situations:
+    #
+    # * When the tracking domain you specified is not verified in Amazon
+    #   SES.
+    #
+    # * When the tracking domain you specified is not a valid domain or
+    #   subdomain.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/InvalidTrackingOptionsException AWS API Documentation
+    #
+    class InvalidTrackingOptionsException < Aws::EmptyStructure; end
 
     # Contains the delivery stream ARN and the IAM role ARN associated with
     # an Amazon Kinesis Firehose event destination.
@@ -2728,6 +2779,18 @@ module Aws::SES
       :invocation_type)
       include Aws::Structure
     end
+
+    # Indicates that a resource could not be created because of service
+    # limits. For a list of Amazon SES limits, see the [Amazon SES Developer
+    # Guide][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/limits.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # Represents a request to list the configuration sets associated with
     # your AWS account. Configuration sets enable you to publish email
@@ -3098,6 +3161,19 @@ module Aws::SES
       include Aws::Structure
     end
 
+    # Indicates that the message could not be sent because Amazon SES could
+    # not read the MX record required to use the specified MAIL FROM domain.
+    # For information about editing the custom MAIL FROM domain settings for
+    # an identity, see the [Amazon SES Developer Guide][1].
+    #
+    #
+    #
+    # [1]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-edit.html
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/MailFromDomainNotVerifiedException AWS API Documentation
+    #
+    class MailFromDomainNotVerifiedException < Aws::EmptyStructure; end
+
     # Represents the message to be sent, composed of a subject and a body.
     #
     # @note When making an API call, you may pass Message
@@ -3194,6 +3270,14 @@ module Aws::SES
       include Aws::Structure
     end
 
+    # Indicates that the action failed, and the message could not be sent.
+    # Check the error stack for more information about what caused the
+    # error.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/MessageRejected AWS API Documentation
+    #
+    class MessageRejected < Aws::EmptyStructure; end
+
     # Contains the name and value of a tag that you can provide to
     # `SendEmail` or `SendRawEmail` to apply to an email.
     #
@@ -3253,6 +3337,12 @@ module Aws::SES
       :template_name)
       include Aws::Structure
     end
+
+    # Indicates that the account has not been granted production access.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/ProductionAccessNotGrantedException AWS API Documentation
+    #
+    class ProductionAccessNotGrantedException < Aws::EmptyStructure; end
 
     # A request to modify the delivery options for a configuration set.
     #

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client_api.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client_api.rb
@@ -252,6 +252,12 @@ module Aws::SESV2
     VolumeStatistics = Shapes::StructureShape.new(name: 'VolumeStatistics')
     WarmupStatus = Shapes::StringShape.new(name: 'WarmupStatus')
 
+    AccountSuspendedException.struct_class = Types::AccountSuspendedException
+
+    AlreadyExistsException.struct_class = Types::AlreadyExistsException
+
+    BadRequestException.struct_class = Types::BadRequestException
+
     BlacklistEntries.member = Shapes::ShapeRef.new(shape: BlacklistEntry)
 
     BlacklistEntry.add_member(:rbl_name, Shapes::ShapeRef.new(shape: RblName, location_name: "RblName"))
@@ -277,6 +283,8 @@ module Aws::SESV2
     CloudWatchDimensionConfiguration.struct_class = Types::CloudWatchDimensionConfiguration
 
     CloudWatchDimensionConfigurations.member = Shapes::ShapeRef.new(shape: CloudWatchDimensionConfiguration)
+
+    ConcurrentModificationException.struct_class = Types::ConcurrentModificationException
 
     ConfigurationSetNameList.member = Shapes::ShapeRef.new(shape: ConfigurationSetName)
 
@@ -575,6 +583,8 @@ module Aws::SESV2
     InboxPlacementTrackingOption.add_member(:tracked_isps, Shapes::ShapeRef.new(shape: IspNameList, location_name: "TrackedIsps"))
     InboxPlacementTrackingOption.struct_class = Types::InboxPlacementTrackingOption
 
+    InvalidNextTokenException.struct_class = Types::InvalidNextTokenException
+
     IpList.member = Shapes::ShapeRef.new(shape: Ip)
 
     IspNameList.member = Shapes::ShapeRef.new(shape: IspName)
@@ -588,6 +598,8 @@ module Aws::SESV2
     KinesisFirehoseDestination.add_member(:iam_role_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "IamRoleArn"))
     KinesisFirehoseDestination.add_member(:delivery_stream_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "DeliveryStreamArn"))
     KinesisFirehoseDestination.struct_class = Types::KinesisFirehoseDestination
+
+    LimitExceededException.struct_class = Types::LimitExceededException
 
     ListConfigurationSetsRequest.add_member(:next_token, Shapes::ShapeRef.new(shape: NextToken, location: "querystring", location_name: "NextToken"))
     ListConfigurationSetsRequest.add_member(:page_size, Shapes::ShapeRef.new(shape: MaxItems, location: "querystring", location_name: "PageSize"))
@@ -656,15 +668,21 @@ module Aws::SESV2
     MailFromAttributes.add_member(:behavior_on_mx_failure, Shapes::ShapeRef.new(shape: BehaviorOnMxFailure, required: true, location_name: "BehaviorOnMxFailure"))
     MailFromAttributes.struct_class = Types::MailFromAttributes
 
+    MailFromDomainNotVerifiedException.struct_class = Types::MailFromDomainNotVerifiedException
+
     Message.add_member(:subject, Shapes::ShapeRef.new(shape: Content, required: true, location_name: "Subject"))
     Message.add_member(:body, Shapes::ShapeRef.new(shape: Body, required: true, location_name: "Body"))
     Message.struct_class = Types::Message
+
+    MessageRejected.struct_class = Types::MessageRejected
 
     MessageTag.add_member(:name, Shapes::ShapeRef.new(shape: MessageTagName, required: true, location_name: "Name"))
     MessageTag.add_member(:value, Shapes::ShapeRef.new(shape: MessageTagValue, required: true, location_name: "Value"))
     MessageTag.struct_class = Types::MessageTag
 
     MessageTagList.member = Shapes::ShapeRef.new(shape: MessageTag)
+
+    NotFoundException.struct_class = Types::NotFoundException
 
     OverallVolume.add_member(:volume_statistics, Shapes::ShapeRef.new(shape: VolumeStatistics, location_name: "VolumeStatistics"))
     OverallVolume.add_member(:read_rate_percent, Shapes::ShapeRef.new(shape: Percentage, location_name: "ReadRatePercent"))
@@ -806,6 +824,8 @@ module Aws::SESV2
     SendingOptions.add_member(:sending_enabled, Shapes::ShapeRef.new(shape: Enabled, location_name: "SendingEnabled"))
     SendingOptions.struct_class = Types::SendingOptions
 
+    SendingPausedException.struct_class = Types::SendingPausedException
+
     SnsDestination.add_member(:topic_arn, Shapes::ShapeRef.new(shape: AmazonResourceName, required: true, location_name: "TopicArn"))
     SnsDestination.struct_class = Types::SnsDestination
 
@@ -851,6 +871,8 @@ module Aws::SESV2
     Template.add_member(:template_arn, Shapes::ShapeRef.new(shape: TemplateArn, location_name: "TemplateArn"))
     Template.add_member(:template_data, Shapes::ShapeRef.new(shape: TemplateData, location_name: "TemplateData"))
     Template.struct_class = Types::Template
+
+    TooManyRequestsException.struct_class = Types::TooManyRequestsException
 
     TrackingOptions.add_member(:custom_redirect_domain, Shapes::ShapeRef.new(shape: CustomRedirectDomain, required: true, location_name: "CustomRedirectDomain"))
     TrackingOptions.struct_class = Types::TrackingOptions

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/errors.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/errors.rb
@@ -10,5 +10,126 @@ module Aws::SESV2
 
     extend Aws::Errors::DynamicErrors
 
+    class AccountSuspendedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::AccountSuspendedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AlreadyExistsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::AlreadyExistsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BadRequestException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::BadRequestException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ConcurrentModificationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::ConcurrentModificationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidNextTokenException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::InvalidNextTokenException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MailFromDomainNotVerifiedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::MailFromDomainNotVerifiedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MessageRejected < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::MessageRejected] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class NotFoundException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::NotFoundException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class SendingPausedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::SendingPausedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyRequestsException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SESV2::Types::TooManyRequestsException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/types.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/types.rb
@@ -8,6 +8,25 @@
 module Aws::SESV2
   module Types
 
+    # The message can't be sent because the account's ability to send
+    # email has been permanently restricted.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/AccountSuspendedException AWS API Documentation
+    #
+    class AccountSuspendedException < Aws::EmptyStructure; end
+
+    # The resource specified in your request already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/AlreadyExistsException AWS API Documentation
+    #
+    class AlreadyExistsException < Aws::EmptyStructure; end
+
+    # The input you provided is invalid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/BadRequestException AWS API Documentation
+    #
+    class BadRequestException < Aws::EmptyStructure; end
+
     # An object that contains information about a blacklisting event that
     # impacts one of the dedicated IP addresses that is associated with your
     # account.
@@ -150,6 +169,12 @@ module Aws::SESV2
       :default_dimension_value)
       include Aws::Structure
     end
+
+    # The resource is being modified by another operation or thread.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/ConcurrentModificationException AWS API Documentation
+    #
+    class ConcurrentModificationException < Aws::EmptyStructure; end
 
     # An object that represents the content of the email, and optionally a
     # character set specification.
@@ -2172,6 +2197,12 @@ module Aws::SESV2
       include Aws::Structure
     end
 
+    # The specified request includes an invalid or expired token.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/InvalidNextTokenException AWS API Documentation
+    #
+    class InvalidNextTokenException < Aws::EmptyStructure; end
+
     # An object that describes how email sent during the predictive inbox
     # placement test was handled by a certain email provider.
     #
@@ -2223,6 +2254,12 @@ module Aws::SESV2
       :delivery_stream_arn)
       include Aws::Structure
     end
+
+    # There are too many instances of the specified resource type.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
 
     # A request to obtain a list of configuration sets for your Amazon SES
     # account in the current AWS Region.
@@ -2687,6 +2724,12 @@ module Aws::SESV2
       include Aws::Structure
     end
 
+    # The message can't be sent because the sending domain isn't verified.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/MailFromDomainNotVerifiedException AWS API Documentation
+    #
+    class MailFromDomainNotVerifiedException < Aws::EmptyStructure; end
+
     # Represents the email message that you're sending. The `Message`
     # object consists of a subject line and a message body.
     #
@@ -2734,6 +2777,12 @@ module Aws::SESV2
       include Aws::Structure
     end
 
+    # The message can't be sent because it contains invalid content.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/MessageRejected AWS API Documentation
+    #
+    class MessageRejected < Aws::EmptyStructure; end
+
     # Contains the name and value of a tag that you apply to an email. You
     # can use message tags when you publish email sending events.
     #
@@ -2772,6 +2821,12 @@ module Aws::SESV2
       :value)
       include Aws::Structure
     end
+
+    # The resource you attempted to access doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/NotFoundException AWS API Documentation
+    #
+    class NotFoundException < Aws::EmptyStructure; end
 
     # An object that contains information about email that was sent from the
     # selected domain.
@@ -3842,6 +3897,13 @@ module Aws::SESV2
       include Aws::Structure
     end
 
+    # The message can't be sent because the account's ability to send
+    # email is currently paused.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/SendingPausedException AWS API Documentation
+    #
+    class SendingPausedException < Aws::EmptyStructure; end
+
     # An object that defines an Amazon SNS destination for email events. You
     # can use Amazon SNS to send notification when certain email events
     # occur.
@@ -4133,6 +4195,12 @@ module Aws::SESV2
       :template_data)
       include Aws::Structure
     end
+
+    # Too many requests have been made to the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sesv2-2019-09-27/TooManyRequestsException AWS API Documentation
+    #
+    class TooManyRequestsException < Aws::EmptyStructure; end
 
     # An object that defines the tracking options for a configuration set.
     # When you use the Amazon SES API v2 to send an email, it contains an

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
@@ -539,6 +539,8 @@ module Aws::SMS
 
     Tags.member = Shapes::ShapeRef.new(shape: Tag)
 
+    TemporarilyUnavailableException.struct_class = Types::TemporarilyUnavailableException
+
     TerminateAppRequest.add_member(:app_id, Shapes::ShapeRef.new(shape: AppId, location_name: "appId"))
     TerminateAppRequest.struct_class = Types::TerminateAppRequest
 

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
@@ -154,6 +154,17 @@ module Aws::SMS
 
     end
 
+    class TemporarilyUnavailableException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SMS::Types::TemporarilyUnavailableException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class UnauthorizedOperationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
@@ -1994,6 +1994,12 @@ module Aws::SMS
       include Aws::Structure
     end
 
+    # The service is temporarily unavailable.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sms-2016-10-24/TemporarilyUnavailableException AWS API Documentation
+    #
+    class TemporarilyUnavailableException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass TerminateAppRequest
     #   data as a hash:
     #

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
@@ -112,6 +112,10 @@ module Aws::SQS
 
     AttributeNameList.member = Shapes::ShapeRef.new(shape: QueueAttributeName, location_name: "AttributeName")
 
+    BatchEntryIdsNotDistinct.struct_class = Types::BatchEntryIdsNotDistinct
+
+    BatchRequestTooLong.struct_class = Types::BatchRequestTooLong
+
     BatchResultErrorEntry.add_member(:id, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Id"))
     BatchResultErrorEntry.add_member(:sender_fault, Shapes::ShapeRef.new(shape: Boolean, required: true, location_name: "SenderFault"))
     BatchResultErrorEntry.add_member(:code, Shapes::ShapeRef.new(shape: String, required: true, location_name: "Code"))
@@ -181,6 +185,8 @@ module Aws::SQS
     DeleteQueueRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     DeleteQueueRequest.struct_class = Types::DeleteQueueRequest
 
+    EmptyBatchRequest.struct_class = Types::EmptyBatchRequest
+
     GetQueueAttributesRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     GetQueueAttributesRequest.add_member(:attribute_names, Shapes::ShapeRef.new(shape: AttributeNameList, location_name: "AttributeNames"))
     GetQueueAttributesRequest.struct_class = Types::GetQueueAttributesRequest
@@ -194,6 +200,14 @@ module Aws::SQS
 
     GetQueueUrlResult.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, location_name: "QueueUrl"))
     GetQueueUrlResult.struct_class = Types::GetQueueUrlResult
+
+    InvalidAttributeName.struct_class = Types::InvalidAttributeName
+
+    InvalidBatchEntryId.struct_class = Types::InvalidBatchEntryId
+
+    InvalidIdFormat.struct_class = Types::InvalidIdFormat
+
+    InvalidMessageContents.struct_class = Types::InvalidMessageContents
 
     ListDeadLetterSourceQueuesRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     ListDeadLetterSourceQueuesRequest.struct_class = Types::ListDeadLetterSourceQueuesRequest
@@ -239,6 +253,8 @@ module Aws::SQS
 
     MessageList.member = Shapes::ShapeRef.new(shape: Message, location_name: "Message")
 
+    MessageNotInflight.struct_class = Types::MessageNotInflight
+
     MessageSystemAttributeMap.key = Shapes::ShapeRef.new(shape: MessageSystemAttributeName, location_name: "Name")
     MessageSystemAttributeMap.value = Shapes::ShapeRef.new(shape: String, location_name: "Value")
 
@@ -249,13 +265,25 @@ module Aws::SQS
     MessageSystemAttributeValue.add_member(:data_type, Shapes::ShapeRef.new(shape: String, required: true, location_name: "DataType"))
     MessageSystemAttributeValue.struct_class = Types::MessageSystemAttributeValue
 
+    OverLimit.struct_class = Types::OverLimit
+
+    PurgeQueueInProgress.struct_class = Types::PurgeQueueInProgress
+
     PurgeQueueRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     PurgeQueueRequest.struct_class = Types::PurgeQueueRequest
 
     QueueAttributeMap.key = Shapes::ShapeRef.new(shape: QueueAttributeName, location_name: "Name")
     QueueAttributeMap.value = Shapes::ShapeRef.new(shape: String, location_name: "Value")
 
+    QueueDeletedRecently.struct_class = Types::QueueDeletedRecently
+
+    QueueDoesNotExist.struct_class = Types::QueueDoesNotExist
+
+    QueueNameExists.struct_class = Types::QueueNameExists
+
     QueueUrlList.member = Shapes::ShapeRef.new(shape: String, location_name: "QueueUrl")
+
+    ReceiptHandleIsInvalid.struct_class = Types::ReceiptHandleIsInvalid
 
     ReceiveMessageRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     ReceiveMessageRequest.add_member(:attribute_names, Shapes::ShapeRef.new(shape: AttributeNameList, location_name: "AttributeNames"))
@@ -332,6 +360,10 @@ module Aws::SQS
     TagQueueRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     TagQueueRequest.add_member(:tags, Shapes::ShapeRef.new(shape: TagMap, required: true, location_name: "Tags"))
     TagQueueRequest.struct_class = Types::TagQueueRequest
+
+    TooManyEntriesInBatchRequest.struct_class = Types::TooManyEntriesInBatchRequest
+
+    UnsupportedOperation.struct_class = Types::UnsupportedOperation
 
     UntagQueueRequest.add_member(:queue_url, Shapes::ShapeRef.new(shape: String, required: true, location_name: "QueueUrl"))
     UntagQueueRequest.add_member(:tag_keys, Shapes::ShapeRef.new(shape: TagKeyList, required: true, location_name: "TagKeys"))

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
@@ -10,5 +10,181 @@ module Aws::SQS
 
     extend Aws::Errors::DynamicErrors
 
+    class BatchEntryIdsNotDistinct < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::BatchEntryIdsNotDistinct] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BatchRequestTooLong < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::BatchRequestTooLong] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class EmptyBatchRequest < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::EmptyBatchRequest] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidAttributeName < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::InvalidAttributeName] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidBatchEntryId < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::InvalidBatchEntryId] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidIdFormat < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::InvalidIdFormat] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidMessageContents < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::InvalidMessageContents] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class MessageNotInflight < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::MessageNotInflight] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class OverLimit < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::OverLimit] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class PurgeQueueInProgress < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::PurgeQueueInProgress] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class QueueDeletedRecently < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::QueueDeletedRecently] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class QueueDoesNotExist < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::QueueDoesNotExist] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class QueueNameExists < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::QueueNameExists] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ReceiptHandleIsInvalid < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::ReceiptHandleIsInvalid] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class TooManyEntriesInBatchRequest < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::TooManyEntriesInBatchRequest] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedOperation < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SQS::Types::UnsupportedOperation] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
   end
 end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
@@ -73,6 +73,18 @@ module Aws::SQS
       include Aws::Structure
     end
 
+    # Two or more batch entries in the request have the same `Id`.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/BatchEntryIdsNotDistinct AWS API Documentation
+    #
+    class BatchEntryIdsNotDistinct < Aws::EmptyStructure; end
+
+    # The length of all the messages put together is more than the limit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/BatchRequestTooLong AWS API Documentation
+    #
+    class BatchRequestTooLong < Aws::EmptyStructure; end
+
     # Gives a detailed description of the result of an action on each entry
     # in the request.
     #
@@ -616,6 +628,12 @@ module Aws::SQS
       include Aws::Structure
     end
 
+    # The batch request doesn't contain any entries.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/EmptyBatchRequest AWS API Documentation
+    #
+    class EmptyBatchRequest < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass GetQueueAttributesRequest
     #   data as a hash:
     #
@@ -810,6 +828,31 @@ module Aws::SQS
       :queue_url)
       include Aws::Structure
     end
+
+    # The specified attribute doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/InvalidAttributeName AWS API Documentation
+    #
+    class InvalidAttributeName < Aws::EmptyStructure; end
+
+    # The `Id` of a batch entry in a batch request doesn't abide by the
+    # specification.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/InvalidBatchEntryId AWS API Documentation
+    #
+    class InvalidBatchEntryId < Aws::EmptyStructure; end
+
+    # The specified receipt handle isn't valid for the current version.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/InvalidIdFormat AWS API Documentation
+    #
+    class InvalidIdFormat < Aws::EmptyStructure; end
+
+    # The message contains characters outside the allowed set.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/InvalidMessageContents AWS API Documentation
+    #
+    class InvalidMessageContents < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ListDeadLetterSourceQueuesRequest
     #   data as a hash:
@@ -1059,6 +1102,12 @@ module Aws::SQS
       include Aws::Structure
     end
 
+    # The specified message isn't in flight.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/MessageNotInflight AWS API Documentation
+    #
+    class MessageNotInflight < Aws::EmptyStructure; end
+
     # The user-specified message system attribute value. For string data
     # types, the `Value` attribute has the same restrictions on the content
     # as the message body. For more information, see ` SendMessage.`
@@ -1124,6 +1173,23 @@ module Aws::SQS
       include Aws::Structure
     end
 
+    # The specified action violates a limit. For example, `ReceiveMessage`
+    # returns this error if the maximum number of inflight messages is
+    # reached and `AddPermission` returns this error if the maximum number
+    # of permissions for the queue is reached.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/OverLimit AWS API Documentation
+    #
+    class OverLimit < Aws::EmptyStructure; end
+
+    # Indicates that the specified queue previously received a `PurgeQueue`
+    # request within the last 60 seconds (the time it can take to delete the
+    # messages in the queue).
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/PurgeQueueInProgress AWS API Documentation
+    #
+    class PurgeQueueInProgress < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass PurgeQueueRequest
     #   data as a hash:
     #
@@ -1144,6 +1210,33 @@ module Aws::SQS
       :queue_url)
       include Aws::Structure
     end
+
+    # You must wait 60 seconds after deleting a queue before you can create
+    # another queue with the same name.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/QueueDeletedRecently AWS API Documentation
+    #
+    class QueueDeletedRecently < Aws::EmptyStructure; end
+
+    # The specified queue doesn't exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/QueueDoesNotExist AWS API Documentation
+    #
+    class QueueDoesNotExist < Aws::EmptyStructure; end
+
+    # A queue with this name already exists. Amazon SQS returns this error
+    # only if the request includes attributes whose values differ from those
+    # of the existing queue.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/QueueNameExists AWS API Documentation
+    #
+    class QueueNameExists < Aws::EmptyStructure; end
+
+    # The specified receipt handle isn't valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ReceiptHandleIsInvalid AWS API Documentation
+    #
+    class ReceiptHandleIsInvalid < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass ReceiveMessageRequest
     #   data as a hash:
@@ -2150,6 +2243,18 @@ module Aws::SQS
       :tags)
       include Aws::Structure
     end
+
+    # The batch request contains more entries than permissible.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/TooManyEntriesInBatchRequest AWS API Documentation
+    #
+    class TooManyEntriesInBatchRequest < Aws::EmptyStructure; end
+
+    # Error code 400. Unsupported operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/UnsupportedOperation AWS API Documentation
+    #
+    class UnsupportedOperation < Aws::EmptyStructure; end
 
     # @note When making an API call, you may pass UntagQueueRequest
     #   data as a hash:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
@@ -1068,6 +1068,8 @@ module Aws::SSM
     AlreadyExistsException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     AlreadyExistsException.struct_class = Types::AlreadyExistsException
 
+    AssociatedInstances.struct_class = Types::AssociatedInstances
+
     Association.add_member(:name, Shapes::ShapeRef.new(shape: DocumentARN, location_name: "Name"))
     Association.add_member(:instance_id, Shapes::ShapeRef.new(shape: InstanceId, location_name: "InstanceId"))
     Association.add_member(:association_id, Shapes::ShapeRef.new(shape: AssociationId, location_name: "AssociationId"))
@@ -1079,6 +1081,8 @@ module Aws::SSM
     Association.add_member(:schedule_expression, Shapes::ShapeRef.new(shape: ScheduleExpression, location_name: "ScheduleExpression"))
     Association.add_member(:association_name, Shapes::ShapeRef.new(shape: AssociationName, location_name: "AssociationName"))
     Association.struct_class = Types::Association
+
+    AssociationAlreadyExists.struct_class = Types::AssociationAlreadyExists
 
     AssociationDescription.add_member(:name, Shapes::ShapeRef.new(shape: DocumentARN, location_name: "Name"))
     AssociationDescription.add_member(:instance_id, Shapes::ShapeRef.new(shape: InstanceId, location_name: "InstanceId"))
@@ -1155,6 +1159,8 @@ module Aws::SSM
     AssociationFilterList.member = Shapes::ShapeRef.new(shape: AssociationFilter)
 
     AssociationIdList.member = Shapes::ShapeRef.new(shape: AssociationId)
+
+    AssociationLimitExceeded.struct_class = Types::AssociationLimitExceeded
 
     AssociationList.member = Shapes::ShapeRef.new(shape: Association)
 
@@ -2081,6 +2087,8 @@ module Aws::SSM
     DuplicateDocumentVersionName.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     DuplicateDocumentVersionName.struct_class = Types::DuplicateDocumentVersionName
 
+    DuplicateInstanceId.struct_class = Types::DuplicateInstanceId
+
     EffectivePatch.add_member(:patch, Shapes::ShapeRef.new(shape: Patch, location_name: "Patch"))
     EffectivePatch.add_member(:patch_status, Shapes::ShapeRef.new(shape: PatchStatus, location_name: "PatchStatus"))
     EffectivePatch.struct_class = Types::EffectivePatch
@@ -2535,6 +2543,8 @@ module Aws::SSM
     InvalidAutomationStatusUpdateException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidAutomationStatusUpdateException.struct_class = Types::InvalidAutomationStatusUpdateException
 
+    InvalidCommandId.struct_class = Types::InvalidCommandId
+
     InvalidDeleteInventoryParametersException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidDeleteInventoryParametersException.struct_class = Types::InvalidDeleteInventoryParametersException
 
@@ -2561,6 +2571,8 @@ module Aws::SSM
 
     InvalidFilter.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidFilter.struct_class = Types::InvalidFilter
+
+    InvalidFilterKey.struct_class = Types::InvalidFilterKey
 
     InvalidFilterOption.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "message"))
     InvalidFilterOption.struct_class = Types::InvalidFilterOption
@@ -2599,17 +2611,27 @@ module Aws::SSM
     InvalidOptionException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidOptionException.struct_class = Types::InvalidOptionException
 
+    InvalidOutputFolder.struct_class = Types::InvalidOutputFolder
+
+    InvalidOutputLocation.struct_class = Types::InvalidOutputLocation
+
     InvalidParameters.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidParameters.struct_class = Types::InvalidParameters
 
     InvalidPermissionType.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidPermissionType.struct_class = Types::InvalidPermissionType
 
+    InvalidPluginName.struct_class = Types::InvalidPluginName
+
     InvalidPolicyAttributeException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "message"))
     InvalidPolicyAttributeException.struct_class = Types::InvalidPolicyAttributeException
 
     InvalidPolicyTypeException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "message"))
     InvalidPolicyTypeException.struct_class = Types::InvalidPolicyTypeException
+
+    InvalidResourceId.struct_class = Types::InvalidResourceId
+
+    InvalidResourceType.struct_class = Types::InvalidResourceType
 
     InvalidResultAttributeException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     InvalidResultAttributeException.struct_class = Types::InvalidResultAttributeException
@@ -2721,6 +2743,8 @@ module Aws::SSM
 
     InventoryResultItemMap.key = Shapes::ShapeRef.new(shape: InventoryResultItemKey)
     InventoryResultItemMap.value = Shapes::ShapeRef.new(shape: InventoryResultItem)
+
+    InvocationDoesNotExist.struct_class = Types::InvocationDoesNotExist
 
     ItemContentMismatchException.add_member(:type_name, Shapes::ShapeRef.new(shape: InventoryItemTypeName, location_name: "TypeName"))
     ItemContentMismatchException.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
@@ -3678,6 +3702,8 @@ module Aws::SSM
     StartSessionResponse.add_member(:stream_url, Shapes::ShapeRef.new(shape: StreamUrl, location_name: "StreamUrl"))
     StartSessionResponse.struct_class = Types::StartSessionResponse
 
+    StatusUnchanged.struct_class = Types::StatusUnchanged
+
     StepExecution.add_member(:step_name, Shapes::ShapeRef.new(shape: String, location_name: "StepName"))
     StepExecution.add_member(:action, Shapes::ShapeRef.new(shape: AutomationActionName, location_name: "Action"))
     StepExecution.add_member(:timeout_seconds, Shapes::ShapeRef.new(shape: Long, location_name: "TimeoutSeconds", metadata: {"box"=>true}))
@@ -3766,6 +3792,8 @@ module Aws::SSM
 
     TerminateSessionResponse.add_member(:session_id, Shapes::ShapeRef.new(shape: SessionId, location_name: "SessionId"))
     TerminateSessionResponse.struct_class = Types::TerminateSessionResponse
+
+    TooManyTagsError.struct_class = Types::TooManyTagsError
 
     TooManyUpdates.add_member(:message, Shapes::ShapeRef.new(shape: String, location_name: "Message"))
     TooManyUpdates.struct_class = Types::TooManyUpdates

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
@@ -26,6 +26,28 @@ module Aws::SSM
 
     end
 
+    class AssociatedInstances < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::AssociatedInstances] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class AssociationAlreadyExists < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::AssociationAlreadyExists] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class AssociationDoesNotExist < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -54,6 +76,17 @@ module Aws::SSM
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class AssociationLimitExceeded < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::AssociationLimitExceeded] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -298,6 +331,17 @@ module Aws::SSM
 
     end
 
+    class DuplicateInstanceId < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::DuplicateInstanceId] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class FeatureNotAvailableException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -538,6 +582,17 @@ module Aws::SSM
 
     end
 
+    class InvalidCommandId < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidCommandId] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidDeleteInventoryParametersException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -678,6 +733,17 @@ module Aws::SSM
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvalidFilterKey < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidFilterKey] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -879,6 +945,28 @@ module Aws::SSM
 
     end
 
+    class InvalidOutputFolder < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidOutputFolder] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidOutputLocation < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidOutputLocation] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidParameters < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -911,6 +999,17 @@ module Aws::SSM
 
     end
 
+    class InvalidPluginName < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidPluginName] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class InvalidPolicyAttributeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -939,6 +1038,28 @@ module Aws::SSM
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvalidResourceId < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidResourceId] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidResourceType < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvalidResourceType] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -1035,6 +1156,17 @@ module Aws::SSM
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class InvocationDoesNotExist < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::InvocationDoesNotExist] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end
@@ -1452,6 +1584,17 @@ module Aws::SSM
 
     end
 
+    class StatusUnchanged < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::StatusUnchanged] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class SubTypeCountLimitExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -1496,6 +1639,17 @@ module Aws::SSM
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class TooManyTagsError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::SSM::Types::TooManyTagsError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
@@ -173,6 +173,13 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # You must disassociate a document from all instances before you can
+    # delete it.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/AssociatedInstances AWS API Documentation
+    #
+    class AssociatedInstances < Aws::EmptyStructure; end
+
     # Describes an association of a Systems Manager document and an
     # instance.
     #
@@ -234,6 +241,12 @@ module Aws::SSM
       :association_name)
       include Aws::Structure
     end
+
+    # The specified association already exists.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/AssociationAlreadyExists AWS API Documentation
+    #
+    class AssociationAlreadyExists < Aws::EmptyStructure; end
 
     # Describes the parameters for a document.
     #
@@ -581,6 +594,12 @@ module Aws::SSM
       :value)
       include Aws::Structure
     end
+
+    # You can have at most 2,000 active associations.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/AssociationLimitExceeded AWS API Documentation
+    #
+    class AssociationLimitExceeded < Aws::EmptyStructure; end
 
     # Information about the association.
     #
@@ -6397,6 +6416,12 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # You cannot specify an instance ID in more than one association.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DuplicateInstanceId AWS API Documentation
+    #
+    class DuplicateInstanceId < Aws::EmptyStructure; end
+
     # The EffectivePatch structure defines metadata about a patch along with
     # the approval state of the patch in a particular patch baseline. The
     # approval state includes information about whether the patch is
@@ -8959,6 +8984,10 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidCommandId AWS API Documentation
+    #
+    class InvalidCommandId < Aws::EmptyStructure; end
+
     # One or more of the parameters specified for the delete operation is
     # not valid. Verify all parameters and try again.
     #
@@ -9077,6 +9106,12 @@ module Aws::SSM
       :message)
       include Aws::Structure
     end
+
+    # The specified key is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidFilterKey AWS API Documentation
+    #
+    class InvalidFilterKey < Aws::EmptyStructure; end
 
     # The specified filter option is not valid. Valid options are Equals and
     # BeginsWith. For Path filter, valid options are Recursive and OneLevel.
@@ -9244,6 +9279,18 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # The S3 bucket does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidOutputFolder AWS API Documentation
+    #
+    class InvalidOutputFolder < Aws::EmptyStructure; end
+
+    # The output location is not valid or does not exist.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidOutputLocation AWS API Documentation
+    #
+    class InvalidOutputLocation < Aws::EmptyStructure; end
+
     # You must specify values for all required parameters in the Systems
     # Manager document. You can only supply values to parameters defined in
     # the Systems Manager document.
@@ -9271,6 +9318,12 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # The plugin name is not valid.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidPluginName AWS API Documentation
+    #
+    class InvalidPluginName < Aws::EmptyStructure; end
+
     # A policy attribute or its value is invalid.
     #
     # @!attribute [rw] message
@@ -9296,6 +9349,20 @@ module Aws::SSM
       :message)
       include Aws::Structure
     end
+
+    # The resource ID is not valid. Verify that you entered the correct ID
+    # and try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidResourceId AWS API Documentation
+    #
+    class InvalidResourceId < Aws::EmptyStructure; end
+
+    # The resource type is not valid. For example, if you are attempting to
+    # tag an instance, the instance must be a registered, managed instance.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvalidResourceType AWS API Documentation
+    #
+    class InvalidResourceType < Aws::EmptyStructure; end
 
     # The specified inventory item result attribute is not valid.
     #
@@ -9794,6 +9861,13 @@ module Aws::SSM
       :content)
       include Aws::Structure
     end
+
+    # The command ID and instance ID you specified did not match any
+    # invocations. Verify the command ID and the instance ID and try again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/InvocationDoesNotExist AWS API Documentation
+    #
+    class InvocationDoesNotExist < Aws::EmptyStructure; end
 
     # The inventory item has invalid content.
     #
@@ -15368,6 +15442,12 @@ module Aws::SSM
       include Aws::Structure
     end
 
+    # The updated status is the same as the current status.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/StatusUnchanged AWS API Documentation
+    #
+    class StatusUnchanged < Aws::EmptyStructure; end
+
     # Detailed information about an the execution state of an Automation
     # step.
     #
@@ -15791,6 +15871,13 @@ module Aws::SSM
       :session_id)
       include Aws::Structure
     end
+
+    # The `Targets` parameter includes too many tags. Remove one or more
+    # tags and try the command again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/TooManyTagsError AWS API Documentation
+    #
+    class TooManyTagsError < Aws::EmptyStructure; end
 
     # There are concurrent updates for a resource that supports one update
     # at a time.

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/client_api.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/client_api.rb
@@ -91,6 +91,8 @@ module Aws::Textract
     Warning = Shapes::StructureShape.new(name: 'Warning')
     Warnings = Shapes::ListShape.new(name: 'Warnings')
 
+    AccessDeniedException.struct_class = Types::AccessDeniedException
+
     AnalyzeDocumentRequest.add_member(:document, Shapes::ShapeRef.new(shape: Document, required: true, location_name: "Document"))
     AnalyzeDocumentRequest.add_member(:feature_types, Shapes::ShapeRef.new(shape: FeatureTypes, required: true, location_name: "FeatureTypes"))
     AnalyzeDocumentRequest.add_member(:human_loop_config, Shapes::ShapeRef.new(shape: HumanLoopConfig, location_name: "HumanLoopConfig"))
@@ -101,6 +103,8 @@ module Aws::Textract
     AnalyzeDocumentResponse.add_member(:human_loop_activation_output, Shapes::ShapeRef.new(shape: HumanLoopActivationOutput, location_name: "HumanLoopActivationOutput"))
     AnalyzeDocumentResponse.add_member(:analyze_document_model_version, Shapes::ShapeRef.new(shape: String, location_name: "AnalyzeDocumentModelVersion"))
     AnalyzeDocumentResponse.struct_class = Types::AnalyzeDocumentResponse
+
+    BadDocumentException.struct_class = Types::BadDocumentException
 
     Block.add_member(:block_type, Shapes::ShapeRef.new(shape: BlockType, location_name: "BlockType"))
     Block.add_member(:confidence, Shapes::ShapeRef.new(shape: Percent, location_name: "Confidence"))
@@ -144,6 +148,8 @@ module Aws::Textract
 
     DocumentMetadata.add_member(:pages, Shapes::ShapeRef.new(shape: UInteger, location_name: "Pages"))
     DocumentMetadata.struct_class = Types::DocumentMetadata
+
+    DocumentTooLargeException.struct_class = Types::DocumentTooLargeException
 
     EntityTypes.member = Shapes::ShapeRef.new(shape: EntityType)
 
@@ -203,6 +209,18 @@ module Aws::Textract
 
     IdList.member = Shapes::ShapeRef.new(shape: NonEmptyString)
 
+    IdempotentParameterMismatchException.struct_class = Types::IdempotentParameterMismatchException
+
+    InternalServerError.struct_class = Types::InternalServerError
+
+    InvalidJobIdException.struct_class = Types::InvalidJobIdException
+
+    InvalidParameterException.struct_class = Types::InvalidParameterException
+
+    InvalidS3ObjectException.struct_class = Types::InvalidS3ObjectException
+
+    LimitExceededException.struct_class = Types::LimitExceededException
+
     NotificationChannel.add_member(:sns_topic_arn, Shapes::ShapeRef.new(shape: SNSTopicArn, required: true, location_name: "SNSTopicArn"))
     NotificationChannel.add_member(:role_arn, Shapes::ShapeRef.new(shape: RoleArn, required: true, location_name: "RoleArn"))
     NotificationChannel.struct_class = Types::NotificationChannel
@@ -214,6 +232,8 @@ module Aws::Textract
     Point.struct_class = Types::Point
 
     Polygon.member = Shapes::ShapeRef.new(shape: Point)
+
+    ProvisionedThroughputExceededException.struct_class = Types::ProvisionedThroughputExceededException
 
     Relationship.add_member(:type, Shapes::ShapeRef.new(shape: RelationshipType, location_name: "Type"))
     Relationship.add_member(:ids, Shapes::ShapeRef.new(shape: IdList, location_name: "Ids"))
@@ -244,6 +264,10 @@ module Aws::Textract
 
     StartDocumentTextDetectionResponse.add_member(:job_id, Shapes::ShapeRef.new(shape: JobId, location_name: "JobId"))
     StartDocumentTextDetectionResponse.struct_class = Types::StartDocumentTextDetectionResponse
+
+    ThrottlingException.struct_class = Types::ThrottlingException
+
+    UnsupportedDocumentException.struct_class = Types::UnsupportedDocumentException
 
     Warning.add_member(:error_code, Shapes::ShapeRef.new(shape: ErrorCode, location_name: "ErrorCode"))
     Warning.add_member(:pages, Shapes::ShapeRef.new(shape: Pages, location_name: "Pages"))

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/errors.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/errors.rb
@@ -10,6 +10,39 @@ module Aws::Textract
 
     extend Aws::Errors::DynamicErrors
 
+    class AccessDeniedException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::AccessDeniedException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class BadDocumentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::BadDocumentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class DocumentTooLargeException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::DocumentTooLargeException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class HumanLoopQuotaExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -32,6 +65,105 @@ module Aws::Textract
       # @return [String]
       def service_code
         @data[:service_code]
+      end
+
+    end
+
+    class IdempotentParameterMismatchException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::IdempotentParameterMismatchException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InternalServerError < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::InternalServerError] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidJobIdException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::InvalidJobIdException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidParameterException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::InvalidParameterException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class InvalidS3ObjectException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::InvalidS3ObjectException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class LimitExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::LimitExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ProvisionedThroughputExceededException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::ProvisionedThroughputExceededException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class ThrottlingException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::ThrottlingException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
+    class UnsupportedDocumentException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::Textract::Types::UnsupportedDocumentException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/types.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/types.rb
@@ -8,6 +8,12 @@
 module Aws::Textract
   module Types
 
+    # You aren't authorized to perform the action.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/AccessDeniedException AWS API Documentation
+    #
+    class AccessDeniedException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass AnalyzeDocumentRequest
     #   data as a hash:
     #
@@ -91,6 +97,12 @@ module Aws::Textract
       :analyze_document_model_version)
       include Aws::Structure
     end
+
+    # Amazon Textract isn't able to read the document.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/BadDocumentException AWS API Documentation
+    #
+    class BadDocumentException < Aws::EmptyStructure; end
 
     # A `Block` represents items that are recognized in a document within a
     # group of pixels close to each other. The information returned in a
@@ -460,6 +472,14 @@ module Aws::Textract
       include Aws::Structure
     end
 
+    # The document can't be processed because it's too large. The maximum
+    # document size for synchronous operations 5 MB. The maximum document
+    # size for asynchronous operations is 500 MB for PDF files.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/DocumentTooLargeException AWS API Documentation
+    #
+    class DocumentTooLargeException < Aws::EmptyStructure; end
+
     # Information about where the following items are located on a document
     # page: detected page, text, key-value pairs, tables, table cells, and
     # selection elements.
@@ -755,6 +775,55 @@ module Aws::Textract
       include Aws::Structure
     end
 
+    # A `ClientRequestToken` input parameter was reused with an operation,
+    # but at least one of the other input parameters is different from the
+    # previous call to the operation.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/IdempotentParameterMismatchException AWS API Documentation
+    #
+    class IdempotentParameterMismatchException < Aws::EmptyStructure; end
+
+    # Amazon Textract experienced a service issue. Try your call again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/InternalServerError AWS API Documentation
+    #
+    class InternalServerError < Aws::EmptyStructure; end
+
+    # An invalid job identifier was passed to GetDocumentAnalysis or to
+    # GetDocumentAnalysis.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/InvalidJobIdException AWS API Documentation
+    #
+    class InvalidJobIdException < Aws::EmptyStructure; end
+
+    # An input parameter violated a constraint. For example, in synchronous
+    # operations, an `InvalidParameterException` exception occurs when
+    # neither of the `S3Object` or `Bytes` values are supplied in the
+    # `Document` request parameter. Validate your parameter before calling
+    # the API operation again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/InvalidParameterException AWS API Documentation
+    #
+    class InvalidParameterException < Aws::EmptyStructure; end
+
+    # Amazon Textract is unable to access the S3 object that's specified in
+    # the request.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/InvalidS3ObjectException AWS API Documentation
+    #
+    class InvalidS3ObjectException < Aws::EmptyStructure; end
+
+    # An Amazon Textract service limit was exceeded. For example, if you
+    # start too many asynchronous jobs concurrently, calls to start
+    # operations (`StartDocumentTextDetection`, for example) raise a
+    # LimitExceededException exception (HTTP status code: 400) until the
+    # number of concurrently running jobs is below the Amazon Textract
+    # service limit.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/LimitExceededException AWS API Documentation
+    #
+    class LimitExceededException < Aws::EmptyStructure; end
+
     # The Amazon Simple Notification Service (Amazon SNS) topic to which
     # Amazon Textract publishes the completion status of an asynchronous
     # document operation, such as StartDocumentTextDetection.
@@ -811,6 +880,13 @@ module Aws::Textract
       :y)
       include Aws::Structure
     end
+
+    # The number of requests exceeded your throughput limit. If you want to
+    # increase this limit, contact Amazon Textract.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/ProvisionedThroughputExceededException AWS API Documentation
+    #
+    class ProvisionedThroughputExceededException < Aws::EmptyStructure; end
 
     # Information about how blocks are related to each other. A `Block`
     # object contains 0 or more `Relation` objects in a list,
@@ -1036,6 +1112,21 @@ module Aws::Textract
       :job_id)
       include Aws::Structure
     end
+
+    # Amazon Textract is temporarily unable to process the request. Try your
+    # call again.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/ThrottlingException AWS API Documentation
+    #
+    class ThrottlingException < Aws::EmptyStructure; end
+
+    # The format of the input document isn't supported. Documents for
+    # synchronous operations can be in PNG or JPEG format. Documents for
+    # asynchronous operations can also be in PDF format.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/textract-2018-06-27/UnsupportedDocumentException AWS API Documentation
+    #
+    class UnsupportedDocumentException < Aws::EmptyStructure; end
 
     # A warning about an issue that occurred during asynchronous text
     # analysis (StartDocumentAnalysis) or asynchronous document text

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
@@ -1194,6 +1194,8 @@ module Aws::WAF
     WAFInternalErrorException.add_member(:message, Shapes::ShapeRef.new(shape: errorMessage, location_name: "message"))
     WAFInternalErrorException.struct_class = Types::WAFInternalErrorException
 
+    WAFInvalidAccountException.struct_class = Types::WAFInvalidAccountException
+
     WAFInvalidOperationException.add_member(:message, Shapes::ShapeRef.new(shape: errorMessage, location_name: "message"))
     WAFInvalidOperationException.struct_class = Types::WAFInvalidOperationException
 

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
@@ -58,6 +58,17 @@ module Aws::WAF
 
     end
 
+    class WAFInvalidAccountException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::WAF::Types::WAFInvalidAccountException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class WAFInvalidOperationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
@@ -5974,6 +5974,13 @@ module Aws::WAF
       include Aws::Structure
     end
 
+    # The operation failed because you tried to create, update, or delete an
+    # object by using an invalid account identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/WAFInvalidAccountException AWS API Documentation
+    #
+    class WAFInvalidAccountException < Aws::EmptyStructure; end
+
     # The operation failed because there was nothing to do. For example:
     #
     # * You tried to remove a `Rule` from a `WebACL`, but the `Rule` isn't

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
@@ -1231,6 +1231,8 @@ module Aws::WAFRegional
     WAFInternalErrorException.add_member(:message, Shapes::ShapeRef.new(shape: errorMessage, location_name: "message"))
     WAFInternalErrorException.struct_class = Types::WAFInternalErrorException
 
+    WAFInvalidAccountException.struct_class = Types::WAFInvalidAccountException
+
     WAFInvalidOperationException.add_member(:message, Shapes::ShapeRef.new(shape: errorMessage, location_name: "message"))
     WAFInvalidOperationException.struct_class = Types::WAFInvalidOperationException
 

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
@@ -58,6 +58,17 @@ module Aws::WAFRegional
 
     end
 
+    class WAFInvalidAccountException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::WAFRegional::Types::WAFInvalidAccountException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class WAFInvalidOperationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
@@ -6126,6 +6126,13 @@ module Aws::WAFRegional
       include Aws::Structure
     end
 
+    # The operation failed because you tried to create, update, or delete an
+    # object by using an invalid account identifier.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/WAFInvalidAccountException AWS API Documentation
+    #
+    class WAFInvalidAccountException < Aws::EmptyStructure; end
+
     # The operation failed because there was nothing to do. For example:
     #
     # * You tried to remove a `Rule` from a `WebACL`, but the `Rule` isn't

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
@@ -340,6 +340,8 @@ module Aws::WorkDocs
     DeactivateUserRequest.add_member(:authentication_token, Shapes::ShapeRef.new(shape: AuthenticationHeaderType, location: "header", location_name: "Authentication"))
     DeactivateUserRequest.struct_class = Types::DeactivateUserRequest
 
+    DeactivatingLastSystemUserException.struct_class = Types::DeactivatingLastSystemUserException
+
     DeleteCommentRequest.add_member(:authentication_token, Shapes::ShapeRef.new(shape: AuthenticationHeaderType, location: "header", location_name: "Authentication"))
     DeleteCommentRequest.add_member(:document_id, Shapes::ShapeRef.new(shape: ResourceIdType, required: true, location: "uri", location_name: "DocumentId"))
     DeleteCommentRequest.add_member(:version_id, Shapes::ShapeRef.new(shape: DocumentVersionIdType, required: true, location: "uri", location_name: "VersionId"))
@@ -774,6 +776,8 @@ module Aws::WorkDocs
 
     TooManySubscriptionsException.add_member(:message, Shapes::ShapeRef.new(shape: ErrorMessageType, location_name: "Message"))
     TooManySubscriptionsException.struct_class = Types::TooManySubscriptionsException
+
+    UnauthorizedOperationException.struct_class = Types::UnauthorizedOperationException
 
     UnauthorizedResourceAccessException.add_member(:message, Shapes::ShapeRef.new(shape: ErrorMessageType, location_name: "Message"))
     UnauthorizedResourceAccessException.struct_class = Types::UnauthorizedResourceAccessException

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
@@ -58,6 +58,17 @@ module Aws::WorkDocs
 
     end
 
+    class DeactivatingLastSystemUserException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::WorkDocs::Types::DeactivatingLastSystemUserException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
+      end
+
+    end
+
     class DocumentLockedForCommentsException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -363,6 +374,17 @@ module Aws::WorkDocs
       # @return [String]
       def message
         @message || @data[:message]
+      end
+
+    end
+
+    class UnauthorizedOperationException < ServiceError
+
+      # @param [Seahorse::Client::RequestContext] context
+      # @param [String] message
+      # @param [Aws::WorkDocs::Types::UnauthorizedOperationException] data
+      def initialize(context, message, data = Aws::EmptyStructure.new)
+        super(context, message, data)
       end
 
     end

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
@@ -683,6 +683,12 @@ module Aws::WorkDocs
       include Aws::Structure
     end
 
+    # The last user in the organization is being deactivated.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeactivatingLastSystemUserException AWS API Documentation
+    #
+    class DeactivatingLastSystemUserException < Aws::EmptyStructure; end
+
     # @note When making an API call, you may pass DeleteCommentRequest
     #   data as a hash:
     #
@@ -2815,6 +2821,12 @@ module Aws::WorkDocs
       :message)
       include Aws::Structure
     end
+
+    # The operation is not permitted.
+    #
+    # @see http://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UnauthorizedOperationException AWS API Documentation
+    #
+    class UnauthorizedOperationException < Aws::EmptyStructure; end
 
     # The caller does not have access to perform the action on the resource.
     #


### PR DESCRIPTION
Not too sure on this change, but it appears errors are not generated in line with v2. Maybe broken behavior from https://github.com/aws/aws-sdk-ruby/pull/2049 ?

Errors: https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/ElastiCache/Errors.html
No errors: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ElastiCache/Errors.html

Errors: https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/S3/Errors.html
No errors: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Errors.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.