### PR TITLE
Fix raising in `Object#upload_stream` block not triggering the `Aws::S3::MultipartStreamUploader#abort_upload`

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased Changes
 ------------------
 
 * Issue - Don't update endpoint on region mismatch errors when using a custom endpoint.
+* Issue - Fix raising in `Object#upload_stream` block not triggering the `Aws::S3::MultipartStreamUploader#abort_upload`
 
 1.60.2 (2020-02-07)
 ------------------

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -65,7 +65,8 @@ module Aws
           begin
             block.call(write_pipe)
           ensure
-            write_pipe.close # Ensure the pipe is closed to avoid https://github.com/jruby/jruby/issues/6111
+            # Ensure the pipe is closed to avoid https://github.com/jruby/jruby/issues/6111
+            write_pipe.close
           end
           threads.map(&:value).compact
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -155,7 +155,7 @@ module Aws
               nil
             rescue => error
               # keep other threads from uploading other parts
-              mutex.synchronize { read_pipe.close_read }
+              mutex.synchronize { read_pipe.close_read unless read_pipe.closed? }
               error
             end
           end


### PR DESCRIPTION
Suppose I have the following simple script:

```ruby
require 'aws-sdk-s3'

# https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#upload_stream-instance_method
s3 = Aws::S3::Resource.new(http_wire_trace: true)
s3.bucket(ARGV[0]).object(ARGV[1]).upload_stream do |write_stream|
  IO.copy_stream(File.open(ARGV[2]), write_stream)
end
```

This is what I got with Ruby 2.4.4 before the fix:
```bash
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ rvm use ruby-2.4.4
Using /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ ruby aws_mp_upload.rb bekirov-test-ireland-2 object-key-200 ~/Desktop/sample_200m.txt
opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
SSL established
<- "POST /object-key-200?uploads HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.90.1 ruby/2.4.4 x86_64-darwin17 aws-sdk-s3/1.60.2\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163414Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
-> "HTTP/1.1 200 OK\r\n"
-> "x-amz-id-2: +i35AmHw0QZRi6+D8pLalZb5EEUK8Jtme3llgu7ElsL9BRUi0dKsLk0v0kzFYYnBvqfsVtC8CIE=\r\n"
-> "x-amz-request-id: AFBF1D973AA4B311\r\n"
-> "Date: Fri, 06 Mar 2020 16:34:16 GMT\r\n"
-> "Transfer-Encoding: chunked\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
-> "16b\r\n"
reading 363 bytes...
-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>bekirov-test-ireland-2</Bucket><Key>object-key-200</Key><UploadId>7StD_rDBPzA8WylOIPVBq05jqzyqjUOGSDdhDnqLgx81KnZdfTjiJX43sr8ZzsbzwNvogC9pro6eqeFIrD64bwBhiq7KY_0SkQXony4Jw3EZgGGWd7BbChqaRNgDM9LG</UploadId></InitiateMultipartUploadResult>"
read 363 bytes
reading 2 bytes...
-> "\r\n"
read 2 bytes
-> "0\r\n"
-> "\r\n"
Conn keep-alive
<- "PUT /object-key-200?partNumber=1&uploadId=7StD_rDBPzA8WylOIPVBq05jqzyqjUOGSDdhDnqLgx81KnZdfTjiJX43sr8ZzsbzwNvogC9pro6eqeFIrD64bwBhiq7KY_0SkQXony4Jw3EZgGGWd7BbChqaRNgDM9LG HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.90.1 ruby/2.4.4 x86_64-darwin17 aws-sdk-s3/1.60.2\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163415Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
aws_mp_upload.rb:6:in `initialize': No such file or directory @ rb_sysopen - /Users/nikolay.bekirov/Desktop/sample_200m.txt (Errno::ENOENT)
	from aws_mp_upload.rb:6:in `open'
	from aws_mp_upload.rb:6:in `block in <main>'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:65:in `block in upload_parts'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:63:in `pipe'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:63:in `upload_parts'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:43:in `upload'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/customizations/object.rb:267:in `upload_stream'
	from aws_mp_upload.rb:5:in `<main>'
