### PR TITLE
remove mutated string declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 before_install:
   - gem install bundler -v '< 2'
-  - "find . -type f -iname '*.rb' -exec sed -i '1s/^/# frozen_string_literal: true\\n/' \"{}\" +;"
 
 dist: trusty
 
@@ -25,7 +24,10 @@ env:
   - PURE_RUBY=1
   - KITCHEN_SINK=1
 
-script: rake build && rake test:spec
+script: >
+  bundle exec rake build &&
+  find . -not -path './vendor/*' -type f -iname '*.rb' -exec sed -i -z '1s/^\(\s*#\s*encoding[^\n]*\n\)\?/\1# frozen_string_literal: true\n/' '{}' +; &&
+  bundle exec rake test:spec
 
 bundler_args: --without docs repl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 before_install:
   - gem install bundler -v '< 2'
-  - "find . -type f -iname '*.rb' -exec sed -i '1s/^/# frozen_string_literal: true\\n\\n/' \"{}\" +;"
+  - "find . -type f -iname '*.rb' -exec sed -i '1s/^/# frozen_string_literal: true\\n/' \"{}\" +;"
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 
 before_install:
   - gem install bundler -v '< 2'
+  - "find . -type f -iname '*.rb' -exec sed -i '1s/^/# frozen_string_literal: true\\n\\n/' \"{}\" +;"
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
 
 script: >
   (bundle exec rake build) &&
-  (find . -not -path './vendor/*' -type f -iname '*.rb' -exec sed -i -z '1s/^\(\s*#\s*encoding[^\n]*\n\)\?/\1# frozen_string_literal: true\n/' '{}' +;) &&
   (bundle exec rake test:spec)
 
 bundler_args: --without docs repl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+cache: bundler
+
+# to clear bundler cache:
+#   rm -r ./vendor
 
 before_install:
   - gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: ruby
-cache: bundler
-
-# to clear bundler cache:
-#   rm -r ./vendor
 
 before_install:
   - gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ env:
   - KITCHEN_SINK=1
 
 script: >
-  bundle exec rake build &&
-  find . -not -path './vendor/*' -type f -iname '*.rb' -exec sed -i -z '1s/^\(\s*#\s*encoding[^\n]*\n\)\?/\1# frozen_string_literal: true\n/' '{}' +; &&
-  bundle exec rake test:spec
+  (bundle exec rake build) &&
+  (find . -not -path './vendor/*' -type f -iname '*.rb' -exec sed -i -z '1s/^\(\s*#\s*encoding[^\n]*\n\)\?/\1# frozen_string_literal: true\n/' '{}' +;) &&
+  (bundle exec rake test:spec)
 
 bundler_args: --without docs repl
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
@@ -11,7 +11,7 @@ module AwsSdkCodeGenerator
     end
 
     def to_str
-      "@example Response structure\n\n  #{entry(@shape_ref, "resp", Set.new).join("\n  ")}"
+      "@example Response structure\n\n  #{entry(@shape_ref, 'resp', Set.new).join("\n  ")}"
     end
     alias to_s to_str
 
@@ -27,9 +27,9 @@ module AwsSdkCodeGenerator
           event_type = Underscore.underscore(member_name).to_sym
           event_types << event_type
           ctx << "For #{event_type.inspect} event available at #on_#{event_type}_event callback"\
-                 " and response eventstream enumerator:"
-          event_entry = entry(member_ref, "event", Set.new).join("\n  ")
-          ctx << (event_entry.empty? ? " #=> EmptyStruct" : event_entry + "\n")
+                 ' and response eventstream enumerator:'
+          event_entry = entry(member_ref, 'event', Set.new).join("\n  ")
+          ctx << (event_entry.empty? ? ' #=> EmptyStruct' : event_entry + "\n")
         end
         # Add eventstream entry
         event_ctx.unshift("#{context}.event_types #=> #{event_types.inspect}\n")

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
@@ -27,7 +27,7 @@ module AwsSdkCodeGenerator
           event_type = Underscore.underscore(member_name).to_sym
           event_types << event_type
           ctx << "For #{event_type.inspect} event available at #on_#{event_type}_event callback"\
-            " and response eventstream enumerator:"
+                 " and response eventstream enumerator:"
           event_entry = entry(member_ref, "event", Set.new).join("\n  ")
           ctx << (event_entry.empty? ? " #=> EmptyStruct" : event_entry + "\n")
         end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -141,7 +141,7 @@ module AwsSdkCodeGenerator
     end
 
     def apig_prefix(name)
-      "__" << name
+      "__#{name}"
     end
 
     def shape(ref)

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -104,8 +104,8 @@ module {{module_name}}
       when nil then event_stream_class.new
       else
         msg = "expected #{type}_event_stream_handler to be a block or "\
-          "instance of {{module_name}}::#{event_stream_class}"\
-          ", got `#{handler.inspect}` instead"
+              "instance of {{module_name}}::#{event_stream_class}"\
+              ", got `#{handler.inspect}` instead"
         raise ArgumentError, msg
       end
     end

--- a/build_tools/aws-sdk-code-generator/templates/client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_class.mustache
@@ -100,8 +100,8 @@ module {{module_name}}
         when nil then EventStreams::{{output_eventstream_member}}.new
         else
           msg = "expected :event_stream_handler to be a block or "\
-            "instance of {{module_name}}::EventStreams::{{output_eventstream_member}}"\
-            ", got `#{handler.inspect}` instead"
+                "instance of {{module_name}}::EventStreams::{{output_eventstream_member}}"\
+                ", got `#{handler.inspect}` instead"
           raise ArgumentError, msg
         end
 

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -256,8 +256,8 @@ module {{module_name}}
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -33,7 +33,6 @@ describe 'ensure no hard-coded region' do
 
       file = File.open(path, 'r', encoding: 'UTF-8', &:read)
       lines = file.lines.to_a
-      lines_inserted = 2 # for string immutability tests
 
       it "#{path} has no hard-coded region" do
         lines.each_with_index do |val, idx|
@@ -42,9 +41,7 @@ describe 'ensure no hard-coded region' do
 
           # skip known whitelists
           next if whitelist[key] &&
-                  (((idx - lines_inserted)..idx).include?(
-                    whitelist[key][File.basename(path)]
-                  ) ||
+                  (whitelist[key][File.basename(path)] == idx ||
                   whitelist[key][File.basename(path)] == 'SKIP_FILE')
 
           # If we use \w+ we will get false positives for uid fields

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -33,6 +33,7 @@ describe 'ensure no hard-coded region' do
 
       file = File.open(path, 'r', encoding: 'UTF-8', &:read)
       lines = file.lines.to_a
+      lines_inserted = 2 # for string immutability tests
 
       it "#{path} has no hard-coded region" do
         lines.each_with_index do |val, idx|
@@ -41,7 +42,9 @@ describe 'ensure no hard-coded region' do
 
           # skip known whitelists
           next if whitelist[key] &&
-                  (whitelist[key][File.basename(path)] == idx ||
+                  (((idx - lines_inserted)..idx).include?(
+                    whitelist[key][File.basename(path)]
+                  ) ||
                   whitelist[key][File.basename(path)] == 'SKIP_FILE')
 
           # If we use \w+ we will get false positives for uid fields

--- a/gems/aws-eventstream/lib/aws-eventstream/errors.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/errors.rb
@@ -6,7 +6,7 @@ module Aws
       class ReadBytesExceedLengthError < RuntimeError
         def initialize(target_byte, total_len)
           msg = "Attempting reading bytes to offset #{target_byte} exceeds"\
-            " buffer length of #{total_len}"
+                " buffer length of #{total_len}"
           super(msg)
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition.rb
@@ -21,8 +21,8 @@ module Aws
         if @regions.key?(region_name)
           @regions[region_name]
         else
-          msg = "invalid region name #{region_name.inspect}; valid region "
-          msg << "names include #{@regions.keys.join(', ')}"
+          msg = "invalid region name #{region_name.inspect}; valid region "\
+            "names include #{@regions.keys.join(', ')}"
           raise ArgumentError, msg
         end
       end
@@ -45,8 +45,8 @@ module Aws
         if @services.key?(service_name)
           @services[service_name]
         else
-          msg = "invalid service name #{service_name.inspect}; valid service "
-          msg << "names include #{@services.keys.join(', ')}"
+          msg = "invalid service name #{service_name.inspect}; valid service "\
+            "names include #{@services.keys.join(', ')}"
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition.rb
@@ -22,7 +22,7 @@ module Aws
           @regions[region_name]
         else
           msg = "invalid region name #{region_name.inspect}; valid region "\
-            "names include #{@regions.keys.join(', ')}"
+                "names include #{@regions.keys.join(', ')}"
           raise ArgumentError, msg
         end
       end
@@ -46,7 +46,7 @@ module Aws
           @services[service_name]
         else
           msg = "invalid service name #{service_name.inspect}; valid service "\
-            "names include #{@services.keys.join(', ')}"
+                "names include #{@services.keys.join(', ')}"
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition_list.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition_list.rb
@@ -19,8 +19,8 @@ module Aws
         if @partitions.key?(partition_name)
           @partitions[partition_name]
         else
-          msg = "invalid partition name #{partition_name.inspect}; valid "
-          msg << "partition names include %s" % [@partitions.keys.join(', ')]
+          msg = "invalid partition name #{partition_name.inspect}; valid "\
+            "partition names include %s" % [@partitions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-partitions/lib/aws-partitions/partition_list.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition_list.rb
@@ -20,7 +20,7 @@ module Aws
           @partitions[partition_name]
         else
           msg = "invalid partition name #{partition_name.inspect}; valid "\
-            "partition names include %s" % [@partitions.keys.join(', ')]
+                "partition names include %s" % [@partitions.keys.join(', ')]
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1294,7 +1294,7 @@ module Aws::AutoScaling
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1251,7 +1251,7 @@ module Aws::AutoScaling
       Tag.new(
         key: key,
         resource_id: @name,
-        resource_type: "auto-scaling-group",
+        resource_type: 'auto-scaling-group',
         client: @client
       )
     end
@@ -1284,7 +1284,7 @@ module Aws::AutoScaling
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1293,8 +1293,8 @@ module Aws::AutoScaling
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1293,8 +1293,8 @@ module Aws::AutoScaling
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1071,7 +1071,7 @@ module Aws::CloudFormation
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1080,8 +1080,8 @@ module Aws::CloudFormation
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1080,8 +1080,8 @@ module Aws::CloudFormation
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1081,7 +1081,7 @@ module Aws::CloudFormation
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
@@ -37,28 +37,28 @@ module Aws
           }.to raise_error(ArgumentError)
         end
         it 'can generate signed urls with custom policy' do
-          policy =  {
+          policy = {
             'Statement' => [
               'Resource' => 'images/image.jpg',
-                'Condition' => {
-                'IpAddress' => {'AWS:SourceIp' => '10.52.176.0/24'},
-                'DateLessThan' => {'AWS:EpochTime' => expires}
-                }
-              ]
+              'Condition' => {
+                'IpAddress' => { 'AWS:SourceIp' => '10.52.176.0/24' },
+                'DateLessThan' => { 'AWS:EpochTime' => expires }
+              }
+            ]
           }
           url = signer.signed_url(
             "http://abc.cloudfront.net/images/image.jpg",
             :policy => policy.to_json
           )
           expected_url = "http://abc.cloudfront.net/images/image.jpg?"\
-            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2l"\
-            "tYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTO"\
-            "lNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGF"\
-            "uIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__"\
-            "&Signature=n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk"\
-            "8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL8"\
-            "3aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106"\
-            "HT4-Hp1c~nyOmXs4R5mU_&Key-Pair-Id=CF_KEYPAIR_ID"
+                         "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2l"\
+                         "tYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTO"\
+                         "lNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGF"\
+                         "uIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__"\
+                         "&Signature=n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk"\
+                         "8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL8"\
+                         "3aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106"\
+                         "HT4-Hp1c~nyOmXs4R5mU_&Key-Pair-Id=CF_KEYPAIR_ID"
             expect(url).to eq(expected_url)
         end
         it 'can generate signed urls with canned policy' do
@@ -67,11 +67,11 @@ module Aws
             :expires => expires
           )
           expected_url = "https://abc.cloudfront.net/images/image.jpg?"\
-            "color=red&Expires=1357034400&Signature=GvrDx3aAG1u1sAQF"\
-            "68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehw"\
-            "h~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLG"\
-            "USfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_"\
-            "&Key-Pair-Id=CF_KEYPAIR_ID"
+                         "color=red&Expires=1357034400&Signature=GvrDx3aAG1u1sAQF"\
+                         "68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehw"\
+                         "h~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLG"\
+                         "USfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_"\
+                         "&Key-Pair-Id=CF_KEYPAIR_ID"
             expect(url).to eq(expected_url)
         end
         it 'can generate signed rtmp urls' do
@@ -80,10 +80,10 @@ module Aws
             :expires => expires
           )
           expected_url = "videos/example.mp4?Expires=1357034400"\
