### PR TITLE
Fix printing of exception in a thread in passing spec

### DIFF
--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -28,6 +28,17 @@ RSpec.configure do |config|
     stub_request(:put, "http://169.254.169.254#{token_path}").to_raise(SocketError)
 
     Aws.shared_config.fresh
-
   end
+end
+
+def without_thread_report_on_exception
+  if Thread.respond_to?(:report_on_exception)
+    current_value = Thread.report_on_exception
+    Thread.report_on_exception = false
+  end
+
+  yield
+
+ensure
+  Thread.report_on_exception = current_value if current_value
 end

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -29,16 +29,18 @@ RSpec.configure do |config|
 
     Aws.shared_config.fresh
   end
-end
 
-def without_thread_report_on_exception
-  if Thread.respond_to?(:report_on_exception)
-    current_value = Thread.report_on_exception
-    Thread.report_on_exception = false
+  # Thread.report_on_exception was set to default true in Ruby 2.5
+  # When testing code that intentionally has threads that raise exceptions
+  # disable printing of those exceptions.
+  config.around(:each, thread_report_on_exception: false) do |example|
+    if Thread.respond_to?(:report_on_exception)
+      current_value = Thread.report_on_exception
+      Thread.report_on_exception = false
+    end
+
+    example.call
+
+    Thread.report_on_exception = current_value if current_value
   end
-
-  yield
-
-ensure
-  Thread.report_on_exception = current_value if current_value
 end

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -361,27 +361,25 @@ module Aws
             )
           end
 
-          it 'aborts the upload on errors' do
-            without_thread_report_on_exception do
-              client.stub_responses(:upload_part_copy, 'NoSuchKey')
-              allow(client).to receive(:create_multipart_upload)
-                .with(bucket: 'bucket', key: 'unescaped/key path')
-                .and_return(
-                  client.stub_data(:create_multipart_upload, upload_id: 'id')
-                )
-              expect(client).to receive(:abort_multipart_upload)
-                .with(
-                  bucket: 'bucket',
-                  key: 'unescaped/key path',
-                  upload_id: 'id'
-                )
-              expect do
-                object.copy_from(
-                  'source-bucket/source%20key',
-                  multipart_copy: true
-                )
-              end.to raise_error(Aws::S3::Errors::NoSuchKey)
-            end
+          it 'aborts the upload on errors', thread_report_on_exception: false do
+            client.stub_responses(:upload_part_copy, 'NoSuchKey')
+            allow(client).to receive(:create_multipart_upload)
+              .with(bucket: 'bucket', key: 'unescaped/key path')
+              .and_return(
+                client.stub_data(:create_multipart_upload, upload_id: 'id')
+              )
+            expect(client).to receive(:abort_multipart_upload)
+              .with(
+                bucket: 'bucket',
+                key: 'unescaped/key path',
+                upload_id: 'id'
+              )
+            expect do
+              object.copy_from(
+                'source-bucket/source%20key',
+                multipart_copy: true
+              )
+            end.to raise_error(Aws::S3::Errors::NoSuchKey)
           end
 
           it 'rejects files smaller than 5MB' do

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -362,24 +362,26 @@ module Aws
           end
 
           it 'aborts the upload on errors' do
-            client.stub_responses(:upload_part_copy, 'NoSuchKey')
-            allow(client).to receive(:create_multipart_upload)
-              .with(bucket: 'bucket', key: 'unescaped/key path')
-              .and_return(
-                client.stub_data(:create_multipart_upload, upload_id: 'id')
-              )
-            expect(client).to receive(:abort_multipart_upload)
-              .with(
-                bucket: 'bucket',
-                key: 'unescaped/key path',
-                upload_id: 'id'
-              )
-            expect do
-              object.copy_from(
-                'source-bucket/source%20key',
-                multipart_copy: true
-              )
-            end.to raise_error(Aws::S3::Errors::NoSuchKey)
+            without_thread_report_on_exception do
+              client.stub_responses(:upload_part_copy, 'NoSuchKey')
+              allow(client).to receive(:create_multipart_upload)
+                .with(bucket: 'bucket', key: 'unescaped/key path')
+                .and_return(
+                  client.stub_data(:create_multipart_upload, upload_id: 'id')
+                )
+              expect(client).to receive(:abort_multipart_upload)
+                .with(
+                  bucket: 'bucket',
+                  key: 'unescaped/key path',
+                  upload_id: 'id'
+                )
+              expect do
+                object.copy_from(
+                  'source-bucket/source%20key',
+                  multipart_copy: true
+                )
+              end.to raise_error(Aws::S3::Errors::NoSuchKey)
+            end
           end
 
           it 'rejects files smaller than 5MB' do


### PR DESCRIPTION
Ruby 2.5 added a default value for Thread.report_on_exception to true (https://blog.bigbinary.com/2018/04/18/ruby-2-5-enables-thread-report_on_exception-by-default.html). 
its not supported before ruby 2.4.  And ruby 2.4 had a default value of false, which was changed to true in 2.5+

Alternative:
Use Rspec around hooks (eg: https://relishapp.com/rspec/rspec-core/v/3-4/docs/hooks/around-hooks#define-a-global-%60around%60-hook)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