```
... note no DELETE HTTP request is issued.

This is what I got with JRuby 9.1.17.0 before the fix:
```bash
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ rvm use jruby-9.1.17.0
Using /Users/nikolay.bekirov/.rvm/gems/jruby-9.1.17.0
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ ruby aws_mp_upload.rb bekirov-test-ireland-2 object-key-200 ~/Desktop/sample_200m.txt
opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
SSL established
<- "POST /object-key-200?uploads HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.89.1 jruby/2.3.3 java aws-sdk-s3/1.60.1\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163709Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
-> "HTTP/1.1 200 OK\r\n"
-> "x-amz-id-2: FnY77lKkvcPl2UNM7ZlnguiRKHUNkFYC6OESYmX401ren3I21Rfi2YVEO73rcJo/0Re9HdYkszk=\r\n"
-> "x-amz-request-id: 3E1C6F2F824AF05C\r\n"
-> "Date: Fri, 06 Mar 2020 16:37:11 GMT\r\n"
-> "Transfer-Encoding: chunked\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
-> "16b\r\n"
reading 363 bytes...
-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>bekirov-test-ireland-2</Bucket><Key>object-key-200</Key><UploadId>5R7BmaRF78MpCqiAjFNaIHbq5lNjPIX06kcuJN5PMRwZ4iPlfwkfbo7Dp_c_1P_SkaH9FVhY7mcoBJllhQ7rffVTCUWpJtgB84H1UaOU0YChmMpMgn.zlLvJTF3IBWZN</UploadId></InitiateMultipartUploadResult>"
read 363 bytes
reading 2 bytes...
-> "\r\n"
read 2 bytes
-> "0\r\n"
-> "\r\n"
Conn keep-alive
```
... script never terminates

This is what I'm getting with Ruby 2.4.4 after the fix:
```bash
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ rvm use ruby-2.4.4
Using /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ ruby aws_mp_upload.rb bekirov-test-ireland-2 object-key-200 ~/Desktop/sample_200m.txt
opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
SSL established
<- "POST /object-key-200?uploads HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.90.1 ruby/2.4.4 x86_64-darwin17 aws-sdk-s3/1.60.2\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163917Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
-> "HTTP/1.1 200 OK\r\n"
-> "x-amz-id-2: /4RJhv7ZeTBMswwqXmzYJCnbENy7P9R/F4EYqt9JaNys28Jjdu15LqRe38R8V45f5mSWiVdt8mI=\r\n"
-> "x-amz-request-id: 73B835EFE35E5062\r\n"
-> "Date: Fri, 06 Mar 2020 16:39:18 GMT\r\n"
-> "Transfer-Encoding: chunked\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
-> "16b\r\n"
reading 363 bytes...
-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>bekirov-test-ireland-2</Bucket><Key>object-key-200</Key><UploadId>SAXJuJTWMuCsGeKl6z.btfEBLzdhjSri17KyPfP7BPgkaIDQ_RHIbA6zm7YlhHNjCWSkBfTZgNSJlu.RmJivz7svG.FoU2s4G9nl.gr.MVPxMPHtYNYjE_RLE51k2o_m</UploadId></InitiateMultipartUploadResult>"
read 363 bytes
reading 2 bytes...
-> "\r\n"
read 2 bytes
-> "0\r\n"
-> "\r\n"
Conn keep-alive
<- opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
"PUT /object-key-200?partNumber=1&uploadId=SAXJuJTWMuCsGeKl6z.btfEBLzdhjSri17KyPfP7BPgkaIDQ_RHIbA6zm7YlhHNjCWSkBfTZgNSJlu.RmJivz7svG.FoU2s4G9nl.gr.MVPxMPHtYNYjE_RLE51k2o_m HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.90.1 ruby/2.4.4 x86_64-darwin17 aws-sdk-s3/1.60.2\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163917Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
-> "HTTP/1.1 200 OK\r\n"
-> "x-amz-id-2: omh1gGVXFfFkVdWdsc23pWFYzTdAus1Ymffr/XepA0JaLv0y4hkn+3xgEN66yOGgSHkMGDAMajo=\r\n"
-> "x-amz-request-id: 68653EEA12F50915\r\n"
-> "Date: Fri, 06 Mar 2020 16:39:18 GMT\r\n"
-> "ETag: \"d41d8cd98f00b204e9800998ecf8427e\"\r\n"
-> "Content-Length: 0\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
reading 0 bytes...
-> ""
read 0 bytes
Conn keep-alive
SSL established
<- "DELETE /object-key-200?uploadId=SAXJuJTWMuCsGeKl6z.btfEBLzdhjSri17KyPfP7BPgkaIDQ_RHIbA6zm7YlhHNjCWSkBfTZgNSJlu.RmJivz7svG.FoU2s4G9nl.gr.MVPxMPHtYNYjE_RLE51k2o_m HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.90.1 ruby/2.4.4 x86_64-darwin17 aws-sdk-s3/1.60.2\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T163917Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
-> "HTTP/1.1 204 No Content\r\n"
-> "x-amz-id-2: BV1Z3AYlk157wmbR4QCtjCzgB6tAOvOMpK9hwTlPPw0xTgJBgtRRinizDgs7+fwktBvgVT6bsO4=\r\n"
-> "x-amz-request-id: E04C488C997AAFA3\r\n"
-> "Date: Fri, 06 Mar 2020 16:39:19 GMT\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
Conn keep-alive
/Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:89:in `abort_upload': multipart upload failed: No such file or directory @ rb_sysopen - /Users/nikolay.bekirov/Desktop/sample_200m.txt (Aws::S3::MultipartUploadError)
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:78:in `upload_parts'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/multipart_stream_uploader.rb:43:in `upload'
	from /Users/nikolay.bekirov/.rvm/gems/ruby-2.4.4/gems/aws-sdk-s3-1.60.2/lib/aws-sdk-s3/customizations/object.rb:267:in `upload_stream'
	from aws_mp_upload.rb:5:in `<main>'