-            "&Signature=TMXSGAw6x4fJsUfmBzJGbR2HYPduVFTPtqmoVQeZOEO"\
-            "Bs1NbQ6sARJoIMb9ot4CYyY95nNy8pzuuOkOm4DTsbda30a-8BrKx7"\
-            "loGHRb1AZztMkC1u-joz-3B9EgBRH6t6qpAFKtWoZI42F5LSacCb6O"\
-            "cTVsiWVeKyCGT~8i81-4_&Key-Pair-Id=CF_KEYPAIR_ID"
+                         "&Signature=TMXSGAw6x4fJsUfmBzJGbR2HYPduVFTPtqmoVQeZOEO"\
+                         "Bs1NbQ6sARJoIMb9ot4CYyY95nNy8pzuuOkOm4DTsbda30a-8BrKx7"\
+                         "loGHRb1AZztMkC1u-joz-3B9EgBRH6t6qpAFKtWoZI42F5LSacCb6O"\
+                         "cTVsiWVeKyCGT~8i81-4_&Key-Pair-Id=CF_KEYPAIR_ID"
           expect(url).to eq(expected_url)
         end
       end

--- a/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
@@ -6,7 +6,7 @@ module Aws
 
       let(:options) {
         {
-          :key_pair_id => "CF_KEYPAIR_ID",
+          :key_pair_id => 'CF_KEYPAIR_ID',
           :private_key_path =>"#{File.dirname(__FILE__)}/cf_private_key.pem"
         }
       }
@@ -24,7 +24,7 @@ module Aws
         it 'requires either private key or its path' do
           expect {
             Aws::CloudFront::UrlSigner.new(
-              :key_pair_id => "CF_KEYPAIR_ID"
+              :key_pair_id => 'CF_KEYPAIR_ID'
             )
           }.to raise_error(ArgumentError)
         end
@@ -33,7 +33,7 @@ module Aws
       describe '#signed_url' do
         it 'raises error if url is invaild' do
           expect {
-            signer.signed_url("what_ever_ilegal/url")
+            signer.signed_url('what_ever_ilegal/url')
           }.to raise_error(ArgumentError)
         end
         it 'can generate signed urls with custom policy' do
@@ -47,43 +47,43 @@ module Aws
             ]
           }
           url = signer.signed_url(
-            "http://abc.cloudfront.net/images/image.jpg",
+            'http://abc.cloudfront.net/images/image.jpg',
             :policy => policy.to_json
           )
-          expected_url = "http://abc.cloudfront.net/images/image.jpg?"\
-                         "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2l"\
-                         "tYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTO"\
-                         "lNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGF"\
-                         "uIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__"\
-                         "&Signature=n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk"\
-                         "8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL8"\
-                         "3aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106"\
-                         "HT4-Hp1c~nyOmXs4R5mU_&Key-Pair-Id=CF_KEYPAIR_ID"
+          expected_url = 'http://abc.cloudfront.net/images/image.jpg?'\
+                         'Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaW1hZ2VzL2l'\
+                         'tYWdlLmpwZyIsIkNvbmRpdGlvbiI6eyJJcEFkZHJlc3MiOnsiQVdTO'\
+                         'lNvdXJjZUlwIjoiMTAuNTIuMTc2LjAvMjQifSwiRGF0ZUxlc3NUaGF'\
+                         'uIjp7IkFXUzpFcG9jaFRpbWUiOjEzNTcwMzQ0MDB9fX1dfQ__'\
+                         '&Signature=n4V7xum3wA-w1PaCMyEMpWVXdfw-Yt8I26RpZJKc~Nk'\
+                         '8yQh8LYOxewItGJXFq0BxnKuSEKoEVYVTFEteFAGKXwhkbC7K~JfL8'\
+                         '3aroPbRagjyG-V9Y5wMLccBAzMj5nHXxjvjlOu541VUR-RlR0KK106'\
+                         'HT4-Hp1c~nyOmXs4R5mU_&Key-Pair-Id=CF_KEYPAIR_ID'
             expect(url).to eq(expected_url)
         end
         it 'can generate signed urls with canned policy' do
           url = signer.signed_url(
-            "https://abc.cloudfront.net/images/image.jpg?color=red",
+            'https://abc.cloudfront.net/images/image.jpg?color=red',
             :expires => expires
           )
-          expected_url = "https://abc.cloudfront.net/images/image.jpg?"\
-                         "color=red&Expires=1357034400&Signature=GvrDx3aAG1u1sAQF"\
-                         "68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehw"\
-                         "h~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLG"\
-                         "USfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_"\
-                         "&Key-Pair-Id=CF_KEYPAIR_ID"
+          expected_url = 'https://abc.cloudfront.net/images/image.jpg?'\
+                         'color=red&Expires=1357034400&Signature=GvrDx3aAG1u1sAQF'\
+                         '68c~xD6LVORt36mRTvC2u5RwLjsvusXI0sJPxy3D0R8AQp4qFZlRehw'\
+                         'h~mablw8DBNRFLQ81mazmbrUOhXbuepav5ZmCU-KgOmXtpMS49L7TLG'\
+                         'USfwSksDx1qriAtB4mS4iJaNt2mfo0C5G-vlt9qMftkJg_'\
+                         '&Key-Pair-Id=CF_KEYPAIR_ID'
             expect(url).to eq(expected_url)
         end
         it 'can generate signed rtmp urls' do
           url = signer.signed_url(
-            "rtmp://example-distribution.cloudfront.net/videos/example.mp4",
+            'rtmp://example-distribution.cloudfront.net/videos/example.mp4',
             :expires => expires
           )
-          expected_url = "videos/example.mp4?Expires=1357034400"\
-                         "&Signature=TMXSGAw6x4fJsUfmBzJGbR2HYPduVFTPtqmoVQeZOEO"\
-                         "Bs1NbQ6sARJoIMb9ot4CYyY95nNy8pzuuOkOm4DTsbda30a-8BrKx7"\
-                         "loGHRb1AZztMkC1u-joz-3B9EgBRH6t6qpAFKtWoZI42F5LSacCb6O"\
-                         "cTVsiWVeKyCGT~8i81-4_&Key-Pair-Id=CF_KEYPAIR_ID"
+          expected_url = 'videos/example.mp4?Expires=1357034400'\
+                         '&Signature=TMXSGAw6x4fJsUfmBzJGbR2HYPduVFTPtqmoVQeZOEO'\
+                         'Bs1NbQ6sARJoIMb9ot4CYyY95nNy8pzuuOkOm4DTsbda30a-8BrKx7'\
+                         'loGHRb1AZztMkC1u-joz-3B9EgBRH6t6qpAFKtWoZI42F5LSacCb6O'\
+                         'cTVsiWVeKyCGT~8i81-4_&Key-Pair-Id=CF_KEYPAIR_ID'
           expect(url).to eq(expected_url)
         end
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -515,7 +515,7 @@ module Aws::CloudWatch
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -505,7 +505,7 @@ module Aws::CloudWatch
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -514,8 +514,8 @@ module Aws::CloudWatch
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -514,8 +514,8 @@ module Aws::CloudWatch
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
@@ -400,7 +400,7 @@ module Aws::CloudWatch
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
@@ -399,8 +399,8 @@ module Aws::CloudWatch
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
@@ -390,7 +390,7 @@ module Aws::CloudWatch
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -399,8 +399,8 @@ module Aws::CloudWatch
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -168,7 +168,7 @@ module Aws
     # @api private
     def eager_autoload!(*args)
       msg = 'Aws.eager_autoload is no longer needed, usage of '\
-        'autoload has been replaced with require statements'
+            'autoload has been replaced with require statements'
       warn(msg)
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -167,8 +167,8 @@ module Aws
 
     # @api private
     def eager_autoload!(*args)
-      msg = 'Aws.eager_autoload is no longer needed, usage of '
-      msg << 'autoload has been replaced with require statements'
+      msg = 'Aws.eager_autoload is no longer needed, usage of '\
+        'autoload has been replaced with require statements'
       warn(msg)
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
@@ -43,7 +43,7 @@ module Aws
         @send_events
       else
         msg = 'This method is only implemented for stubbed clients, and is '\
-          'available when you enable stubbing in the constructor with `stub_responses: true`'
+              'available when you enable stubbing in the constructor with `stub_responses: true`'
         raise NotImplementedError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
@@ -42,8 +42,8 @@ module Aws
       if config.stub_responses
         @send_events
       else
-        msg = 'This method is only implemented for stubbed clients, and is '
-        msg << 'available when you enable stubbing in the constructor with `stub_responses: true`'
+        msg = 'This method is only implemented for stubbed clients, and is '\
+          'available when you enable stubbing in the constructor with `stub_responses: true`'
         raise NotImplementedError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -176,7 +176,7 @@ module Aws
         apply_stubs(operation_name, stubs.flatten)
       else
         msg = 'stubbing is not enabled; enable stubbing in the constructor '\
-          'with `:stub_responses => true`'
+              'with `:stub_responses => true`'
         raise msg
       end
     end
@@ -199,7 +199,7 @@ module Aws
         end
       else
         msg = 'This method is only implemented for stubbed clients, and is '\
-          'available when you enable stubbing in the constructor with `stub_responses: true`'
+              'available when you enable stubbing in the constructor with `stub_responses: true`'
         raise NotImplementedError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -175,8 +175,8 @@ module Aws
       if config.stub_responses
         apply_stubs(operation_name, stubs.flatten)
       else
-        msg = 'stubbing is not enabled; enable stubbing in the constructor '
-        msg << 'with `:stub_responses => true`'
+        msg = 'stubbing is not enabled; enable stubbing in the constructor '\
+          'with `:stub_responses => true`'
         raise msg
       end
     end
@@ -198,8 +198,8 @@ module Aws
           @api_requests
         end
       else
-        msg = 'This method is only implemented for stubbed clients, and is '
-        msg << 'available when you enable stubbing in the constructor with `stub_responses: true`'
+        msg = 'This method is only implemented for stubbed clients, and is '\
+          'available when you enable stubbing in the constructor with `stub_responses: true`'
         raise NotImplementedError.new(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
@@ -48,14 +48,12 @@ module Aws
     def deprecated(method, options = {})
 
       deprecation_msg = options[:message] || begin
-        msg = "#################### DEPRECATION WARNING ####################\n"
-        msg << "Called deprecated method `#{method}` of #{self}."
-        msg << " Use `#{options[:use]}` instead.\n" if options[:use]
-        if options[:version]
-          msg << "Method `#{method}` will be removed in #{options[:version]}."
-        end
-        msg << "\n#############################################################"
-        msg
+        "#################### DEPRECATION WARNING ####################\n"\
+        "Called deprecated method `#{method}` of #{self}."\
+        "#{" Use `#{options[:use]}` instead.\n" if options[:use]}"\
+        "#{"Method `#{method}` will be removed in #{options[:version]}."\
+          if options[:version]}"\
+        "\n#############################################################"
       end
 
       alias_method(:"deprecated_#{method}", method)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -208,8 +208,8 @@ module Aws
     # Raised when a client is constructed and region is not specified.
     class MissingRegionError < ArgumentError
       def initialize(*args)
