### PR TITLE
[#1455] Added region to instance

### DIFF
--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -52,6 +52,12 @@ module Aws::EC2
       data[:instance_type]
     end
 
+    # Region which is associated with the instance
+    # @return [String]
+    def current_region
+      data.placement.availability_zone.chop
+    end
+
     # The kernel associated with this instance, if applicable.
     # @return [String]
     def kernel_id


### PR DESCRIPTION
FIX #1455 issue

Adds region method to instance which returns region of the instance. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