```
...with a DELETE HTTP request.

This is what I'm getting with JRuby 9.1.17.0 after the fix:
```bash
nikolay.bekirov@Nikolays-MacBook-Pro:~/Projects/access-server$ ruby aws_mp_upload.rb bekirov-test-ireland-2 object-key-200 ~/Desktop/sample_200m.txt
opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
SSL established
<- "POST /object-key-200?uploads HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.89.1 jruby/2.3.3 java aws-sdk-s3/1.60.1\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T164138Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
-> "HTTP/1.1 200 OK\r\n"
-> "x-amz-id-2: u7ShIhxDefES6026avM4euFWWsKBNgmKEwrSxqwnrSTxhTtmG/utJaqlVc4mzwCq4fPGge1qVdg=\r\n"
-> "x-amz-request-id: F1F3A28344D4667F\r\n"
-> "Date: Fri, 06 Mar 2020 16:41:40 GMT\r\n"
-> "Transfer-Encoding: chunked\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
-> "16b\r\n"
reading 363 bytes...
-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>bekirov-test-ireland-2</Bucket><Key>object-key-200</Key><UploadId>VWMvbLWqHKTDyKbDK7_kJwScbBBtQEW0s.8K0P1aOv8S_TTDlcoPOcMyG5NzkGDBP2SEjTIZdAla7KeVHX8N4OAwG9.puLQApTVMEajiGH7hHSWi2AQ.g8aZ3Or_W28r</UploadId></InitiateMultipartUploadResult>"
read 363 bytes
reading 2 bytes...
-> "\r\n"
read 2 bytes
-> "0\r\n"
-> "\r\n"
Conn keep-alive
opening connection to bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...<-
"DELETE /object-key-200?uploadId=VWMvbLWqHKTDyKbDK7_kJwScbBBtQEW0s.8K0P1aOv8S_TTDlcoPOcMyG5NzkGDBP2SEjTIZdAla7KeVHX8N4OAwG9.puLQApTVMEajiGH7hHSWi2AQ.g8aZ3Or_W28r HTTP/1.1\r\nContent-Type: \r\nAccept-Encoding: \r\nUser-Agent: aws-sdk-ruby3/3.89.1 jruby/2.3.3 java aws-sdk-s3/1.60.1\r\nHost: bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com\r\nX-Amz-Date: 20200306T164139Z\r\nX-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAuthorization: [..]"
opened
starting SSL for bekirov-test-ireland-2.s3.eu-west-1.amazonaws.com:443...
SSL established
-> "HTTP/1.1 204 No Content\r\n"
-> "x-amz-id-2: yTYsNA0X+KNB97woQyx1jchGXaDeI2LpSG+GY92VfO1goc8Ao/ArB1lnd195XbR0TjzGKGbypvw=\r\n"
-> "x-amz-request-id: 306791B53E2A5F7B\r\n"
-> "Date: Fri, 06 Mar 2020 16:41:40 GMT\r\n"
-> "Server: AmazonS3\r\n"
-> "\r\n"
Conn keep-alive
Aws::S3::MultipartUploadError: multipart upload failed: No such file or directory - /Users/nikolay.bekirov/Desktop/sample_200m.txt
   abort_upload at /Users/nikolay.bekirov/.rvm/gems/jruby-9.1.17.0/gems/aws-sdk-s3-1.60.1/lib/aws-sdk-s3/multipart_stream_uploader.rb:89
   upload_parts at /Users/nikolay.bekirov/.rvm/gems/jruby-9.1.17.0/gems/aws-sdk-s3-1.60.1/lib/aws-sdk-s3/multipart_stream_uploader.rb:78
         upload at /Users/nikolay.bekirov/.rvm/gems/jruby-9.1.17.0/gems/aws-sdk-s3-1.60.1/lib/aws-sdk-s3/multipart_stream_uploader.rb:43
  upload_stream at /Users/nikolay.bekirov/.rvm/gems/jruby-9.1.17.0/gems/aws-sdk-s3-1.60.1/lib/aws-sdk-s3/customizations/object.rb:267
         <main> at aws_mp_upload.rb:5
```
... script terminates with the expected error. JRuby specific handling is needed because of jruby/jruby#6111


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