-        msg = "missing region; use :region option or "
-        msg << "export region name to ENV['AWS_REGION']"
+        msg = "missing region; use :region option or "\
+          "export region name to ENV['AWS_REGION']"
         super(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -52,7 +52,7 @@ module Aws
     # EcsCredentialsProvider fails to parse the metadata response after retries
     class MetadataParserError < RuntimeError
       def initialize(*args)
-        msg = "Failed to parse metadata service response."
+        msg = 'Failed to parse metadata service response.'
         super(msg)
       end
     end
@@ -83,8 +83,8 @@ module Aws
 
       def initialize(name)
         msg = "Missing required parameter #{name} to construct"\
-              " endpoint host prefix. You can disable host prefix by"\
-              " setting :disable_host_prefix_injection to `true`."
+              ' endpoint host prefix. You can disable host prefix by'\
+              ' setting :disable_host_prefix_injection to `true`.'
         super(msg)
       end
 
@@ -208,7 +208,7 @@ module Aws
     # Raised when a client is constructed and region is not specified.
     class MissingRegionError < ArgumentError
       def initialize(*args)
-        msg = "missing region; use :region option or "\
+        msg = 'missing region; use :region option or '\
               "export region name to ENV['AWS_REGION']"
         super(msg)
       end
@@ -289,7 +289,7 @@ Known AWS regions include (not specific to this service):
     module DynamicErrors
 
       def self.extended(submodule)
-        submodule.instance_variable_set("@const_set_mutex", Mutex.new)
+        submodule.instance_variable_set('@const_set_mutex', Mutex.new)
         submodule.const_set(:ServiceError, Class.new(ServiceError))
       end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -71,7 +71,7 @@ module Aws
     class EndpointDiscoveryError < RuntimeError
       def initialize(*args)
         msg = 'Endpoint discovery failed for the operation or discovered endpoint is not working, '\
-          'request will keep failing until endpoint discovery succeeds or :endpoint option is provided.'
+              'request will keep failing until endpoint discovery succeeds or :endpoint option is provided.'
         super(msg)
       end
     end
@@ -83,8 +83,8 @@ module Aws
 
       def initialize(name)
         msg = "Missing required parameter #{name} to construct"\
-          " endpoint host prefix. You can disable host prefix by"\
-          " setting :disable_host_prefix_injection to `true`."
+              " endpoint host prefix. You can disable host prefix by"\
+              " setting :disable_host_prefix_injection to `true`."
         super(msg)
       end
 
@@ -195,8 +195,8 @@ module Aws
     class MissingWebIdentityTokenFile < RuntimeError
       def initialize(*args)
         msg = 'Missing :web_identity_token_file parameter or'\
-          ' invalid file path provided for'\
-          ' Aws::AssumeRoleWebIdentityCredentials provider'
+              ' invalid file path provided for'\
+              ' Aws::AssumeRoleWebIdentityCredentials provider'
         super(msg)
       end
     end
@@ -209,7 +209,7 @@ module Aws
     class MissingRegionError < ArgumentError
       def initialize(*args)
         msg = "missing region; use :region option or "\
-          "export region name to ENV['AWS_REGION']"
+              "export region name to ENV['AWS_REGION']"
         super(msg)
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -152,7 +152,7 @@ module Aws
     def correct_type?(ref, value, errors, context)
       if ref.eventstream && @input
         errors << "instead of providing value directly for eventstreams at input,"\
-          " expected to use #signal events per stream"
+                  " expected to use #signal events per stream"
         return false
       end
       case value

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -167,8 +167,8 @@ a clock skew correction and retry requests with skewed client clocks.
         # Raise if provided value is not one of the retry modes
         if value != 'legacy' && value != 'standard' && value != 'adaptive'
           raise ArgumentError,
-                'Must provide either `legacy`, `standard`, or `adaptive` for '\
-                'retry_mode profile option or for ENV[\'AWS_RETRY_MODE\']'
+            'Must provide either `legacy`, `standard`, or `adaptive` for '\
+            'retry_mode profile option or for ENV[\'AWS_RETRY_MODE\']'
         end
         value
       end
@@ -180,8 +180,8 @@ a clock skew correction and retry requests with skewed client clocks.
         # Raise if provided value is not a positive integer
         if !value.is_a?(Integer) || value <= 0
           raise ArgumentError,
-                'Must provide a positive integer for max_attempts profile '\
-                'option or for ENV[\'AWS_MAX_ATTEMPTS\']'
+            'Must provide a positive integer for max_attempts profile '\
+            'option or for ENV[\'AWS_MAX_ATTEMPTS\']'
         end
         value
       end
@@ -194,9 +194,9 @@ a clock skew correction and retry requests with skewed client clocks.
         # Raise if provided value is not true or false
         if value != 'true' && value != 'false'
           raise ArgumentError,
-                'Must provide either `true` or `false` for '\
-                'adaptive_retry_wait_to_fill profile option or for '\
-                'ENV[\'AWS_ADAPTIVE_RETRY_WAIT_TO_FILL\']'
+            'Must provide either `true` or `false` for '\
+            'adaptive_retry_wait_to_fill profile option or for '\
+            'ENV[\'AWS_ADAPTIVE_RETRY_WAIT_TO_FILL\']'
         end
 
         value == 'true'
@@ -210,9 +210,9 @@ a clock skew correction and retry requests with skewed client clocks.
         # Raise if provided value is not true or false
         if value != 'true' && value != 'false'
           raise ArgumentError,
-                'Must provide either `true` or `false` for '\
-                'correct_clock_skew profile option or for '\
-                'ENV[\'AWS_CORRECT_CLOCK_SKEW\']'
+            'Must provide either `true` or `false` for '\
+            'correct_clock_skew profile option or for '\
+            'ENV[\'AWS_CORRECT_CLOCK_SKEW\']'
         end
 
         value == 'true'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
@@ -50,8 +50,8 @@ module Aws
             if StringShape === shape_ref.shape.member.shape
               list_of_strings(shape_ref.location_name, param_value)
             else
-              msg = "Only list of strings supported, got "
-              msg << shape_ref.shape.member.shape.class.name
+              msg = "Only list of strings supported, got "\
+                    "#{shape_ref.shape.member.shape.class.name}"
               raise NotImplementedError, msg
             end
           else

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -306,8 +306,8 @@ module Aws
     def validate_profile_exists(profile)
       unless (@parsed_credentials && @parsed_credentials[profile]) ||
              (@parsed_config && @parsed_config[profile])
-        msg = "Profile `#{profile}' not found in #{@credentials_path}"
-        msg << " or #{@config_path}" if @config_path
+        msg = "Profile `#{profile}' not found in #{@credentials_path}"\
+        "#{" or #{@config_path}" if @config_path}"
         raise Errors::NoSuchProfileError, msg
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -184,9 +184,9 @@ module Aws
         credential_source ||= prof_cfg['credential_source']
         if opts[:source_profile] && credential_source
           raise Errors::CredentialSourceConflictError,
-                "Profile #{profile} has a source_profile, and "\
-                'a credential_source. For assume role credentials, must '\
-                'provide only source_profile or credential_source, not both.'
+            "Profile #{profile} has a source_profile, and "\
+            'a credential_source. For assume role credentials, must '\
+            'provide only source_profile or credential_source, not both.'
         elsif opts[:source_profile]
           opts[:credentials] = resolve_source_profile(opts[:source_profile], opts)
           if opts[:credentials]
@@ -199,8 +199,9 @@ module Aws
             opts[:profile] = opts.delete(:source_profile)
             AssumeRoleCredentials.new(opts)
           else
-            raise Errors::NoSourceProfileError, "Profile #{profile} has a role_arn, and source_profile, but the"\
-                ' source_profile does not have credentials.'
+            raise Errors::NoSourceProfileError,
+              "Profile #{profile} has a role_arn, and source_profile, but the"\
+              ' source_profile does not have credentials.'
           end
         elsif credential_source
           opts[:credentials] = credentials_from_source(
@@ -217,8 +218,9 @@ module Aws
             opts.delete(:source_profile) # Cleanup
             AssumeRoleCredentials.new(opts)
           else
-            raise Errors::NoSourceCredentials, "Profile #{profile} could not get source credentials from"\
-                " provider #{credential_source}"
+            raise Errors::NoSourceCredentials,
+              "Profile #{profile} could not get source credentials from"\
+              " provider #{credential_source}"
           end
         elsif prof_cfg['role_arn']
           raise Errors::NoSourceProfileError, "Profile #{profile} has a role_arn, but no source_profile."
@@ -307,7 +309,7 @@ module Aws
       unless (@parsed_credentials && @parsed_credentials[profile]) ||
              (@parsed_config && @parsed_config[profile])
         msg = "Profile `#{profile}' not found in #{@credentials_path}"\
-        "#{" or #{@config_path}" if @config_path}"
+              "#{" or #{@config_path}" if @config_path}"
         raise Errors::NoSuchProfileError, msg
       end
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
@@ -23,9 +23,9 @@ module Aws
           xml = []
           builder = Aws::Xml::DocBuilder.new(target: xml, indent: '  ')
           builder.node(operation.name + 'Response', xmlns: xmlns(api)) do
-            if rules = operation.output
+            if (rules = operation.output)
               rules.location_name = operation.name + 'Result'
-              Xml::Builder.new(rules, target:xml, pad:'  ').to_xml(data)
+              Xml::Builder.new(rules, target: xml, pad:'  ').to_xml(data)
             end
             builder.node('ResponseMetadata') do
               builder.node('RequestId', 'stubbed-request-id')

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
@@ -94,9 +94,9 @@ module Aws
               # Pending
               raise 'Stubbing :exception event is not supported'
             end
-            stream << Aws::EventStream::Encoder.new.encode(
-              Aws::EventStream::Message.new(opts))
-            stream
+            [stream, Aws::EventStream::Encoder.new.encode(
+              Aws::EventStream::Message.new(opts)
+            )].pack('a*a*')
           end
         end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
@@ -11,7 +11,7 @@ module Aws
         @xml = options[:target] || []
         indent = options[:indent] || '  '
         pad = options[:pad] || ''
-        @builder = DocBuilder.new(target:@xml, indent:indent, pad:pad)
+        @builder = DocBuilder.new(target: @xml, indent: indent, pad: pad)
       end
 
       def to_xml(params)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
@@ -6,7 +6,11 @@ module Aws
       # @option options [String] :pad ('')
       # @option options [String] :indent ('')
       def initialize(options = {})
-        @target = options[:target] || String.new
+        @target = options[:target] || (
+          # The String has to be mutable
+          # because @target implements `<<` method.
+          String.new
+        )
         @indent = options[:indent] || ''
         @pad = options[:pad] || ''
         @end_of_line = @indent == '' ? '' : "\n"

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
@@ -6,7 +6,7 @@ module Aws
       # @option options [String] :pad ('')
       # @option options [String] :indent ('')
       def initialize(options = {})
-        @target = options[:target] || ''
+        @target = options[:target] || ::String.new
         @indent = options[:indent] || ''
         @pad = options[:pad] || ''
         @end_of_line = @indent == '' ? '' : "\n"
@@ -32,7 +32,7 @@ module Aws
         if block_given?
           @target << open_el(name, attrs)
           @target << @end_of_line
-          increase_pad { yield }
+          increase_pad(&block)
           @target << @pad
           @target << close_el(name)
         elsif args.empty?
@@ -77,7 +77,7 @@ module Aws
       def increase_pad(&block)
         pre_increase = @pad
         @pad = @pad + @indent
-        yield
+        block.call
         @pad = pre_increase
       end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
@@ -6,7 +6,7 @@ module Aws
       # @option options [String] :pad ('')
       # @option options [String] :indent ('')
       def initialize(options = {})
-        @target = options[:target] || ::String.new
+        @target = options[:target] || String.new
         @indent = options[:indent] || ''
         @pad = options[:pad] || ''
         @end_of_line = @indent == '' ? '' : "\n"

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
@@ -15,7 +15,8 @@ module Aws
 
         def parse(xml)
           begin
-            source = REXML::Source.new(xml)
+            mutable_xml = xml.dup # REXML only accepts mutable string
+            source = REXML::Source.new(mutable_xml)
             REXML::Parsers::StreamParser.new(source, self).parse
           rescue REXML::ParseException => error
             @stack.error(error.message)

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -89,7 +89,7 @@ module Seahorse
               @status = :active
             elsif @status == :closed
               msg = "Async Client HTTP2 Connection is closed, you may"\
-                " use #new_connection to create a new HTTP2 Connection for this client"
+                    " use #new_connection to create a new HTTP2 Connection for this client"
               raise Http2ConnectionClosedError.new(msg)
             end
           }
@@ -171,7 +171,7 @@ module Seahorse
           @h2_client.on(:frame) do |bytes|
             if @socket.nil?
               msg = "Connection is closed due to errors, "\
-                "you can find errors at async_client.connection.errors"
+                    "you can find errors at async_client.connection.errors"
               raise Http2ConnectionClosedError.new(msg)
             else
               @socket.print(bytes)

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -76,7 +76,7 @@ module Seahorse
               tcp, addr = _tcp_socket(endpoint) 
               debug_output("opening connection to #{endpoint.host}:#{endpoint.port} ...")
               _nonblocking_connect(tcp, addr)
-              debug_output("opened")
+              debug_output('opened')
 
               @socket = OpenSSL::SSL::SSLSocket.new(tcp, _tls_context)
               @socket.sync_close = true
@@ -84,12 +84,12 @@ module Seahorse
 
               debug_output("starting TLS for #{endpoint.host}:#{endpoint.port} ...")
               @socket.connect
-              debug_output("TLS established")
+              debug_output('TLS established')
               _register_h2_callbacks
               @status = :active
             elsif @status == :closed
-              msg = "Async Client HTTP2 Connection is closed, you may"\
-                    " use #new_connection to create a new HTTP2 Connection for this client"
+              msg = 'Async Client HTTP2 Connection is closed, you may'\
+                    ' use #new_connection to create a new HTTP2 Connection for this client'
               raise Http2ConnectionClosedError.new(msg)
             end
           }
@@ -106,7 +106,7 @@ module Seahorse
                 rescue IO::WaitReadable
                   begin
                     unless IO.select([@socket], nil, nil, connection_read_timeout)
-                      self.debug_output("socket connection read time out")
+                      self.debug_output('socket connection read time out')
                       self.close!
                     else
                       # available, retry to start reading
