### PR TITLE
Add cn-northwest-1 endpoint.

### DIFF
--- a/endpoints.json
+++ b/endpoints.json
@@ -1409,6 +1409,98 @@
         "hostname": "glacier.cn-north-1.amazonaws.com.cn"
       }
     },
+	    "cn-northwest-1": {
+      "cloudformation": {
+        "http": false,
+        "https": true,
+        "hostname": "cloudformation.cn-northwest-1.amazonaws.com.cn"
+      },
+      "monitoring": {
+        "http": true,
+        "https": true,
+        "hostname": "monitoring.cn-northwest-1.amazonaws.com.cn"
+      },
+      "dynamodb": {
+        "http": true,
+        "https": true,
+        "hostname": "dynamodb.cn-northwest-1.amazonaws.com.cn"
+      },
+      "ec2": {
+        "http": true,
+        "https": true,
+        "hostname": "ec2.cn-northwest-1.amazonaws.com.cn"
+      },
+      "elasticmapreduce": {
+        "http": true,
+        "https": true,
+        "hostname": "elasticmapreduce.cn-northwest-1.amazonaws.com.cn"
+      },
+      "elasticache": {
+        "http": false,
+        "https": true,
+        "hostname": "elasticache.cn-northwest-1.amazonaws.com.cn"
+      },
+      "rds": {
+        "http": false,
+        "https": true,
+        "hostname": "rds.cn-northwest-1.amazonaws.com.cn"
+      },
+      "sns": {
+        "http": true,
+        "https": true,
+        "hostname": "sns.cn-northwest-1.amazonaws.com.cn"
+      },
+      "sqs": {
+        "http": true,
+        "https": true,
+        "hostname": "sqs.cn-northwest-1.amazonaws.com.cn"
+      },
+      "s3": {
+        "http": true,
+        "https": true,
+        "hostname": "s3.cn-northwest-1.amazonaws.com.cn"
+      },
+      "autoscaling": {
+        "http": true,
+        "https": true,
+        "hostname": "autoscaling.cn-northwest-1.amazonaws.com.cn"
+      },
+      "iam": {
+        "http": false,
+        "https": true,
+        "hostname": "iam.cn-northwest-1.amazonaws.com.cn"
+      },
+      "sts": {
+        "http": false,
+        "https": true,
+        "hostname": "sts.cn-northwest-1.amazonaws.com.cn"
+      },
+      "storagegateway": {
+        "http": false,
+        "https": true,
+        "hostname": "storagegateway.cn-northwest-1.amazonaws.com.cn"
+      },
+      "support": {
+        "http": false,
+        "https": true,
+        "hostname": "support.cn-northwest-1.amazonaws.com.cn"
+      },
+      "elasticloadbalancing": {
+        "http": true,
+        "https": true,
+        "hostname": "elasticloadbalancing.cn-northwest-1.amazonaws.com.cn"
+      },
+      "swf": {
+        "http": false,
+        "https": true,
+        "hostname": "swf.cn-northwest-1.amazonaws.com.cn"
+      },
+      "glacier": {
+        "http": true,
+        "https": true,
+        "hostname": "glacier.cn-northwest-1.amazonaws.com.cn"
+      }
+    },
     "us-gov-west-1": {
       "monitoring": {
         "http": false,
@@ -1494,7 +1586,8 @@
       "sa-east-1",
       "eu-west-1",
       "eu-central-1",
-      "cn-north-1"
+      "cn-north-1",
+	  "cn-northwest-1"
     ],
     "cloudfront": [
       "us-east-1",
@@ -1540,6 +1633,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "logs": [
@@ -1558,6 +1652,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "ec2": [
@@ -1571,6 +1666,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "elasticmapreduce": [
@@ -1584,6 +1680,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "elasticache": [
@@ -1595,7 +1692,8 @@
       "ap-southeast-2",
       "sa-east-1",
       "eu-west-1",
-      "cn-north-1"
+      "cn-north-1",
+	  "cn-northwest-1"
     ],
     "rds": [
       "us-east-1",
@@ -1608,6 +1706,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "route53": [
@@ -1647,6 +1746,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "sqs": [
@@ -1660,6 +1760,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "s3": [
@@ -1673,6 +1774,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "autoscaling": [
@@ -1686,6 +1788,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "elasticbeanstalk": [
@@ -1710,6 +1813,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "importexport": [
@@ -1733,6 +1837,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "storagegateway": [
@@ -1745,7 +1850,8 @@
       "sa-east-1",
       "eu-west-1",
       "eu-central-1",
-      "cn-north-1"
+      "cn-north-1",
+	  "cn-northwest-1"
     ],
     "support": [
       "us-east-1",
@@ -1762,6 +1868,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "swf": [
@@ -1775,6 +1882,7 @@
       "eu-west-1",
       "eu-central-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "us-gov-west-1"
     ],
     "glacier": [
@@ -1785,6 +1893,7 @@
       "ap-southeast-2",
       "ap-northeast-1",
       "cn-north-1",
+	  "cn-northwest-1",
       "eu-central-1"
     ],
     "directconnect": [


### PR DESCRIPTION
There are two Regions in AWS China, but the information of cn-northwest-1 is not included in endpoints.json.
This will cause the cn-northwest-1 resource to be created incorrectly when using aws-sdk-v1.
Therefore, this pr supplements the information (cn-northwest-1).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
