### PR TITLE
Fix ruby 2.7 warnings

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
@@ -16,7 +16,9 @@ module AwsSdkCodeGenerator
         parts << ResourceBatchBuilder.new(resource: @resource).build
         parts << "#{resource_type}::Collection.new([batch], size: batch.size)"
       elsif resource_action?
-        parts << client_request
+        parts << client_request(
+          @resource['identifiers'].any? { |i| i['source'] == 'response' } || @resource['path']
+        )
         parts << ResourceBuilder.new(resource: @resource, request_made: true).build
       else
         parts << client_request
@@ -27,8 +29,8 @@ module AwsSdkCodeGenerator
 
     private
 
-    def client_request
-      ResourceClientRequest.build(request: @request, resp: true, streaming: @streaming)
+    def client_request(resp = true)
+      ResourceClientRequest.build(request: @request, resp: resp, streaming: @streaming)
     end
 
     def resource_type

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -14,7 +14,7 @@ def whitelist
     },
     's3' => {
       'location_constraint.rb' => 12,
-      'bucket.rb' => 143,
+      'bucket.rb' => 145,
       'presigned_post.rb' => 587,
       'iad_regional_endpoint.rb' => 'SKIP_FILE'
     },

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -658,7 +658,7 @@ module Aws::AutoScaling
     # @return [ScalingPolicy]
     def put_scaling_policy(options = {})
       options = options.merge(auto_scaling_group_name: @name)