@@ -132,7 +132,7 @@ module Seahorse
 
         def close!
           @mutex.synchronize {
-            self.debug_output("closing connection ...")
+            self.debug_output('closing connection ...')
             if @socket
               @socket.close
               @socket = nil
@@ -151,10 +151,10 @@ module Seahorse
 
         def debug_output(msg, type = nil)
           prefix = case type
-            when :send then "-> "
-            when :receive then "<- "
+            when :send then '-> '
+            when :receive then '<- '
             else
-              ""
+              ''
             end
           return unless @logger
           _debug_entry(prefix + msg)
@@ -170,8 +170,8 @@ module Seahorse
         def _register_h2_callbacks
           @h2_client.on(:frame) do |bytes|
             if @socket.nil?
-              msg = "Connection is closed due to errors, "\
-                    "you can find errors at async_client.connection.errors"
+              msg = 'Connection is closed due to errors, '\
+                    'you can find errors at async_client.connection.errors'
               raise Http2ConnectionClosedError.new(msg)
             else
               @socket.print(bytes)
@@ -223,7 +223,7 @@ module Seahorse
             ssl_ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
           end
           if enable_alpn
-            debug_output("enabling ALPN for TLS ...")
+            debug_output('enabling ALPN for TLS ...')
             ssl_ctx.alpn_protocols = ['h2']
           end
           ssl_ctx

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -87,7 +87,7 @@ module Seahorse
           @step = step
         else
           msg = "invalid :step `%s', must be one of :initialize, :validate, "\
-                ":build, :sign or :send"
+                ':build, :sign or :send'
           raise ArgumentError, msg % step.inspect
         end
       end

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -86,8 +86,8 @@ module Seahorse
         if STEPS.key?(step)
           @step = step
         else
-          msg = "invalid :step `%s', must be one of :initialize, :validate, "
-          msg << ":build, :sign or :send"
+          msg = "invalid :step `%s', must be one of :initialize, :validate, "\
+            ":build, :sign or :send"
           raise ArgumentError, msg % step.inspect
         end
       end

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -87,7 +87,7 @@ module Seahorse
           @step = step
         else
           msg = "invalid :step `%s', must be one of :initialize, :validate, "\
-            ":build, :sign or :send"
+                ":build, :sign or :send"
           raise ArgumentError, msg % step.inspect
         end
       end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -34,7 +34,7 @@ module Seahorse
           if endpoint.nil? or URI::HTTP === endpoint or URI::HTTPS === endpoint
             @endpoint = endpoint
           else
-            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "\
+            msg = 'invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, '\
                   "got #{endpoint.inspect}"
             raise ArgumentError, msg
           end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -34,8 +34,8 @@ module Seahorse
           if endpoint.nil? or URI::HTTP === endpoint or URI::HTTPS === endpoint
             @endpoint = endpoint
           else
-            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "
-            msg << "got #{endpoint.inspect}"
+            msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "\
+              "got #{endpoint.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -35,7 +35,7 @@ module Seahorse
             @endpoint = endpoint
           else
             msg = "invalid endpoint, expected URI::HTTP, URI::HTTPS, or nil, "\
-              "got #{endpoint.inspect}"
+                  "got #{endpoint.inspect}"
             raise ArgumentError, msg
           end
         end
@@ -55,7 +55,7 @@ module Seahorse
 
         # @param [#read, #size, #rewind] io
         def body=(io)
-          @body =case io
+          @body = case io
             when nil then StringIO.new('')
             when String then StringIO.new(io)
             else io

--- a/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
@@ -109,8 +109,8 @@ module Seahorse
             @done = true
             emit(:done)
           else
-            msg = "options must be empty or must contain :status_code, :headers, "\
-                  "and :body"
+            msg = 'options must be empty or must contain :status_code, :headers, '\
+                  'and :body'
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
@@ -109,8 +109,8 @@ module Seahorse
             @done = true
             emit(:done)
           else
-            msg = "options must be empty or must contain :status_code, :headers, "
-            msg << "and :body"
+            msg = "options must be empty or must contain :status_code, :headers, "\
+              "and :body"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
@@ -110,7 +110,7 @@ module Seahorse
             emit(:done)
           else
             msg = "options must be empty or must contain :status_code, :headers, "\
-              "and :body"
+                  "and :body"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -13,8 +13,8 @@ module Seahorse
         # @api private
         class TruncatedBodyError < IOError
           def initialize(bytes_expected, bytes_received)
-            msg = "http response body truncated, expected #{bytes_expected} "
-            msg << "bytes, received #{bytes_received} bytes"
+            msg = "http response body truncated, expected #{bytes_expected} "\
+              "bytes, received #{bytes_received} bytes"
             super(msg)
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -14,7 +14,7 @@ module Seahorse
         class TruncatedBodyError < IOError
           def initialize(bytes_expected, bytes_received)
             msg = "http response body truncated, expected #{bytes_expected} "\
-              "bytes, received #{bytes_received} bytes"
+                  "bytes, received #{bytes_received} bytes"
             super(msg)
           end
         end

--- a/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
@@ -198,12 +198,12 @@ module Aws
             {
               status_code: 404,
               body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
-                "<Error>\n"\
-                "<Code>NoSuchKey</Code>\n"\
-                "<Message>The resource you requested does not exist</Message>\n"\
-                "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
-                "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                "</Error>",
+                    "<Error>\n"\
+                    "<Code>NoSuchKey</Code>\n"\
+                    "<Message>The resource you requested does not exist</Message>\n"\
+                    "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
+                    "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
+                    "</Error>",
               headers: {}
             },
             {}
@@ -234,12 +234,12 @@ module Aws
             {
               status_code: 404,
               body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
-                "<Error>\n"\
-                "<Code>NoSuchKey</Code>\n"\
-                "<Message>The resource you requested does not exist</Message>\n"\
-                "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
-                "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                "</Error>",
+                    "<Error>\n"\
+                    "<Code>NoSuchKey</Code>\n"\
+                    "<Message>The resource you requested does not exist</Message>\n"\
+                    "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
+                    "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
+                    "</Error>",
               headers: {
                 "x-amz-id-2" => "fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=",
                 "x-amz-request-id" => "226FC0DC6464C2AE"
@@ -364,12 +364,12 @@ module Aws
               {
                 status_code: 404,
                 body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
-                  "<Error>\n"\
-                  "<Code>NoSuchKey</Code>\n"\
-                  "<Message>The resource you requested does not exist</Message>\n"\
-                  "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
-                  "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                  "</Error>",
+                      "<Error>\n"\
+                      "<Code>NoSuchKey</Code>\n"\
+                      "<Message>The resource you requested does not exist</Message>\n"\
+                      "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
+                      "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
+                      "</Error>",
                 headers: {}
               },
               {}
@@ -409,12 +409,12 @@ module Aws
               {
                 status_code: 500,
                 body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
-                  "<Error>\n"\
-                  "<Code>InternalServiceError</Code>\n"\
-                  "<Message>Fake internal service error.</Message>\n"\
-                  "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
-                  "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                  "</Error>",
+                      "<Error>\n"\
+                      "<Code>InternalServiceError</Code>\n"\
+                      "<Message>Fake internal service error.</Message>\n"\
+                      "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
+                      "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
+                      "</Error>",
                 headers: {}
               },
               {}

--- a/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 module Aws
   module Plugins
 
-    describe "Client Side Monitoring Plugins" do
+    describe 'Client Side Monitoring Plugins' do
       ClientMetricsSvc = ApiHelper.sample_rest_xml # S3
 
       let(:stub_publisher) do
@@ -35,26 +35,26 @@ module Aws
       let(:env) {{}}
 
       before do
-        stub_const("ENV", env)
+        stub_const('ENV', env)
       end
 
       before(:each) do
         stub_publisher.metrics = []
       end
 
-      describe "configuration" do
+      describe 'configuration' do
         it 'defaults config.client_side_monitoring to false' do
           expect(client.config.client_side_monitoring).not_to be_truthy
         end
 
         it 'defaults to an empty string client id' do
-          expect(client.config.client_side_monitoring_client_id).to eq("")
+          expect(client.config.client_side_monitoring_client_id).to eq('')
         end
 
         it 'does not include the plugin when client_side_monitoring is false' do
           client = ClientMetricsSvc::Client.new(
             credentials: Aws::Credentials.new('stub_akid', 'stub_secret'),
-            region: "us-stubbed-1",
+            region: 'us-stubbed-1',
             client_side_monitoring: false
           )
           expect(client.handlers.to_a).not_to include(
@@ -71,7 +71,7 @@ module Aws
         it 'does not include the plugin if an invalid port is provided' do
           client = ClientMetricsSvc::Client.new(
             credentials: Aws::Credentials.new('stub_akid', 'stub_secret'),
-            region: "us-stubbed-1",
+            region: 'us-stubbed-1',
             client_side_monitoring: true,
             client_side_monitoring_port: nil
           )
@@ -89,11 +89,11 @@ module Aws
         it 'does include the plugins when using the default port and host' do
           client = ClientMetricsSvc::Client.new(
             credentials: Aws::Credentials.new('stub_akid', 'stub_secret'),
-            region: "us-stubbed-1",
+            region: 'us-stubbed-1',
             client_side_monitoring: true
           )
           expect(client.config.client_side_monitoring_port).to eq(31000)
-          expect(client.config.client_side_monitoring_host).to eq("127.0.0.1")
+          expect(client.config.client_side_monitoring_host).to eq('127.0.0.1')
           expect(client.handlers.to_a).to include(
             Aws::Plugins::ClientMetricsPlugin::Handler
           )
@@ -106,7 +106,7 @@ module Aws
         end
 
         it 'accepts client_side_monitoring as an env variable' do
-          env["AWS_CSM_ENABLED"] = "fAlSe"
+          env['AWS_CSM_ENABLED'] = 'fAlSe'
           client = ClientMetricsSvc::Client.new(stub_responses: true)
           expect(client.handlers.to_a).not_to include(
             Aws::Plugins::ClientMetricsPlugin
@@ -114,7 +114,7 @@ module Aws
           expect(client.handlers.to_a).not_to include(
             Aws::Plugins::ClientMetricsSendPlugin
           )
-          env["AWS_CSM_ENABLED"] = "F"
+          env['AWS_CSM_ENABLED'] = 'F'
           client2 = ClientMetricsSvc::Client.new(stub_responses: true)
           expect(client2.handlers.to_a).not_to include(
             Aws::Plugins::ClientMetricsPlugin
@@ -125,21 +125,21 @@ module Aws
         end
 
         it 'accepts a custom client id' do
-          env["AWS_CSM_CLIENT_ID"] = "env-client"
+          env['AWS_CSM_CLIENT_ID'] = 'env-client'
           client = ClientMetricsSvc::Client.new(
             stub_responses: true,
-            client_side_monitoring_client_id: "foo-client"
+            client_side_monitoring_client_id: 'foo-client'
           )
           expect(client.config.client_side_monitoring_client_id).to eq(
-            "foo-client"
+            'foo-client'
           )
         end
 
         it 'fetches client id from env variables' do
-          env["AWS_CSM_CLIENT_ID"] = "env-client"
+          env['AWS_CSM_CLIENT_ID'] = 'env-client'
           client = ClientMetricsSvc::Client.new(stub_responses: true)
           expect(client.config.client_side_monitoring_client_id).to eq(
-            "env-client"
+            'env-client'
           )
         end
 
@@ -151,27 +151,27 @@ module Aws
         end
       end
 
-      describe "ApiCall Metrics" do
-        it "collects basic call data" do
+      describe 'ApiCall Metrics' do
+        it 'collects basic call data' do
           client.list_buckets
           expect(stub_publisher.metrics.size).to eq(1)
           api_call = stub_publisher.metrics[0].api_call
-          expect(api_call.service).to eq("S3")
-          expect(api_call.api).to eq("ListBuckets")
+          expect(api_call.service).to eq('S3')
+          expect(api_call.api).to eq('ListBuckets')
           expect(api_call.timestamp).to be_a_kind_of(Integer)
           expect(api_call.version).to be_a_kind_of(Integer)
           expect(api_call.attempt_count).to eq(1)
           expect(api_call.latency).to be_a_kind_of(Integer)
-          expect(api_call.client_id).to eq("")
-          expect(api_call.region).to eq("us-stubbed-1")
+          expect(api_call.client_id).to eq('')
+          expect(api_call.region).to eq('us-stubbed-1')
           expect(api_call.user_agent).to match(/^aws-sdk-ruby3/)
           expect(api_call.user_agent).to match(/aws-sdk-sampleapi.\/1.0.0/)
           expect(api_call.final_http_status_code).to eq(200)
         end
       end
 
-      describe "ApiCallAttempt Metrics" do
-        it "collects basic attempt data" do
+      describe 'ApiCallAttempt Metrics' do
+        it 'collects basic attempt data' do
           client.list_buckets
           expect(stub_publisher.metrics.size).to eq(1)
           request_metrics = stub_publisher.metrics[0]
@@ -179,21 +179,21 @@ module Aws
           expect(api_call_attempts.size).to eq(1)
           expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
           attempt = api_call_attempts[0]
-          expect(attempt.service).to eq("S3")
-          expect(attempt.api).to eq("ListBuckets")
+          expect(attempt.service).to eq('S3')
+          expect(attempt.api).to eq('ListBuckets')
           expect(attempt.timestamp).to be_a_kind_of(Integer)
           expect(attempt.version).to be_a_kind_of(Integer)
-          expect(attempt.fqdn).to eq("s3.us-stubbed-1.amazonaws.com")
-          expect(attempt.region).to eq("us-stubbed-1")
+          expect(attempt.fqdn).to eq('s3.us-stubbed-1.amazonaws.com')
+          expect(attempt.region).to eq('us-stubbed-1')
           expect(attempt.user_agent).to match(/^aws-sdk-ruby3/)
           expect(attempt.user_agent).to match(/aws-sdk-sampleapi.\/1.0.0/)
-          expect(attempt.access_key).to eq("stubbed-akid")
+          expect(attempt.access_key).to eq('stubbed-akid')
           expect(attempt.http_status_code).to eq(200)
           expect(attempt.request_latency).to be_a_kind_of(Integer)
-          expect(attempt.client_id).to eq("")
+          expect(attempt.client_id).to eq('')
         end
 
-        it "collects exception information when an error occurs" do
+        it 'collects exception information when an error occurs' do
           client.stub_responses(:get_object,
             {
               status_code: 404,
@@ -203,33 +203,33 @@ module Aws
                     "<Message>The resource you requested does not exist</Message>\n"\
                     "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
                     "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                    "</Error>",
+                    '</Error>',
               headers: {}
             },
             {}
           )
           expect {
-            client.get_object(bucket: "mybucket", key: "myfoto.jpg")
-          }.to raise_error("The resource you requested does not exist")
+            client.get_object(bucket: 'mybucket', key: 'myfoto.jpg')
+          }.to raise_error('The resource you requested does not exist')
           expect(stub_publisher.metrics.size).to eq(1)
           request_metrics = stub_publisher.metrics[0]
           api_call_attempts = request_metrics.api_call_attempts
           expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
           expect(request_metrics.api_call.final_aws_exception).to eq(
-            "NoSuchKey"
+            'NoSuchKey'
           )
           expect(request_metrics.api_call.final_aws_exception_message).to eq(
-            "The resource you requested does not exist"
+            'The resource you requested does not exist'
           )
           expect(api_call_attempts.size).to eq(1)
           attempt = api_call_attempts[0]
-          expect(attempt.aws_exception).to eq("NoSuchKey")
+          expect(attempt.aws_exception).to eq('NoSuchKey')
           expect(attempt.aws_exception_msg).to eq(
-            "The resource you requested does not exist"
+            'The resource you requested does not exist'
           )
         end
 
-        it "collects request ID headers when available" do
+        it 'collects request ID headers when available' do
           client.stub_responses(:get_object,
             {
               status_code: 404,
@@ -239,28 +239,28 @@ module Aws
                     "<Message>The resource you requested does not exist</Message>\n"\
                     "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
                     "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                    "</Error>",
+                    '</Error>',
               headers: {
-                "x-amz-id-2" => "fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=",
-                "x-amz-request-id" => "226FC0DC6464C2AE"
+                'x-amz-id-2' => 'fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=',
+                'x-amz-request-id' => '226FC0DC6464C2AE'
               }
             },
             {}
           )
           expect {
-            client.get_object(bucket: "mybucket", key: "myfoto.jpg")
-          }.to raise_error("The resource you requested does not exist")
+            client.get_object(bucket: 'mybucket', key: 'myfoto.jpg')
+          }.to raise_error('The resource you requested does not exist')
           expect(stub_publisher.metrics.size).to eq(1)
           request_metrics = stub_publisher.metrics[0]
           api_call_attempts = request_metrics.api_call_attempts
           expect(api_call_attempts.size).to eq(1)
           expect(request_metrics.api_call.max_retries_exceeded).to eq(0)
           attempt = api_call_attempts[0]
-          expect(attempt.x_amz_id_2).to eq("fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=")
-          expect(attempt.x_amz_request_id).to eq("226FC0DC6464C2AE")
+          expect(attempt.x_amz_id_2).to eq('fWhd+V0u5IWKNLhbIZi2ZR/DoWpAt2Km8T9ZZ75UnvkZFl0MU3jlf2B2zRJYHmxqkEc6iAtctOc=')
+          expect(attempt.x_amz_request_id).to eq('226FC0DC6464C2AE')
         end
 
-        describe "failures without network requests" do
+        describe 'failures without network requests' do
           let(:failure_client) {
             client = ClientMetricsSvc::Client.new(
               stub_responses: true,
@@ -291,7 +291,7 @@ module Aws
           it 'correctly publishes metrics for a validation error' do
             expect {
               failure_client.list_buckets
-            }.to raise_error(ArgumentError, "Injected exception.")
+            }.to raise_error(ArgumentError, 'Injected exception.')
             expect(stub_publisher.metrics.size).to eq(1)
             request_metrics = stub_publisher.metrics[0]
             api_call_attempts = request_metrics.api_call_attempts
@@ -300,17 +300,17 @@ module Aws
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
             expect(request_metrics.api_call.final_sdk_exception).to eq(
-              "ArgumentError"
+              'ArgumentError'
             )
             expect(request_metrics.api_call.final_sdk_exception_message).to eq(
-              "Injected exception."
+              'Injected exception.'
             )
-            expect(attempt.sdk_exception).to eq("ArgumentError")
-            expect(attempt.sdk_exception_msg).to eq("Injected exception.")
+            expect(attempt.sdk_exception).to eq('ArgumentError')
+            expect(attempt.sdk_exception_msg).to eq('Injected exception.')
           end
         end
 
-        describe "failures without network requests" do
+        describe 'failures without network requests' do
           let(:failure_client) {
             client = ClientMetricsSvc::Client.new(
               stub_responses: true,
@@ -338,10 +338,10 @@ module Aws
             client
           }
 
-          it "accounts for failures during response handling" do
+          it 'accounts for failures during response handling' do
             expect {
               failure_client.list_buckets
-            }.to raise_error(ArgumentError, "Bad response.")
+            }.to raise_error(ArgumentError, 'Bad response.')
             expect(stub_publisher.metrics.size).to eq(1)
             request_metrics = stub_publisher.metrics[0]
             api_call_attempts = request_metrics.api_call_attempts
@@ -350,16 +350,16 @@ module Aws
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
             expect(request_metrics.api_call.final_sdk_exception).to eq(
-              "ArgumentError"
+              'ArgumentError'
             )
             expect(request_metrics.api_call.final_sdk_exception_message).to eq(
-              "Bad response."
+              'Bad response.'
             )
-            expect(attempt.sdk_exception).to eq("ArgumentError")
-            expect(attempt.sdk_exception_msg).to eq("Bad response.")
+            expect(attempt.sdk_exception).to eq('ArgumentError')
+            expect(attempt.sdk_exception_msg).to eq('Bad response.')
           end
 
-          it "can handle sdk exceptions and aws exceptions together" do
+          it 'can handle sdk exceptions and aws exceptions together' do
             failure_client.stub_responses(:get_object,
               {
                 status_code: 404,
@@ -369,14 +369,14 @@ module Aws
                       "<Message>The resource you requested does not exist</Message>\n"\
                       "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
                       "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                      "</Error>",
+                      '</Error>',
                 headers: {}
               },
               {}
             )
             expect {
-              failure_client.get_object(bucket: "mybucket", key: "myfoto.jpg")
-            }.to raise_error(ArgumentError, "Bad response.")
+              failure_client.get_object(bucket: 'mybucket', key: 'myfoto.jpg')
+            }.to raise_error(ArgumentError, 'Bad response.')
             expect(stub_publisher.metrics.size).to eq(1)
             request_metrics = stub_publisher.metrics[0]
             api_call_attempts = request_metrics.api_call_attempts
@@ -385,23 +385,23 @@ module Aws
             expect(api_call_attempts.size).to eq(1)
             attempt = api_call_attempts[0]
             expect(request_metrics.api_call.final_aws_exception).to eq(
-              "NoSuchKey"
+              'NoSuchKey'
             )
             expect(request_metrics.api_call.final_aws_exception_message).to eq(
-              "The resource you requested does not exist"
+              'The resource you requested does not exist'
             )
             expect(request_metrics.api_call.final_sdk_exception).to eq(
-              "ArgumentError"
+              'ArgumentError'
             )
             expect(request_metrics.api_call.final_sdk_exception_message).to eq(
-              "Bad response."
+              'Bad response.'
             )
-            expect(attempt.aws_exception).to eq("NoSuchKey")
+            expect(attempt.aws_exception).to eq('NoSuchKey')
             expect(attempt.aws_exception_msg).to eq(
-              "The resource you requested does not exist"
+              'The resource you requested does not exist'
             )
-            expect(attempt.sdk_exception).to eq("ArgumentError")
-            expect(attempt.sdk_exception_msg).to eq("Bad response.")
+            expect(attempt.sdk_exception).to eq('ArgumentError')
+            expect(attempt.sdk_exception_msg).to eq('Bad response.')
           end
 
           it 'recognizes retryable exceptions' do
@@ -414,14 +414,14 @@ module Aws
                       "<Message>Fake internal service error.</Message>\n"\
                       "<Resource>/mybucket/myfoto.jpg</Resource>\n"\
                       "<RequestId>4442587FB7D0A2F9</RequestId>\n"\
-                      "</Error>",
+                      '</Error>',
                 headers: {}
               },
               {}
             )
             expect {
-              client.get_object(bucket: "mybucket", key: "myfoto.jpg")
-            }.to raise_error("Fake internal service error.")
+              client.get_object(bucket: 'mybucket', key: 'myfoto.jpg')
+            }.to raise_error('Fake internal service error.')
             expect(stub_publisher.metrics.size).to eq(1)
             request_metrics = stub_publisher.metrics[0]
             api_call_attempts = request_metrics.api_call_attempts
@@ -449,14 +449,14 @@ module Aws
 
     class FailureInjectionHandler < Seahorse::Client::Handler
       def call(context)
-        raise ArgumentError, "Injected exception."
+        raise ArgumentError, 'Injected exception.'
       end
     end
 
     class ResponseFailureHandler < Seahorse::Client::Handler
       def call(context)
         @handler.call(context)
-        raise ArgumentError, "Bad response."
+        raise ArgumentError, 'Bad response.'
       end
     end
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
@@ -8,7 +8,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = String.new # REXML only accepts mutable strings
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
@@ -8,7 +8,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = String.new # REXML only accepts mutable strings
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
@@ -8,7 +8,7 @@ module Aws
         describe '#stub_data' do
 
           def normalize(xml)
-            result = ''
+            result = String.new # REXML only accepts mutable strings
             REXML::Document.new(xml).write(result, 2)
             result.strip
           end

--- a/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
@@ -5,7 +5,7 @@ module Aws
   module Xml
     describe DocBuilder do
 
-      let(:result) { '' }
+      let(:result) { String.new }
 
       let(:options) { { target: result, indent: '' } }
 

--- a/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
@@ -119,8 +119,8 @@ module Aws
         stub_request(:post, "https://cloudfront.amazonaws.com/2018-11-05/origin-access-identity/cloudfront").
           to_return(:status => 400, :body => unmodeled_error)
         msg = "1 validation error detected: Value null at"\
-          " 'cloudFrontOriginAccessIdentityConfig' failed to satisfy"\
-          " constraint: Member must not be null"
+              " 'cloudFrontOriginAccessIdentityConfig' failed to satisfy"\
+              " constraint: Member must not be null"
         expect {
           cloudfront.create_cloud_front_origin_access_identity(
             cloud_front_origin_access_identity_config: {
@@ -140,7 +140,8 @@ module Aws
         expect {
           route53.change_resource_record_sets
         }.to raise_error { |error|
-          expected_msg = "Tried to create resource record set "\
+          expected_msg =
+            "Tried to create resource record set "\
             "duplicate.example.com. type A, but it already exists"
           expect(error.message).to eq(expected_msg)
         }

--- a/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
@@ -103,7 +103,7 @@ module Aws
       XML
 
       it 'extracts code and message for empty struct errors' do
-        stub_request(:post, "https://cloudfront.amazonaws.com/2018-11-05/distribution").
+        stub_request(:post, 'https://cloudfront.amazonaws.com/2018-11-05/distribution').
           to_return(:status => 400, :body => empty_struct_error)
         expect {
           cloudfront.create_distribution(
@@ -116,11 +116,11 @@ module Aws
       end
 
       it 'extracts code and message for unmodeled errors' do
-        stub_request(:post, "https://cloudfront.amazonaws.com/2018-11-05/origin-access-identity/cloudfront").
+        stub_request(:post, 'https://cloudfront.amazonaws.com/2018-11-05/origin-access-identity/cloudfront').
           to_return(:status => 400, :body => unmodeled_error)
-        msg = "1 validation error detected: Value null at"\
-              " 'cloudFrontOriginAccessIdentityConfig' failed to satisfy"\
-              " constraint: Member must not be null"
+        msg = '1 validation error detected: Value null at'\
+              ' \'cloudFrontOriginAccessIdentityConfig\' failed to satisfy'\
+              ' constraint: Member must not be null'
         expect {
           cloudfront.create_cloud_front_origin_access_identity(
             cloud_front_origin_access_identity_config: {
@@ -135,37 +135,37 @@ module Aws
       end
 
       it 'handles route53 error format with message' do
-        stub_request(:post, "https://route53.amazonaws.com/2013-04-01/hostedzone//rrset/").
+        stub_request(:post, 'https://route53.amazonaws.com/2013-04-01/hostedzone//rrset/').
           to_return(:status => 400, :body => route53_error)
         expect {
           route53.change_resource_record_sets
         }.to raise_error { |error|
           expected_msg =
-            "Tried to create resource record set "\
-            "duplicate.example.com. type A, but it already exists"
+            'Tried to create resource record set '\
+            'duplicate.example.com. type A, but it already exists'
           expect(error.message).to eq(expected_msg)
         }
       end
 
       it 'supports unmodeled `ec2-query` error' do
-        stub_request(:post, "https://ec2.us-west-2.amazonaws.com/").
+        stub_request(:post, 'https://ec2.us-west-2.amazonaws.com/').
           to_return(:status => 400, :body => ec2_error)
         expect {
           ec2.create_subnet
         }.to raise_error { |error|
-          expect(error.code).to eq("InvalidRequest")
-          expect(error.message).to eq("Required parameter 'AvailabilityZone' is not provided.")
+          expect(error.code).to eq('InvalidRequest')
+          expect(error.message).to eq('Required parameter \'AvailabilityZone\' is not provided.')
         }
       end
 
       it 'supports modeled query error' do
-        stub_request(:post, "https://sns.us-west-2.amazonaws.com/").
+        stub_request(:post, 'https://sns.us-west-2.amazonaws.com/').
           to_return(:status => 400, :body => query_error)
         expect {
           sns.create_topic
         }.to raise_error { |error|
-          expect(error.code).to eq("InvalidParameter")
-          expect(error.message).to eq("Invalid parameter: TopicArn Reason: no value for required parameter")
+          expect(error.code).to eq('InvalidParameter')
+          expect(error.message).to eq('Invalid parameter: TopicArn Reason: no value for required parameter')
         }
       end
     end

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -86,22 +86,22 @@ module Seahorse
         describe 'errors' do
 
           it 'raises an error if :step is not valid' do
-            msg = "invalid :step `:bogus', must be one of :initialize, "\
-                  ":validate, :build, :sign or :send"
+            msg = 'invalid :step `:bogus\', must be one of :initialize, '\
+                  ':validate, :build, :sign or :send'
             expect {
               handlers.add('handler', step: :bogus)
             }.to raise_error(ArgumentError, msg)
           end
 
           it 'raises an error if :priority is less than 0' do
-            msg = "invalid :priority `-1', must be between 0 and 99"
+            msg = 'invalid :priority `-1\', must be between 0 and 99'
             expect {
               handlers.add('handler', priority: -1)
             }.to raise_error(ArgumentError, msg)
           end
 
           it 'raises an error if :priority is greater than 99' do
-            msg = "invalid :priority `100', must be between 0 and 99"
+            msg = 'invalid :priority `100\', must be between 0 and 99'
             expect {
               handlers.add('handler', priority: 100)
             }.to raise_error(ArgumentError, msg)

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -87,7 +87,7 @@ module Seahorse
 
           it 'raises an error if :step is not valid' do
             msg = "invalid :step `:bogus', must be one of :initialize, "\
-              ":validate, :build, :sign or :send"
+                  ":validate, :build, :sign or :send"
             expect {
               handlers.add('handler', step: :bogus)
             }.to raise_error(ArgumentError, msg)

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -86,8 +86,8 @@ module Seahorse
         describe 'errors' do
 
           it 'raises an error if :step is not valid' do
-            msg = "invalid :step `:bogus', must be one of :initialize, "
-            msg << ":validate, :build, :sign or :send"
+            msg = "invalid :step `:bogus', must be one of :initialize, "\
+              ":validate, :build, :sign or :send"
             expect {
               handlers.add('handler', step: :bogus)
             }.to raise_error(ArgumentError, msg)

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
@@ -9,7 +9,7 @@ module Seahorse
         class LogNullDevice
           attr_reader :messages
           def write(msg)
-            @messages ||= ''
+            @messages ||= String.new
             @messages << msg
           end
           def close; end

--- a/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
@@ -122,7 +122,7 @@ module Seahorse
         describe 'IO object target' do
 
           it 'writes to the given object' do
-            buffer = StringIO.new('')
+            buffer = StringIO.new(String.new)
             request.send_request(target: buffer)
             expect(buffer.string).to eq("part1part2part3")
           end

--- a/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
+++ b/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
@@ -37,7 +37,7 @@ def handle_with_retry(test_cases)
   expect(i).to(
     eq(test_cases.size),
     "Wrong number of retries. Handler was called #{i} times but "\
-            "#{test_cases.size} test cases were defined."
+    "#{test_cases.size} test cases were defined."
   )
 
   # Handle has finished called.  Apply final expectations.

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -48,7 +48,7 @@ module Aws
           when true, false then { bool: obj }
           when nil then { null: true }
           else
-            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "\
+            msg = 'unsupported type, expected Hash, Array, Set, String, Numeric, '\
                   "IO, true, false, or nil, got #{obj.class.name}"
             raise ArgumentError, msg
           end
@@ -64,7 +64,7 @@ module Aws
           when Numeric then { ns: set.map(&:to_s) }
           when StringIO, IO then { bs: set.to_a }
           else
-            msg = "set types only support String, Numeric, or IO objects"
+            msg = 'set types only support String, Numeric, or IO objects'
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -49,7 +49,7 @@ module Aws
           when nil then { null: true }
           else
             msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "\
-              "IO, true, false, or nil, got #{obj.class.name}"
+                  "IO, true, false, or nil, got #{obj.class.name}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -48,8 +48,8 @@ module Aws
           when true, false then { bool: obj }
           when nil then { null: true }
           else
-            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "
-            msg << "IO, true, false, or nil, got #{obj.class.name}"
+            msg = "unsupported type, expected Hash, Array, Set, String, Numeric, "\
+              "IO, true, false, or nil, got #{obj.class.name}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
@@ -606,7 +606,7 @@ module Aws::EC2
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
@@ -605,8 +605,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -1567,7 +1567,7 @@ module Aws::EC2
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -1566,8 +1566,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
@@ -7,8 +7,8 @@ module Aws
         def after_initialize(client)
           if region = client.config.region
             if matches = region.match(/^(\w+-\w+-\d+)[a-z]$/)
-              msg = ":region option must a region name, not an availability "
-              msg << "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
+              msg = ":region option must a region name, not an availability "\
+                "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
@@ -8,7 +8,7 @@ module Aws
           if region = client.config.region
             if matches = region.match(/^(\w+-\w+-\d+)[a-z]$/)
               msg = ":region option must a region name, not an availability "\
-                "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
+                    "zone name; try `#{matches[1]}' instead of `#{matches[0]}'"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
@@ -608,7 +608,7 @@ module Aws::EC2
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
@@ -607,8 +607,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -1940,7 +1940,7 @@ module Aws::EC2
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -814,7 +814,7 @@ module Aws::EC2
     def accepted_vpc_peering_connections(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "accepter-vpc-info.vpc-id",
+          name: 'accepter-vpc-info.vpc-id',
           values: [@id]
         }])
         resp = @client.describe_vpc_peering_connections(options)
@@ -1145,7 +1145,7 @@ module Aws::EC2
     def instances(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_instances(options)
@@ -1215,7 +1215,7 @@ module Aws::EC2
     def internet_gateways(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "attachment.vpc-id",
+          name: 'attachment.vpc-id',
           values: [@id]
         }])
         resp = @client.describe_internet_gateways(options)
@@ -1313,7 +1313,7 @@ module Aws::EC2
     def network_acls(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_network_acls(options)
@@ -1470,7 +1470,7 @@ module Aws::EC2
     def network_interfaces(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_network_interfaces(options)
@@ -1555,7 +1555,7 @@ module Aws::EC2
     def requested_vpc_peering_connections(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "requester-vpc-info.vpc-id",
+          name: 'requester-vpc-info.vpc-id',
           values: [@id]
         }])
         resp = @client.describe_vpc_peering_connections(options)
@@ -1671,7 +1671,7 @@ module Aws::EC2
     def route_tables(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_route_tables(options)
@@ -1804,7 +1804,7 @@ module Aws::EC2
     def security_groups(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_security_groups(options)
@@ -1898,7 +1898,7 @@ module Aws::EC2
     def subnets(options = {})
       batches = Enumerator.new do |y|
         options = Aws::Util.deep_merge(options, filters: [{
-          name: "vpc-id",
+          name: 'vpc-id',
           values: [@id]
         }])
         resp = @client.describe_subnets(options)
@@ -1930,7 +1930,7 @@ module Aws::EC2
       value = args[0] || options.delete(:id)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :id"
+      when nil then raise ArgumentError, 'missing required option :id'
       else
         msg = "expected :id to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1939,8 +1939,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -1939,8 +1939,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -324,7 +324,7 @@ module Aws::EC2
       value = args[0] || options.delete(:id)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :id"
+      when nil then raise ArgumentError, 'missing required option :id'
       else
         msg = "expected :id to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -333,8 +333,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -334,7 +334,7 @@ module Aws::EC2
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -333,8 +333,8 @@ module Aws::EC2
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -335,8 +335,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -336,7 +336,7 @@ module Aws::IAM
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -326,7 +326,7 @@ module Aws::IAM
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -335,8 +335,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -901,8 +901,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -902,7 +902,7 @@ module Aws::IAM
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -892,7 +892,7 @@ module Aws::IAM
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -901,8 +901,8 @@ module Aws::IAM
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -529,8 +529,8 @@ module Aws::Kinesis
       when nil then event_stream_class.new
       else
         msg = "expected #{type}_event_stream_handler to be a block or "\
-          "instance of Aws::Kinesis::#{event_stream_class}"\
-          ", got `#{handler.inspect}` instead"
+              "instance of Aws::Kinesis::#{event_stream_class}"\
+              ", got `#{handler.inspect}` instead"
         raise ArgumentError, msg
       end
     end

--- a/gems/aws-sdk-polly/spec/presigner_spec.rb
+++ b/gems/aws-sdk-polly/spec/presigner_spec.rb
@@ -39,7 +39,8 @@ module Aws
       describe '#presigned_url' do
 
         it 'can presign #synthesize_speech correctly' do
-          expected_url = "https://polly.us-west-2.amazonaws.com/v1/speech?"\
+          expected_url =
+            "https://polly.us-west-2.amazonaws.com/v1/speech?"\
             "LexiconNames=mno&LexiconNames=abc&OutputFormat=mp3&SampleRate=128&"\
             "Text=Hello%20World&TextType=text&VoiceId=Ewa&"\
             "X-Amz-Algorithm=AWS4-HMAC-SHA256&"\

--- a/gems/aws-sdk-polly/spec/presigner_spec.rb
+++ b/gems/aws-sdk-polly/spec/presigner_spec.rb
@@ -40,15 +40,15 @@ module Aws
 
         it 'can presign #synthesize_speech correctly' do
           expected_url =
-            "https://polly.us-west-2.amazonaws.com/v1/speech?"\
-            "LexiconNames=mno&LexiconNames=abc&OutputFormat=mp3&SampleRate=128&"\
-            "Text=Hello%20World&TextType=text&VoiceId=Ewa&"\
-            "X-Amz-Algorithm=AWS4-HMAC-SHA256&"\
-            "X-Amz-Credential=akid%2F20160101%2F"\
-            "us-west-2%2Fpolly%2Faws4_request&"\
-            "X-Amz-Date=20160101T112233Z&X-Amz-Expires=900&"\
-            "X-Amz-SignedHeaders=host&"\
-            "X-Amz-Signature=956ef486286b12f43ffc02dd09eae03cfea4cd8dfb30e0fab3f23de4e131195a"
+            'https://polly.us-west-2.amazonaws.com/v1/speech?'\
+            'LexiconNames=mno&LexiconNames=abc&OutputFormat=mp3&SampleRate=128&'\
+            'Text=Hello%20World&TextType=text&VoiceId=Ewa&'\
+            'X-Amz-Algorithm=AWS4-HMAC-SHA256&'\
+            'X-Amz-Credential=akid%2F20160101%2F'\
+            'us-west-2%2Fpolly%2Faws4_request&'\
+            'X-Amz-Date=20160101T112233Z&X-Amz-Expires=900&'\
+            'X-Amz-SignedHeaders=host&'\
+            'X-Amz-Signature=956ef486286b12f43ffc02dd09eae03cfea4cd8dfb30e0fab3f23de4e131195a'
 
           pre = Presigner.new(region: region, credentials: credentials)
           params = {

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -830,7 +830,7 @@ module Aws::S3
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -829,8 +829,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -48,7 +48,7 @@ module Aws::S3
     # @raise [NotImplementedError]
     # @api private
     def load
-      msg = "#load is not implemented, data only available via enumeration"
+      msg = '#load is not implemented, data only available via enumeration'
       raise NotImplementedError, msg
     end
     alias :reload :load
@@ -820,7 +820,7 @@ module Aws::S3
       value = args[0] || options.delete(:name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :name"
+      when nil then raise ArgumentError, 'missing required option :name'
       else
         msg = "expected :name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -829,8 +829,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
@@ -11239,8 +11239,8 @@ module Aws::S3
         when nil then EventStreams::SelectObjectContentEventStream.new
         else
           msg = "expected :event_stream_handler to be a block or "\
-            "instance of Aws::S3::EventStreams::SelectObjectContentEventStream"\
-            ", got `#{handler.inspect}` instead"
+                "instance of Aws::S3::EventStreams::SelectObjectContentEventStream"\
+                ", got `#{handler.inspect}` instead"
           raise ArgumentError, msg
         end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -331,7 +331,7 @@ module Aws
           elsif options[:encryption_key]
             DefaultKeyProvider.new(options)
           else
-            msg = "you must pass a :kms_key_id, :key_provider, or :encryption_key"
+            msg = 'you must pass a :kms_key_id, :key_provider, or :encryption_key'
             raise ArgumentError, msg
           end
         end
@@ -351,7 +351,7 @@ module Aws
           if [:metadata, :instruction_file].include?(location)
             location
           else
-            msg = ":envelope_location must be :metadata or :instruction_file "\
+            msg = ':envelope_location must be :metadata or :instruction_file '\
                   "got #{location.inspect}"
             raise ArgumentError, msg
           end
@@ -362,7 +362,7 @@ module Aws
           if String === suffix
             suffix
           else
-            msg = ":instruction_file_suffix must be a String"
+            msg = ':instruction_file_suffix must be a String'
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -352,7 +352,7 @@ module Aws
             location
           else
             msg = ":envelope_location must be :metadata or :instruction_file "\
-              "got #{location.inspect}"
+                  "got #{location.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -351,8 +351,8 @@ module Aws
           if [:metadata, :instruction_file].include?(location)
             location
           else
-            msg = ":envelope_location must be :metadata or :instruction_file "
-            msg << "got #{location.inspect}"
+            msg = ":envelope_location must be :metadata or :instruction_file "\
+              "got #{location.inspect}"
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -33,13 +33,13 @@ module Aws
               key
             else
               msg = "invalid key, symmetric key required to be 16, 24, or "\
-                "32 bytes in length, saw length " + key.bytesize.to_s
+                    "32 bytes in length, saw length " + key.bytesize.to_s
               raise ArgumentError, msg
             end
           else
             msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "\
-              "(for asymmetric encryption) or a String (for symmetric "\
-              "encryption)."
+                  "(for asymmetric encryption) or a String (for symmetric "\
+                  "encryption)."
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -32,14 +32,14 @@ module Aws
             if [32, 24, 16].include?(key.bytesize)
               key
             else
-              msg = "invalid key, symmetric key required to be 16, 24, or "
-              msg << "32 bytes in length, saw length " + key.bytesize.to_s
+              msg = "invalid key, symmetric key required to be 16, 24, or "\
+                "32 bytes in length, saw length " + key.bytesize.to_s
               raise ArgumentError, msg
             end
           else
-            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "
-            msg << "(for asymmetric encryption) or a String (for symmetric "
-            msg << "encryption)."
+            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "\
+              "(for asymmetric encryption) or a String (for symmetric "\
+              "encryption)."
             raise ArgumentError, msg
           end
         end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -32,14 +32,14 @@ module Aws
             if [32, 24, 16].include?(key.bytesize)
               key
             else
-              msg = "invalid key, symmetric key required to be 16, 24, or "\
-                    "32 bytes in length, saw length " + key.bytesize.to_s
+              msg = 'invalid key, symmetric key required to be 16, 24, or '\
+                    '32 bytes in length, saw length ' + key.bytesize.to_s
               raise ArgumentError, msg
             end
           else
-            msg = "invalid encryption key, expected an OpenSSL::PKey::RSA key "\
-                  "(for asymmetric encryption) or a String (for symmetric "\
-                  "encryption)."
+            msg = 'invalid encryption key, expected an OpenSSL::PKey::RSA key '\
+                  '(for asymmetric encryption) or a String (for symmetric '\
+                  'encryption).'
             raise ArgumentError, msg
           end
         end
@@ -48,7 +48,7 @@ module Aws
           Json.load(description)
           description
         rescue Json::ParseError, EncodingError
-          msg = "expected description to be a valid JSON document string"
+          msg = 'expected description to be a valid JSON document string'
           raise ArgumentError, msg
         end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -43,7 +43,7 @@ module Aws
           end
         else
           msg = "Invalid mode #{@mode} provided, "\
-            "mode should be :single_request, :get_range or :auto"
+                "mode should be :single_request, :get_range or :auto"
           raise ArgumentError, msg
         end
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -21,7 +21,7 @@ module Aws
 
       def download(destination, options = {})
         @path = destination
-        @mode = options[:mode] || "auto"
+        @mode = options[:mode] || 'auto'
         @thread_count = options[:thread_count] || THREAD_COUNT
         @chunk_size = options[:chunk_size]
         @params = {
@@ -31,19 +31,19 @@ module Aws
         @params[:version_id] = options[:version_id] if options[:version_id]
 
         case @mode
-        when "auto" then multipart_download
-        when "single_request" then single_request
-        when "get_range"
+        when 'auto' then multipart_download
+        when 'single_request' then single_request
+        when 'get_range'
           if @chunk_size
             resp = @client.head_object(@params)
             multithreaded_get_by_ranges(construct_chunks(resp.content_length))
           else
-            msg = "In :get_range mode, :chunk_size must be provided"
+            msg = 'In :get_range mode, :chunk_size must be provided'
             raise ArgumentError, msg
           end
         else
           msg = "Invalid mode #{@mode} provided, "\
-                "mode should be :single_request, :get_range or :auto"
+                'mode should be :single_request, :get_range or :auto'
           raise ArgumentError, msg
         end
       end
@@ -125,8 +125,8 @@ module Aws
       end
 
       def write(resp)
-        range, _ = resp.content_range.split(" ").last.split("/")
-        head, _ = range.split("-").map {|s| s.to_i}
+        range, _ = resp.content_range.split(' ').last.split('/')
+        head, _ = range.split('-').map {|s| s.to_i}
         IO.write(@path, resp.body.read, head)
       end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -113,7 +113,7 @@ module Aws
 
       def read_to_part_body(read_pipe)
         return if read_pipe.closed?
-        temp_io = @tempfile ? Tempfile.new(TEMPFILE_PREIX) : StringIO.new
+        temp_io = @tempfile ? Tempfile.new(TEMPFILE_PREIX) : StringIO.new(String.new)
         temp_io.binmode
         bytes_copied = IO.copy_stream(read_pipe, temp_io, @part_size)
         temp_io.rewind

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1310,7 +1310,7 @@ module Aws::S3
       value = args[0] || options.delete(:bucket_name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :bucket_name"
+      when nil then raise ArgumentError, 'missing required option :bucket_name'
       else
         msg = "expected :bucket_name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1321,7 +1321,7 @@ module Aws::S3
       value = args[1] || options.delete(:key)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :key"
+      when nil then raise ArgumentError, 'missing required option :key'
       else
         msg = "expected :key to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1330,8 +1330,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1330,8 +1330,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1331,7 +1331,7 @@ module Aws::S3
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -81,7 +81,7 @@ module Aws::S3
     # @raise [NotImplementedError]
     # @api private
     def load
-      msg = "#load is not implemented, data only available via enumeration"
+      msg = '#load is not implemented, data only available via enumeration'
       raise NotImplementedError, msg
     end
     alias :reload :load
@@ -1070,7 +1070,7 @@ module Aws::S3
       value = args[0] || options.delete(:bucket_name)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :bucket_name"
+      when nil then raise ArgumentError, 'missing required option :bucket_name'
       else
         msg = "expected :bucket_name to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1081,7 +1081,7 @@ module Aws::S3
       value = args[1] || options.delete(:key)
       case value
       when String then value
-      when nil then raise ArgumentError, "missing required option :key"
+      when nil then raise ArgumentError, 'missing required option :key'
       else
         msg = "expected :key to be a String, got #{value.class}"
         raise ArgumentError, msg
@@ -1090,8 +1090,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "\
-              "yielding the waiter is deprecated"
+        msg = 'pass options to configure the waiter; '\
+              'yielding the waiter is deprecated'
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -1090,8 +1090,8 @@ module Aws::S3
 
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
-        msg = "pass options to configure the waiter; "
-        msg << "yielding the waiter is deprecated"
+        msg = "pass options to configure the waiter; "\
+          "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -1091,7 +1091,7 @@ module Aws::S3
     def yield_waiter_and_warn(waiter, &block)
       if !@waiter_block_warned
         msg = "pass options to configure the waiter; "\
-          "yielding the waiter is deprecated"
+              "yielding the waiter is deprecated"
         warn(msg)
         @waiter_block_warned = true
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -78,12 +78,12 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
 
           def validate_bucket_name!(bucket_name)
             unless BucketDns.dns_compatible?(bucket_name, _ssl = true)
-              msg = "unable to use `accelerate: true` on buckets with "\
-                    "non-DNS compatible names"
+              msg = 'unable to use `accelerate: true` on buckets with '\
+                    'non-DNS compatible names'
               raise ArgumentError, msg
             end
             if bucket_name.include?('.')
-              msg = "unable to use `accelerate: true` on buckets with dots"\
+              msg = 'unable to use `accelerate: true` on buckets with dots'\
                     "in their name: #{bucket_name.inspect}"
               raise ArgumentError, msg
             end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -78,13 +78,13 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
 
           def validate_bucket_name!(bucket_name)
             unless BucketDns.dns_compatible?(bucket_name, _ssl = true)
-              msg = "unable to use `accelerate: true` on buckets with "
-              msg << "non-DNS compatible names"
+              msg = "unable to use `accelerate: true` on buckets with "\
+                "non-DNS compatible names"
               raise ArgumentError, msg
             end
             if bucket_name.include?('.')
-              msg = "unable to use `accelerate: true` on buckets with dots"
-              msg << "in their name: #{bucket_name.inspect}"
+              msg = "unable to use `accelerate: true` on buckets with dots"\
+                "in their name: #{bucket_name.inspect}"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -79,12 +79,12 @@ each bucket.  [Go here for more information](http://docs.aws.amazon.com/AmazonS3
           def validate_bucket_name!(bucket_name)
             unless BucketDns.dns_compatible?(bucket_name, _ssl = true)
               msg = "unable to use `accelerate: true` on buckets with "\
-                "non-DNS compatible names"
+                    "non-DNS compatible names"
               raise ArgumentError, msg
             end
             if bucket_name.include?('.')
               msg = "unable to use `accelerate: true` on buckets with dots"\
-                "in their name: #{bucket_name.inspect}"
+                    "in their name: #{bucket_name.inspect}"
               raise ArgumentError, msg
             end
           end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
@@ -119,12 +119,11 @@ the S3 ARN.
 
           def accesspoint_arn_host(arn, dualstack)
             _resource_type, resource_name = parse_resource(arn.resource)
-            accesspoint = "#{resource_name}-#{arn.account_id}"
-            accesspoint << '.s3-accesspoint'
-            accesspoint << '.dualstack' if dualstack
             sfx = Aws::Partitions::EndpointProvider.dns_suffix_for(arn.region)
-            accesspoint << ".#{arn.region}.#{sfx}"
-            accesspoint
+            "#{resource_name}-#{arn.account_id}"\
+            '.s3-accesspoint'\
+            "#{'.dualstack' if dualstack}"\
+            ".#{arn.region}.#{sfx}"
           end
 
           def parse_resource(str)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
@@ -66,19 +66,19 @@ the S3 ARN.
           def validate_config!(config)
             unless config.regional_endpoint
               raise ArgumentError,
-                    'Cannot provide both an accesspoint ARN and :endpoint.'
+                'Cannot provide both an accesspoint ARN and :endpoint.'
             end
 
             if config.use_accelerate_endpoint
               raise ArgumentError,
-                    'Cannot provide both an accesspoint ARN and setting '\
-                    ':use_accelerate_endpoint to true.'
+                'Cannot provide both an accesspoint ARN and setting '\
+                ':use_accelerate_endpoint to true.'
             end
 
             if config.force_path_style
               raise ArgumentError,
-                    'Cannot provide both an accesspoint ARN and setting '\
-                    ':force_path_style to true.'
+                'Cannot provide both an accesspoint ARN and setting '\
+                ':force_path_style to true.'
             end
           end
         end
@@ -96,7 +96,7 @@ the S3 ARN.
                 [bucket_name, region, arn]
               else
                 raise ArgumentError,
-                      'Only accesspoint type ARNs are currently supported.'
+                  'Only accesspoint type ARNs are currently supported.'
               end
             else
               [bucket_name, region]
@@ -109,7 +109,7 @@ the S3 ARN.
               url.host = accesspoint_arn_host(arn, dualstack)
             else
               raise ArgumentError,
-                    'Only accesspoint type ARNs are currently supported.'
+                'Only accesspoint type ARNs are currently supported.'
             end
             url.path = url_path(url.path, arn)
             url
@@ -145,9 +145,9 @@ the S3 ARN.
             # Raise if provided value is not true or false
             if value != 'true' && value != 'false'
               raise ArgumentError,
-                    'Must provide either `true` or `false` for '\
-                    's3_use_arn_region profile option or for '\
-                    'ENV[\'AWS_S3_USE_ARN_REGION\']'
+                'Must provide either `true` or `false` for '\
+                's3_use_arn_region profile option or for '\
+                'ENV[\'AWS_S3_USE_ARN_REGION\']'
             end
 
             value == 'true'
@@ -169,29 +169,29 @@ the S3 ARN.
 
             if arn.region.empty? || arn.account_id.empty?
               raise ArgumentError,
-                    'S3 Access Point ARNs must contain both a valid region '\
-                    ' and a valid account id.'
+                'S3 Access Point ARNs must contain both a valid region '\
+                ' and a valid account id.'
             end
 
             if resource_name.include?(':') || resource_name.include?('/')
               raise ArgumentError,
-                    'ARN resource id must be a single value.'
+                'ARN resource id must be a single value.'
             end
 
             unless Plugins::BucketDns.valid_subdomain?(
               "#{resource_name}-#{arn.account_id}"
             )
               raise ArgumentError,
-                    "#{resource_name}-#{arn.account_id} is not a "\
-                    'valid subdomain.'
+                "#{resource_name}-#{arn.account_id} is not a "\
+                'valid subdomain.'
             end
           end
 
           def validate_region!(arn, region, s3_use_arn_region)
             if region.include?('fips')
               raise ArgumentError,
-                    'FIPS client regions are currently not supported with '\
-                    'accesspoint ARNs.'
+                'FIPS client regions are currently not supported with '\
+                'accesspoint ARNs.'
             end
 
             if s3_use_arn_region &&

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
@@ -44,7 +44,7 @@ region. Defaults to `legacy` mode using global endpoint.
           mode = ENV['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] ||
             Aws.shared_config.s3_us_east_1_regional_endpoint(profile: cfg.profile) ||
             'legacy'
-          mode.downcase!
+          mode = mode.downcase
           unless %w(legacy regional).include?(mode)
             raise ArgumentError, "expected :s3_us_east_1_regional_endpoint or"\
               " ENV['AWS_S3_US_EAST_1_REGIONAL_ENDPOINT'] to be `legacy` or"\

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -49,7 +49,9 @@ module Aws
           end
 
           def update_in_chunks(digest, io)
-            while chunk = io.read(CHUNK_SIZE, buffer ||= "")
+            loop do
+              chunk = io.read(CHUNK_SIZE)
+              break unless chunk
               digest.update(chunk)
             end
             io.rewind

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -571,8 +571,8 @@ module Aws
 
       def check_required_values!
         unless @key_set
-          msg = "key required; you must provide a key via :key, "
-          msg << ":key_starts_with, or :allow_any => ['key']"
+          msg = "key required; you must provide a key via :key, "\
+            ":key_starts_with, or :allow_any => ['key']"
           raise msg
         end
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -234,7 +234,7 @@ module Aws
       #   as hidden input fields.
       def fields
         check_required_values!
-        datetime = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+        datetime = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
         fields = @fields.dup
         fields.update('policy' => policy(datetime))
         fields.update(signature_fields(datetime))
@@ -571,7 +571,7 @@ module Aws
 
       def check_required_values!
         unless @key_set
-          msg = "key required; you must provide a key via :key, "\
+          msg = 'key required; you must provide a key via :key, '\
                 ":key_starts_with, or :allow_any => ['key']"
           raise msg
         end
@@ -617,7 +617,7 @@ module Aws
 
       def signature(datetime, string_to_sign)
         k_secret = @credentials.secret_access_key
-        k_date = hmac("AWS4" + k_secret, datetime[0,8])
+        k_date = hmac('AWS4' + k_secret, datetime[0,8])
         k_region = hmac(k_date, @bucket_region)
         k_service = hmac(k_region, 's3')
         k_credentials = hmac(k_service, 'aws4_request')

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -572,7 +572,7 @@ module Aws
       def check_required_values!
         unless @key_set
           msg = "key required; you must provide a key via :key, "\
-            ":key_starts_with, or :allow_any => ['key']"
+                ":key_starts_with, or :allow_any => ['key']"
           raise msg
         end
       end

--- a/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/m5ds_spec.rb
@@ -51,7 +51,7 @@ module Aws
           it 'computes the MD5 by reading the body 1MB at a time' do
             body = StringIO.new('.' * 5 * 1024 * 1024) # 5MB
             allow(body).to receive(:read)
-              .with(1024 * 1024, instance_of(String)).and_call_original
+              .with(1024 * 1024, any_args).and_call_original
             client = Client.new(stub_responses: true)
             resp = client.put_object(
               bucket: 'bucket-name',
@@ -105,7 +105,7 @@ module Aws
           it 'computes the MD5 by reading the body 1MB at a time' do
             body = StringIO.new('.' * 5 * 1024 * 1024) # 5MB
             allow(body).to receive(:read)
-              .with(1024 * 1024, instance_of(String)).and_call_original
+              .with(1024 * 1024, any_args).and_call_original
             client = Client.new(stub_responses: true)
             resp = client.upload_part(
               bucket: 'bucket-name',

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -29,7 +29,7 @@ module Aws
       end
 
       context 'accessing eu-central-1 bucket using classic endpoint and wrong'\
-        'sigv4 region' do
+              'sigv4 region' do
         before(:each) do
           stub_request(:put, 'https://bucket.s3.us-west-2.amazonaws.com/key')
             .to_return(status: [400, 'Bad Request'], body: auth_header_malformed_body)

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -344,7 +344,7 @@ module Aws
                   end
                 end
               end
-              data = StringIO.new
+              data = StringIO.new(String.new)
               client.get_object(
                 bucket: 'bucket', key: 'key', response_target: data
               )
@@ -355,7 +355,7 @@ module Aws
               stub_encrypted_get
               data = ''
               client.get_object(bucket: 'bucket', key: 'key') do |chunk|
-                data << chunk
+                data += chunk
               end
               expect(data).to eq('secret')
             end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -119,8 +119,8 @@ module Aws
           end
 
           def mismatch_error_message(section, local_md5, returned_md5, response)
-            m = "MD5 returned by SQS does not match "\
-                "the calculation on the original request. ("
+            m = 'MD5 returned by SQS does not match '\
+                'the calculation on the original request. ('
             if response.respond_to?(:id) && !response.id.nil?
               m = "#{m}Message ID: #{response.id}, "
             end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -120,7 +120,7 @@ module Aws
 
           def mismatch_error_message(section, local_md5, returned_md5, response)
             m = "MD5 returned by SQS does not match "\
-              "the calculation on the original request. ("
+                "the calculation on the original request. ("
             if response.respond_to?(:id) && !response.id.nil?
               m = "#{m}Message ID: #{response.id}, "
             end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -119,14 +119,12 @@ module Aws
           end
 
           def mismatch_error_message(section, local_md5, returned_md5, response)
-            m = "MD5 returned by SQS does not match " <<
-            "the calculation on the original request. ("
-
+            m = "MD5 returned by SQS does not match "\
+              "the calculation on the original request. ("
             if response.respond_to?(:id) && !response.id.nil?
-              m << "Message ID: #{response.id}, "
+              m = "#{m}Message ID: #{response.id}, "
             end
-
-            m << "MD5 calculated by the #{section}: " <<
+            "#{m}MD5 calculated by the #{section}: "\
             "'#{local_md5}', MD5 checksum returned: '#{returned_md5}')"
           end
         end

--- a/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
@@ -47,7 +47,7 @@ module Aws
 
           it 'supports vpc endpoint queue URL' do
             url = "https://vpce-xxxx-yyyy.sqs.us-east-1.vpce."\
-              "amazonaws.com/1234567890/demo"
+                  "amazonaws.com/1234567890/demo"
             client = Client.new(stub_responses:true, region: 'cn-north-1')
             resp = client.send(method, params.merge(queue_url: url))
             expect(resp.context.http_request.headers['authorization'])

--- a/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
@@ -26,7 +26,7 @@ module Aws
           },
           'öther_encodings' => {
             data_type: 'String',
-            string_value: 'Tüst'.encode!('ISO-8859-1')
+            string_value: 'Tüst'.encode('ISO-8859-1')
           }
         }}
 
@@ -99,7 +99,7 @@ module Aws
 
             before(:each) do
               message_attributes.keys.each do |attribute_name|
-                message_attributes[attribute_name][:data_type] << '.test'
+                message_attributes[attribute_name][:data_type] += '.test'
               end
             end
 

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
@@ -457,8 +457,8 @@ module Aws::TranscribeStreamingService
       when nil then event_stream_class.new
       else
         msg = "expected #{type}_event_stream_handler to be a block or "\
-          "instance of Aws::TranscribeStreamingService::#{event_stream_class}"\
-          ", got `#{handler.inspect}` instead"
+              "instance of Aws::TranscribeStreamingService::#{event_stream_class}"\
+              ", got `#{handler.inspect}` instead"
         raise ArgumentError, msg
       end
     end

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -564,7 +564,9 @@ module Aws
           OpenSSL::Digest::SHA256.file(value).hexdigest
         elsif value.respond_to?(:read)
           sha256 = OpenSSL::Digest::SHA256.new
-          while chunk = value.read(1024 * 1024, buffer ||= ::String.new) # 1MB
+          loop do
+            chunk = value.read(1024 * 1024) # 1MB
+            break unless chunk
             sha256.update(chunk)
           end
           value.rewind

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -564,7 +564,7 @@ module Aws
           OpenSSL::Digest::SHA256.file(value).hexdigest
         elsif value.respond_to?(:read)
           sha256 = OpenSSL::Digest::SHA256.new
-          while chunk = value.read(1024 * 1024, buffer ||= "") # 1MB
+          while chunk = value.read(1024 * 1024, buffer ||= ::String.new) # 1MB
             sha256.update(chunk)
           end
           value.rewind

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -11,7 +11,7 @@ end
 desc 'Executes every spec file, one at a time.'
 task 'test:spec:each' do
   failures = []
-  ::Dir.glob('**/spec/**/*_spec.rb').reject(&vendor_selector).each do |spec_file|
+  Dir.glob('**/spec/**/*_spec.rb').reject(&vendor_selector).each do |spec_file|
     sh("bundle exec rspec #{spec_file}") do |ok, _|
       failures << spec_file unless ok
     end
@@ -38,7 +38,7 @@ end
 
 desc 'Execute spec tests.'
 task 'test:spec' do
-  ::Dir.glob('**/spec').reject(&vendor_selector).tap do |spec_file_list|
+  Dir.glob('**/spec').reject(&vendor_selector).tap do |spec_file_list|
     sh("bundle exec rspec #{spec_file_list.join(' ')}")
   end
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,14 +4,10 @@ require 'rspec/core/rake_task'
 ## spec / unit tests
 ##
 
-vendor_selector = lambda do |spec_file|
-  spec_file.start_with?('vendor/')
-end
-
 desc 'Executes every spec file, one at a time.'
 task 'test:spec:each' do
   failures = []
-  Dir.glob('**/spec/**/*_spec.rb').reject(&vendor_selector).each do |spec_file|
+  Dir.glob('**/spec/**/*_spec.rb').each do |spec_file|
     sh("bundle exec rspec #{spec_file}") do |ok, _|
       failures << spec_file unless ok
     end
@@ -38,7 +34,7 @@ end
 
 desc 'Execute spec tests.'
 task 'test:spec' do
-  Dir.glob('**/spec').reject(&vendor_selector).tap do |spec_file_list|
+  Dir.glob('**/spec').tap do |spec_file_list|
     sh("bundle exec rspec #{spec_file_list.join(' ')}")
   end
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,17 +4,21 @@ require 'rspec/core/rake_task'
 ## spec / unit tests
 ##
 
+vendor_selector = lambda do |spec_file|
+  spec_file.start_with?('vendor/')
+end
+
 desc 'Executes every spec file, one at a time.'
 task 'test:spec:each' do
   failures = []
-  Dir.glob("**/spec/**/*_spec.rb").each do |spec_file|
+  ::Dir.glob('**/spec/**/*_spec.rb').reject(&vendor_selector).each do |spec_file|
     sh("bundle exec rspec #{spec_file}") do |ok, _|
-      failures << spec_file if !ok
+      failures << spec_file unless ok
     end
   end
   msg = "One or more spec files had failures:\n\n"
   failures.each do |path|
-    msg << "bundle exec rspec #{path}\n"
+    msg += "bundle exec rspec #{path}\n"
   end
   abort(msg) unless failures.empty?
 end
@@ -34,7 +38,9 @@ end
 
 desc 'Execute spec tests.'
 task 'test:spec' do
-  sh("bundle exec rspec #{Dir.glob('**/spec').join(' ')}")
+  ::Dir.glob('**/spec').reject(&vendor_selector).tap do |spec_file_list|
+    sh("bundle exec rspec #{spec_file_list.join(' ')}")
+  end
 end
 
 ##
@@ -51,10 +57,10 @@ task 'test:features' do
   failures = []
   Dir.glob('gems/*/features').each do |dir|
     sh("bundle exec cucumber -t ~@veryslow -r #{dir} #{dir}") do |ok, _|
-      failures << File.basename(File.dirname(dir)) if !ok
+      failures << File.basename(File.dirname(dir)) unless ok
     end
   end
-  abort("one or more test suites failed: %s" % [failures.join(', ')]) unless failures.empty?
+  abort('one or more test suites failed: %s' % [failures.join(', ')]) unless failures.empty?
 end
 
 desc 'Runs unit and integration tests after rebuilding gems'


### PR DESCRIPTION
These gems are the reason why I cannot set  
RUBYOPT=--enable=frozen-string-literal

Can I introduce just some styling changes, leaving the functionality the same?
This pull request does just that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

P.S. I will let Travis do his jobs first; too lazy to test locally.