### PR TITLE
Ignore expect header for V4 signature

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Don't use `expect` header to compute Signature.
+
 1.1.3 (2020-04-27)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -123,6 +123,7 @@ module Aws
         @unsigned_headers = Set.new((options.fetch(:unsigned_headers, [])).map(&:downcase))
         @unsigned_headers << 'authorization'
         @unsigned_headers << 'x-amzn-trace-id'
+        @unsigned_headers << 'expect'
         [:uri_escape_path, :apply_checksum_header].each do |opt|
           instance_variable_set("@#{opt}", options.key?(opt) ? !!options[:opt] : true)
         end


### PR DESCRIPTION
When ruby SDK is used with nginx as reverse proxy,
the header Expect is not forwarded to the endpoint
and request is rejected with Invalid Signature.

This patch will avoid to use the expect header for V4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
