### PR TITLE
Avoid redirects for region mismatch when using custom / non-aws S3 endpoints

### DIFF
--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -14,7 +14,6 @@ def whitelist
     },
     's3' => {
       'location_constraint.rb' => 12,
-      's3_signer.rb' => 202,
       'bucket.rb' => 143,
       'presigned_post.rb' => 587,
       'iad_regional_endpoint.rb' => 'SKIP_FILE'

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Don't update endpoint on region mismatch errors when using a custom endpoint.
+
 1.60.2 (2020-02-07)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -186,11 +186,13 @@ module Aws
           # @option options [required, #credentials] :credentials
           # @api private
           def build_v4_signer(options = {})
-            Aws::Sigv4::Signer.new(service: 's3',
-                                   region: options[:region],
-                                   credentials_provider: options[:credentials],
-                                   uri_escape_path: false,
-                                   unsigned_headers: ['content-length', 'x-amzn-trace-id'])
+            Aws::Sigv4::Signer.new(
+              service: 's3',
+              region: options[:region],
+              credentials_provider: options[:credentials],
+              uri_escape_path: false,
+              unsigned_headers: ['content-length', 'x-amzn-trace-id']
+            )
           end
 
           def new_hostname(context, region)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -6,7 +6,6 @@ module Aws
       # This plugin is an implementation detail and may be modified.
       # @api private
       class S3Signer < Seahorse::Client::Plugin
-
         option(:signature_version, 'v4')
 
         option(:sigv4_signer) do |cfg|
@@ -18,7 +17,6 @@ module Aws
 
         option(:sigv4_region) do |cfg|
           raise Aws::Errors::MissingRegionError if cfg.region.nil?
-          puts "sigv4_region: #{cfg.region}"
           Aws::Partitions::EndpointProvider.signing_region(cfg.region, 's3')
         end
 
@@ -50,7 +48,6 @@ module Aws
         end
 
         class V4Handler < Seahorse::Client::Handler
-
           def call(context)
             Aws::Plugins::SignatureV4.apply_signature(
               context: context,
@@ -67,7 +64,6 @@ module Aws
             if
               context[:cached_sigv4_region] &&
               context[:cached_sigv4_region] != context.config.sigv4_signer.region
-            then
               S3Signer.build_v4_signer(
                 region: context[:cached_sigv4_region],
                 credentials: context.config.credentials
@@ -76,13 +72,11 @@ module Aws
               context.config.sigv4_signer
             end
           end
-
         end
 
         # This handler will update the http endpoint when the bucket region
         # is known/cached.
         class CachedBucketRegionHandler < Seahorse::Client::Handler
-
           def call(context)
             bucket = context.params[:bucket]
             check_for_cached_region(context, bucket) if bucket
@@ -98,7 +92,6 @@ module Aws
               context[:cached_sigv4_region] = cached_region
             end
           end
-
         end
 
         # This handler detects when a request fails because of a mismatched bucket
@@ -106,7 +99,6 @@ module Aws
         # region, then finally a version 4 signed request against the correct
         # regional endpoint.
         class BucketRegionErrorHandler < Seahorse::Client::Handler
-
           def call(context)
             response = @handler.call(context)
             handle_region_errors(response)
@@ -171,7 +163,7 @@ module Aws
 
           def region_from_body(body)
             region = body.match(/<Region>(.+?)<\/Region>/)[1]
-            if region.nil? || region == ""
+            if region.nil? || region == ''
               raise "couldn't get region from body: #{body}"
             else
               region
@@ -179,32 +171,28 @@ module Aws
           end
 
           def log_warning(context, actual_region)
-            msg = "S3 client configured for #{context.config.region.inspect} " +
-                  "but the bucket #{context.params[:bucket].inspect} is in " +
-                  "#{actual_region.inspect}; Please configure the proper region " +
+            msg = "S3 client configured for #{context.config.region.inspect} " \
+                  "but the bucket #{context.params[:bucket].inspect} is in " \
+                  "#{actual_region.inspect}; Please configure the proper region " \
                   "to avoid multiple unnecessary redirects and signing attempts\n"
-            if logger = context.config.logger
+            if (logger = context.config.logger)
               logger.warn(msg)
             else
               warn(msg)
             end
           end
-
         end
 
         class << self
-
           # @option options [required, String] :region
           # @option options [required, #credentials] :credentials
           # @api private
           def build_v4_signer(options = {})
-            Aws::Sigv4::Signer.new({
-              service: 's3',
-              region: options[:region],
-              credentials_provider: options[:credentials],
-              uri_escape_path: false,
-              unsigned_headers: ['content-length', 'x-amzn-trace-id'],
-            })
+            Aws::Sigv4::Signer.new(service: 's3',
+                                   region: options[:region],
+                                   credentials_provider: options[:credentials],
+                                   uri_escape_path: false,
+                                   unsigned_headers: ['content-length', 'x-amzn-trace-id'])
           end
 
           def new_hostname(context, region)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -17,6 +17,7 @@ module Aws
 
         option(:sigv4_region) do |cfg|
           raise Aws::Errors::MissingRegionError if cfg.region.nil?
+
           Aws::Partitions::EndpointProvider.signing_region(cfg.region, 's3')
         end
 
@@ -61,9 +62,8 @@ module Aws
           def sigv4_signer(context)
             # If the client was configured with the wrong region,
             # we have to build a new signer.
-            if
-              context[:cached_sigv4_region] &&
-              context[:cached_sigv4_region] != context.config.sigv4_signer.region
+            if context[:cached_sigv4_region] &&
+               context[:cached_sigv4_region] != context.config.sigv4_signer.region
               S3Signer.build_v4_signer(
                 region: context[:cached_sigv4_region],
                 credentials: context.config.credentials
@@ -142,10 +142,8 @@ module Aws
 
           def wrong_sigv4_region?(resp)
             resp.context.http_response.status_code == 400 &&
-              (
-                resp.context.http_response.headers['x-amz-bucket-region'] ||
-                resp.context.http_response.body_contents.match(/<Region>.+?<\/Region>/)
-              )
+              (resp.context.http_response.headers['x-amz-bucket-region'] ||
+               resp.context.http_response.body_contents.match(/<Region>.+?<\/Region>/))
           end
 
           def resign_with_new_region(context, actual_region)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -115,7 +115,9 @@ module Aws
           private
 
           def handle_region_errors(response)
-            if wrong_sigv4_region?(response) && !fips_region?(response) && !custom_endpoint?(response)
+            if wrong_sigv4_region?(response) &&
+               !fips_region?(response) &&
+               !custom_endpoint?(response)
               get_region_and_retry(response.context)
             else
               response
@@ -148,10 +150,10 @@ module Aws
 
           def wrong_sigv4_region?(resp)
             resp.context.http_response.status_code == 400 &&
-            (
-              resp.context.http_response.headers['x-amz-bucket-region'] ||
-              resp.context.http_response.body_contents.match(/<Region>.+?<\/Region>/)
-            )
+              (
+                resp.context.http_response.headers['x-amz-bucket-region'] ||
+                resp.context.http_response.body_contents.match(/<Region>.+?<\/Region>/)
+              )
           end
 
           def resign_with_new_region(context, actual_region)
@@ -178,9 +180,9 @@ module Aws
 
           def log_warning(context, actual_region)
             msg = "S3 client configured for #{context.config.region.inspect} " +
-              "but the bucket #{context.params[:bucket].inspect} is in " +
-              "#{actual_region.inspect}; Please configure the proper region " +
-              "to avoid multiple unnecessary redirects and signing attempts\n"
+                  "but the bucket #{context.params[:bucket].inspect} is in " +
+                  "#{actual_region.inspect}; Please configure the proper region " +
+                  "to avoid multiple unnecessary redirects and signing attempts\n"
             if logger = context.config.logger
               logger.warn(msg)
             else

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -13,8 +13,8 @@ module Aws
 
       let(:client) { Client.new(client_opts) }
 
-      let(:auth_header_malformed_body) do
-        '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>'\
+      let(:auth_header_malformed_body) do 
+       '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>'\
        'AuthorizationHeaderMalformed</Code><Message>The '\
        "authorization header is malformed; the region 'us-west-2' is"\
        "wrong; expecting 'eu-central-1'</Message><Region>"\

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -14,7 +14,7 @@ module Aws
       let(:client) { Client.new(client_opts) }
 
       let(:auth_header_malformed_body) do
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
+        '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>'\
        'AuthorizationHeaderMalformed</Code><Message>The '\
        "authorization header is malformed; the region 'us-west-2' is"\
        "wrong; expecting 'eu-central-1'</Message><Region>"\

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -13,53 +13,30 @@ module Aws
 
       let(:client) { Client.new(client_opts) }
 
+      let(:auth_header_malformed_body) do
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
+       'AuthorizationHeaderMalformed</Code><Message>The '\
+       "authorization header is malformed; the region 'us-west-2' is"\
+       "wrong; expecting 'eu-central-1'</Message><Region>"\
+       'eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId>'\
+       '<HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oek'\
+       'WlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>'
+      end
+
       before(:each) do
         allow($stderr).to receive(:write)
         S3::BUCKET_REGIONS.clear
       end
 
-      context 'accessing a bucket in eu-central-1 with wrong region' do
-        before(:each) do
-          body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
-                 'PermanentRedirect</Code><Message>The bucket you are '\
-                 'attempting to access must be addressed using the specified '\
-                 'endpoint. Please send all future requests to this endpoint.'\
-                 '</Message><RequestId>A9D9FE127C48F985</RequestId><Bucket>'\
-                 'aws-sdk-fra</Bucket><HostId>1ErVsdg5tuC0lg2JQiB3FCd7K7blTR3V'\
-                 'MH14Pm3405voMEIQftv8bi4nhpYbn3B4</HostId><Endpoint>'\
-                 'aws-sdk-fra.s3.eu-central-1.amazonaws.com</Endpoint></Error>'
-          stub_request(:put, 'https://bucket.s3.us-west-2.amazonaws.com/key')
-            .to_return(status: [301, 'Moved Permanently'], body: body)
-
-          stub_request(:put, 'https://bucket.s3.external-1.amazonaws.com/key')
-            .to_return(
-              status: [307, 'Temporary Redirect'],
-              headers: {
-                'Location' => 'https://bucket.s3.eu-central-1.amazonaws.com/key'
-              }
-            )
-
-          stub_request(:put, 'https://bucket.s3.eu-central-1.amazonaws.com/key')
-            .to_return(status: [200, 'Ok'])
-        end
-      end
-
       context 'accessing eu-central-1 bucket using classic endpoint and wrong'\
         'sigv4 region' do
         before(:each) do
-          body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
-                 'AuthorizationHeaderMalformed</Code><Message>The '\
-                 "authorization header is malformed; the region 'us-west-2' is"\
-                 "wrong; expecting 'eu-central-1'</Message><Region>"\
-                 'eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId>'\
-                 '<HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oek'\
-                 'WlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>'
           stub_request(:put, 'https://bucket.s3.us-west-2.amazonaws.com/key')
-            .to_return(status: [400, 'Bad Request'], body: body)
+            .to_return(status: [400, 'Bad Request'], body: auth_header_malformed_body)
 
           stub_request(
             :put, 'https://bucket.s3-fips.us-west-2.amazonaws.com/keya'
-          ).to_return(status: [400, 'Bad Request'], body: body)
+          ).to_return(status: [400, 'Bad Request'], body: auth_header_malformed_body)
 
           stub_request(:put, 'https://bucket.s3.eu-central-1.amazonaws.com/key')
             .to_return(status: [200, 'Ok'])
@@ -76,6 +53,7 @@ module Aws
 
         it 'detects the moved permanently and redirects' do
           client = S3::Client.new(client_opts.merge(region: 'us-west-2'))
+          expect_any_instance_of(Plugins::S3Signer::BucketRegionErrorHandler).to receive(:warn)
           resp = client.put_object(bucket: 'bucket', key: 'key', body: 'body')
           host = resp.context.http_request.endpoint.host
           expect(host).to eq('bucket.s3.eu-central-1.amazonaws.com')
@@ -108,15 +86,8 @@ module Aws
 
       context 'using custom endpoint and wrong sigv4 region' do
         before(:each) do
-          body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
-                 'AuthorizationHeaderMalformed</Code><Message>The '\
-                 "authorization header is malformed; the region 'us-west-2' is"\
-                 "wrong; expecting 'eu-central-1'</Message><Region>"\
-                 'eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId>'\
-                 '<HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oek'\
-                 'WlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>'
           stub_request(:put, 'http://bucket.localhost:9000/key')
-            .to_return(status: [400, 'Bad Request'], body: body)
+            .to_return(status: [400, 'Bad Request'], body: auth_header_malformed_body)
         end
 
         it 'doesnt retry with a new endpoint' do
@@ -130,7 +101,6 @@ module Aws
             client.put_object(bucket: 'bucket', key: 'key', body: 'body')
           end.to raise_error(Aws::S3::Errors::AuthorizationHeaderMalformed)
         end
-
       end
 
       describe 'Client Side Monitoring' do
@@ -154,19 +124,14 @@ module Aws
         end
 
         it 'updates fqdn and region in metrics when a 400 redirect occurs' do
-          body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>"\
-                 'AuthorizationHeaderMalformed</Code><Message>The '\
-                 "authorization header is malformed; the region 'us-west-2' is"\
-                 "wrong; expecting 'eu-central-1'</Message><Region>"\
-                 'eu-central-1</Region><RequestId>531B68B3613F5C96</RequestId>'\
-                 '<HostId>TMnOREh0Ms0touCRX0XkJinw7xqsF0v/iFyA+nCC4d3PpF+k2oek'\
-                 'WlSrUk+8d2/rvcnEv2QXer0=</HostId></Error>'
-
           stub_request(:put, 'https://bucket.s3.us-west-2.amazonaws.com/key')
-            .to_return(status: [400, 'Bad Request'], body: body)
+            .to_return(status: [400, 'Bad Request'], body: auth_header_malformed_body)
           stub_request(:put, 'https://bucket.s3.eu-central-1.amazonaws.com/key')
             .to_return(status: [200, 'Ok'])
-          resp = client.put_object(bucket: 'bucket', key: 'key', body: 'body')
+
+          expect_any_instance_of(Plugins::S3Signer::BucketRegionErrorHandler).to receive(:warn)
+
+          client.put_object(bucket: 'bucket', key: 'key', body: 'body')
           expect(stub_publisher.metrics.size).to eq(1)
           metric = stub_publisher.metrics.first
           expect(metric.api_call.region).to eq('eu-central-1')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