-      resp = @client.put_scaling_policy(options)
+      @client.put_scaling_policy(options)
       ScalingPolicy.new(
         name: options[:policy_name],
         client: @client
@@ -719,7 +719,7 @@ module Aws::AutoScaling
     # @return [ScheduledAction]
     def put_scheduled_update_group_action(options = {})
       options = options.merge(auto_scaling_group_name: @name)
-      resp = @client.put_scheduled_update_group_action(options)
+      @client.put_scheduled_update_group_action(options)
       ScheduledAction.new(
         name: options[:scheduled_action_name],
         client: @client
@@ -998,7 +998,7 @@ module Aws::AutoScaling
     # @return [AutoScalingGroup]
     def update(options = {})
       options = options.merge(auto_scaling_group_name: @name)
-      resp = @client.update_auto_scaling_group(options)
+      @client.update_auto_scaling_group(options)
       AutoScalingGroup.new(
         name: options[:auto_scaling_group_name],
         client: @client

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
@@ -327,7 +327,7 @@ module Aws::AutoScaling
     #   [1]: https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html
     # @return [AutoScalingGroup]
     def create_group(options = {})
-      resp = @client.create_auto_scaling_group(options)
+      @client.create_auto_scaling_group(options)
       AutoScalingGroup.new(
         name: options[:auto_scaling_group_name],
         client: @client
@@ -589,7 +589,7 @@ module Aws::AutoScaling
     #   [1]: https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html#as-vpc-tenancy
     # @return [LaunchConfiguration]
     def create_launch_configuration(options = {})
-      resp = @client.create_launch_configuration(options)
+      @client.create_launch_configuration(options)
       LaunchConfiguration.new(
         name: options[:launch_configuration_name],
         client: @client

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
@@ -316,7 +316,7 @@ module Aws::CloudFormation
     #   [2]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-nested-stacks.html
     # @return [Stack]
     def create_stack(options = {})
-      resp = @client.create_stack(options)
+      @client.create_stack(options)
       Stack.new(
         name: options[:stack_name],
         client: @client

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
@@ -586,7 +586,7 @@ module Aws::CloudWatch
         namespace: @namespace,
         metric_name: @name
       )
-      resp = @client.put_metric_alarm(options)
+      @client.put_metric_alarm(options)
       Alarm.new(
         name: options[:alarm_name],
         client: @client

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
@@ -768,7 +768,7 @@ module Aws::EC2
     #   The tags to apply to the new placement group.
     # @return [PlacementGroup]
     def create_placement_group(options = {})
-      resp = @client.create_placement_group(options)
+      @client.create_placement_group(options)
       PlacementGroup.new(
         name: options[:group_name],
         client: @client

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
@@ -267,7 +267,7 @@ module Aws::EC2
     # @return [Route]
     def create_route(options = {})
       options = options.merge(route_table_id: @id)
-      resp = @client.create_route(options)
+      @client.create_route(options)
       Route.new(
         route_table_id: @id,
         destination_cidr_block: options[:destination_cidr_block],

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
@@ -170,7 +170,7 @@ module Aws::Glacier
     # @return [Vault]
     def create_vault(options = {})
       options = options.merge(account_id: @id)
-      resp = @client.create_vault(options)
+      @client.create_vault(options)
       Vault.new(
         account_id: @id,
         name: options[:vault_name],

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
@@ -44,7 +44,7 @@ module Aws::Glacier
     # @return [Vault]
     def create_vault(options = {})
       options = options.merge(account_id: "-")
-      resp = @client.create_vault(options)
+      @client.create_vault(options)
       Vault.new(
         account_id: options[:account_id],
         name: options[:vault_name],

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
@@ -338,7 +338,7 @@ module Aws::IAM
     # @return [GroupPolicy]
     def create_policy(options = {})
       options = options.merge(group_name: @name)
-      resp = @client.put_group_policy(options)
+      @client.put_group_policy(options)
       GroupPolicy.new(
         group_name: @name,
         name: options[:policy_name],
@@ -434,7 +434,7 @@ module Aws::IAM
     # @return [Group]
     def update(options = {})
       options = options.merge(group_name: @name)
-      resp = @client.update_group(options)
+      @client.update_group(options)
       Group.new(
         name: options[:new_group_name],
         client: @client

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
@@ -173,7 +173,7 @@ module Aws::IAM
     #   the user.
     # @return [AccountPasswordPolicy]
     def create_account_password_policy(options = {})
-      resp = @client.update_account_password_policy(options)
+      @client.update_account_password_policy(options)
       AccountPasswordPolicy.new(client: @client)
     end
 
@@ -604,7 +604,7 @@ module Aws::IAM
     #   [1]: http://wikipedia.org/wiki/regex
     # @return [ServerCertificate]
     def create_server_certificate(options = {})
-      resp = @client.upload_server_certificate(options)
+      @client.upload_server_certificate(options)
       ServerCertificate.new(
         name: options[:server_certificate_name],
         client: @client

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
@@ -233,7 +233,7 @@ module Aws::IAM
     # @return [ServerCertificate]
     def update(options = {})
       options = options.merge(server_certificate_name: @name)
-      resp = @client.update_server_certificate(options)
+      @client.update_server_certificate(options)
       ServerCertificate.new(
         name: options[:new_server_certificate_name],
         client: @client

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -502,7 +502,7 @@ module Aws::IAM
     # @return [UserPolicy]
     def create_policy(options = {})
       options = options.merge(user_name: @name)
-      resp = @client.put_user_policy(options)
+      @client.put_user_policy(options)
       UserPolicy.new(
         user_name: @name,
         name: options[:policy_name],
@@ -596,7 +596,7 @@ module Aws::IAM
     # @return [MfaDevice]
     def enable_mfa(options = {})
       options = options.merge(user_name: @name)
-      resp = @client.enable_mfa_device(options)
+      @client.enable_mfa_device(options)
       MfaDevice.new(
         user_name: @name,
         serial_number: options[:serial_number],
@@ -659,7 +659,7 @@ module Aws::IAM
     # @return [User]
     def update(options = {})
       options = options.merge(user_name: @name)
-      resp = @client.update_user(options)
+      @client.update_user(options)
       User.new(
         name: options[:new_user_name],
         client: @client

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -520,7 +520,7 @@ module Aws::S3
     # @return [Object]
     def put_object(options = {})
       options = options.merge(bucket: @name)
-      resp = @client.put_object(options)
+      @client.put_object(options)
       Object.new(
         bucket_name: @name,
         key: options[:key],

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
@@ -5,6 +5,8 @@ module Aws
     class Bucket
       # Save the old initialize method so that we can call 'super'.
       old_initialize = instance_method(:initialize)
+      # Make the method redefinable
+      alias_method :initialize, :initialize
       # Define a new initialize method that extracts out a bucket ARN.
       define_method(:initialize) do |*args|
         old_initialize.bind(self).call(*args)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -3,6 +3,9 @@ module Aws
     class Object
       alias size content_length
 
+      # Make the method redefinable
+      alias_method :copy_from, :copy_from
+
       # Copies another object to this object. Use `multipart_copy: true`
       # for large objects. This is required for objects that exceed 5GB.
       #

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
@@ -4,6 +4,9 @@ module Aws
 
       alias content_length size
 
+      # Make the method redefinable
+      alias_method :copy_from, :copy_from
+
       # @param (see Object#copy_from)
       # @options (see Object#copy_from)
       # @return (see Object#copy_from)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
@@ -274,7 +274,7 @@ module Aws::S3
         key: @object_key,
         upload_id: @id
       )
-      resp = @client.complete_multipart_upload(options)
+      @client.complete_multipart_upload(options)
       Object.new(
         bucket_name: @bucket_name,
         key: @object_key,

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
@@ -13,10 +13,7 @@ module Aws
         class Handler < Seahorse::Client::Handler
 
           def call(context)
-            if
-              context.http_request.body &&
-              context.http_request.body.size > 0
-            then
+            if context.http_request.body && context.http_request.body.size > 0
               context.http_request.headers['expect'] = '100-continue'
             end
             @handler.call(context)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
@@ -27,7 +27,7 @@ module Aws
               error_code = xml.match(/<Code>(.+?)<\/Code>/)[1]
               error_message = xml.match(/<Message>(.+?)<\/Message>/)[1]
               S3::Errors.error_class(error_code).new(context, error_message)
-            elsif !xml.match(/<[\w_]/) # Must have the start of an XML Tag
+            elsif !xml.match(/<\w/) # Must have the start of an XML Tag
               # Other incomplete xml bodies will result in XML ParsingError
               Seahorse::Client::NetworkingError.new(
                 S3::Errors

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
@@ -72,7 +72,7 @@ module Aws::S3
     #   bucket.
     # @return [Bucket]
     def create_bucket(options = {})
-      resp = @client.create_bucket(options)
+      @client.create_bucket(options)
       Bucket.new(
         name: options[:bucket],
         client: @client


### PR DESCRIPTION
There were three classes of warnings:

- two seemingly simple fixes:
  - an `if` statement with no clause on the same line;
  - a redundant regexp (`[\w_]`);
- three unused variable `resp` in generated code;
- method redefinition warnings in the customizations code.

To handle the unused variables, I had to change `resp: true` in
`ResourceActionCode` to `false` in some scenarios. This now looks a bit
complicated.

I silenced the method redefinition warnings by using a technique used by
rails:

https://edgeapi.rubyonrails.org/classes/Module.html#method-i-silence_redefinition_of_method

I ran `rake build` and looked at the changes, they looked fine. I was not sure if these should be included, so I did include them.

`aws-sdk-s3.gemspec` was bumped to `3.96.1`. I am also unsure if this should have been included in the commit.

I added a changelog entry to the s3 gem, since that's the one I was focusing on. The other ones may still contain warnings, even though some of them were fixed by the code generator changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.