### PR TITLE
Fix CloudFront signer URL spliting

### DIFF
--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Split on first instance of `://` in `Signer` to handle 3rd party s3:// urls.
+* Issue - Split on first instance of `://` in `Aws::CloudFront::Signer` to handle 3rd party s3:// urls.
 
 1.27.0 (2020-05-07)
 ------------------

--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Split on first instance of `://` in `Signer` to handle 3rd party s3:// urls.
+
 1.27.0 (2020-05-07)
 ------------------
 

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
@@ -20,7 +20,7 @@ module Aws
       private
 
       def scheme_and_uri(url)
-        url_sections = url.split('://')
+        url_sections = url.split('://', 2)
         if url_sections.length < 2
           raise ArgumentError, "Invalid URL:#{url}"
         end

--- a/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
@@ -86,6 +86,19 @@ module Aws
                          'cTVsiWVeKyCGT~8i81-4_&Key-Pair-Id=CF_KEYPAIR_ID'
           expect(url).to eq(expected_url)
         end
+
+        it 'can handle urls with url-like paths' do
+          url = signer.signed_url(
+            'https://abc.cloudfront.net/images/from/s3://bucket/file.jpg',
+            :expires => expires
+          )
+          expected_url = 'https://abc.cloudfront.net/images/from/s3://bucket/file.jpg?'\
+                         'Expires=1357034400&Signature=Xk0prcC1fjhyROJOIr~x0KUuc-wEOQ~'\
+                         'v0zHwQ1GjPZH2rJPDIbjwNcvK8NIwyuQSk4PxmpaI1oVV8t62tuMPiQ8NuP2'\
+                         'LM6y-XWFPUkegRVVRC~~HKxvPUghef4iWS~zwIbn4bDpXjqjtA9nnyIlasau'\
+                         'Qypl7Zqm94g48YKTL2U0_&Key-Pair-Id=CF_KEYPAIR_ID'
+          expect(url).to eq(expected_url)
+        end
       end
     end
   end


### PR DESCRIPTION
Fix URL signing when a url contains `://` in its path (which is valid for URLs).