### PR TITLE
endpoint_discovery defaults

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
@@ -10,7 +10,7 @@ module AwsSdkCodeGenerator
           name: option.name,
           required: option.required,
           ruby_type: option.doc_type,
-          default_value: option.doc_default,
+          default_value: option.doc_default(options),
           docstring: option.docstring,
           indent: "  "
         ).to_s

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
@@ -112,7 +112,7 @@ module AwsSdkCodeGenerator
         client_examples: @client_examples,
         protocol: @service.protocol,
         signature_version: @service.signature_version,
-        endpoint_discovery_required: @service.endpoint_discovery_required,
+        require_endpoint_discovery: @service.require_endpoint_discovery,
         add_plugins: @service.add_plugins,
         remove_plugins: @service.remove_plugins,
         api: @service.api,

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
@@ -112,6 +112,7 @@ module AwsSdkCodeGenerator
         client_examples: @client_examples,
         protocol: @service.protocol,
         signature_version: @service.signature_version,
+        endpoint_discovery_required: @service.endpoint_discovery_required,
         add_plugins: @service.add_plugins,
         remove_plugins: @service.remove_plugins,
         api: @service.api,

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
@@ -15,17 +15,6 @@ module AwsSdkCodeGenerator
 
     private
 
-    def compute_plugin_options(class_name, options)
-      plugin_options = const_get(class_name).options
-      if class_name == 'Aws::Plugins::EndpointDiscovery' &&
-         options[:endpoint_discovery_required]
-        plugin_options.each do |opt|
-          opt.doc_default = true if opt.name == :endpoint_discovery
-        end
-      end
-      plugin_options
-    end
-
     def compute_plugins(options)
       plugins = {}
       plugins.update(options[:async_client] ? default_async_plugins : default_plugins)
@@ -38,11 +27,10 @@ module AwsSdkCodeGenerator
       plugins.map do |class_name, path|
         path = "./#{path}" unless path[0] == '/'
         Kernel.require(path)
-        plugin_options = compute_plugin_options(class_name, options)
 
         Plugin.new(
           class_name: class_name,
-          options: plugin_options,
+          options: const_get(class_name).options,
           path: path)
       end
     end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
@@ -15,6 +15,17 @@ module AwsSdkCodeGenerator
 
     private
 
+    def compute_plugin_options(class_name, options)
+      plugin_options = const_get(class_name).options
+      if class_name == 'Aws::Plugins::EndpointDiscovery' &&
+         options[:endpoint_discovery_required]
+        plugin_options.each do |opt|
+          opt.doc_default = true if opt.name == :endpoint_discovery
+        end
+      end
+      plugin_options
+    end
+
     def compute_plugins(options)
       plugins = {}
       plugins.update(options[:async_client] ? default_async_plugins : default_plugins)
@@ -27,9 +38,11 @@ module AwsSdkCodeGenerator
       plugins.map do |class_name, path|
         path = "./#{path}" unless path[0] == '/'
         Kernel.require(path)
+        plugin_options = compute_plugin_options(class_name, options)
+
         Plugin.new(
           class_name: class_name,
-          options: const_get(class_name).options,
+          options: plugin_options,
           path: path)
       end
     end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
@@ -46,6 +46,9 @@ module AwsSdkCodeGenerator
       @signature_version = api.fetch('metadata')['signatureVersion']
       @full_name = api.fetch('metadata')['serviceFullName']
       @short_name = api.fetch('metadata')['serviceAbbreviation'] || @full_name
+      @endpoint_discovery_required = api.fetch('operations', []).any? do |_, o|
+        o['endpointdiscovery'] && o['endpointdiscovery']['required']
+      end
     end
 
     # @return [String] The service name, e.g. "S3"
@@ -115,6 +118,9 @@ module AwsSdkCodeGenerator
 
     # @return [String] The short product name for the service, e.g. "Amazon S3".
     attr_reader :short_name
+
+    # @return [Boolean] true if any operation requires endpoint_discovery
+    attr_reader :endpoint_discovery_required
 
     # @api private
     def inspect

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
@@ -46,7 +46,7 @@ module AwsSdkCodeGenerator
       @signature_version = api.fetch('metadata')['signatureVersion']
       @full_name = api.fetch('metadata')['serviceFullName']
       @short_name = api.fetch('metadata')['serviceAbbreviation'] || @full_name
-      @endpoint_discovery_required = api.fetch('operations', []).any? do |_, o|
+      @require_endpoint_discovery = api.fetch('operations', []).any? do |_, o|
         o['endpointdiscovery'] && o['endpointdiscovery']['required']
       end
     end
@@ -120,7 +120,7 @@ module AwsSdkCodeGenerator
     attr_reader :short_name
 
     # @return [Boolean] true if any operation requires endpoint_discovery
-    attr_reader :endpoint_discovery_required
+    attr_reader :require_endpoint_discovery
 
     # @api private
     def inspect

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -243,6 +243,10 @@ module AwsSdkCodeGenerator
         nil
       end
 
+      def require_endpoint_discovery
+        @service.require_endpoint_discovery
+      end
+
       private
 
       def shape_class_name(shape)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
@@ -10,6 +10,7 @@ module AwsSdkCodeGenerator
       # @option options [required, String] :aws_sdk_core_lib_path
       # @option options [required, String] :protocol
       # @option options [required, String] :signature_version
+      # @option options [required, Boolean] :endpoint_discovery_required
       # @option options [required, Hash] :add_plugins
       # @option options [required, Array] :remove_plugins
       # @option options [required, Hash] :api

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
@@ -23,7 +23,7 @@ module AwsSdkCodeGenerator
         @gem_name = options.fetch(:gem_name)
         @gem_version = options.fetch(:gem_version)
         @plugins = PluginList.new(options)
-        @client_constructor = ClientConstructor.new(plugins: @plugins)
+        @client_constructor = ClientConstructor.new(options.merge(plugins: @plugins))
         @operations = ClientOperationList.new(options).to_a
         @waiters = Waiter.build_list(options[:waiters])
         @custom = options.fetch(:custom)

--- a/build_tools/aws-sdk-code-generator/templates/client_api_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_api_module.mustache
@@ -30,6 +30,9 @@ module {{module_name}}
       {{#endpoint_operation}}
       api.endpoint_operation = :{{endpoint_operation}}
       {{/endpoint_operation}}
+      {{#require_endpoint_discovery}}
+      api.require_endpoint_discovery = true
+      {{/require_endpoint_discovery}}
       {{#operations}}
 
       api.add_operation(:{{method_name}}, Seahorse::Model::Operation.new.tap do |o|

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Feature - Default endpoint_discovery to `true` for services with at least one operation that requires it.
 
 3.96.1 (2020-05-18)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
@@ -7,7 +7,7 @@ module Aws
         default: false,
         doc_type: 'Boolean',
         docstring: <<-DOCS) do |cfg|
-When set to `true`, endpoint discovery will be enabled for operations when available. Defaults to `false`.
+When set to `true`, endpoint discovery will be enabled for operations when available.
         DOCS
         resolve_endpoint_discovery(cfg)
       end
@@ -102,6 +102,10 @@ the background every 60 secs (default). Defaults to `false`.
           key = cache.extract_key(ctx)
 
           if required
+            unless ctx.config.endpoint_discovery
+              raise ArgumentError, "Operation #{ctx.operation.name} requires "\
+                'endpoint_discovery to be enabled.'
+            end
             # required for the operation
             unless cache.key?(key)
               cache.update(key, ctx)
@@ -151,8 +155,12 @@ the background every 60 secs (default). Defaults to `false`.
 
       def self.resolve_endpoint_discovery(cfg)
         env = ENV['AWS_ENABLE_ENDPOINT_DISCOVERY']
+        default = cfg.api.operations.any? do |_, o|
+          o.endpoint_discovery && o.endpoint_discovery['required']
+        end
         shared_cfg = Aws.shared_config.endpoint_discovery_enabled(profile: cfg.profile)
-        Aws::Util.str_2_bool(env) || Aws::Util.str_2_bool(shared_cfg)
+        resolved = Aws::Util.str_2_bool(env) || Aws::Util.str_2_bool(shared_cfg)
+        env.nil? && shared_cfg.nil? ? default : !!resolved
       end
 
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
@@ -4,7 +4,7 @@ module Aws
     class EndpointDiscovery < Seahorse::Client::Plugin
 
       option(:endpoint_discovery,
-        doc_default: Proc.new { |options| options[:endpoint_discovery_required] },
+        doc_default: Proc.new { |options| options[:require_endpoint_discovery] },
         doc_type: 'Boolean',
         docstring: <<-DOCS) do |cfg|
 When set to `true`, endpoint discovery will be enabled for operations when available.
@@ -155,9 +155,7 @@ the background every 60 secs (default). Defaults to `false`.
 
       def self.resolve_endpoint_discovery(cfg)
         env = ENV['AWS_ENABLE_ENDPOINT_DISCOVERY']
-        default = cfg.api.operations.any? do |_, o|
-          o.endpoint_discovery && o.endpoint_discovery['required']
-        end
+        default = cfg.api.require_endpoint_discovery
         shared_cfg = Aws.shared_config.endpoint_discovery_enabled(profile: cfg.profile)
         resolved = Aws::Util.str_2_bool(env) || Aws::Util.str_2_bool(shared_cfg)
         env.nil? && shared_cfg.nil? ? default : !!resolved

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
@@ -4,7 +4,7 @@ module Aws
     class EndpointDiscovery < Seahorse::Client::Plugin
 
       option(:endpoint_discovery,
-        default: false,
+        doc_default: Proc.new { |options| options[:endpoint_discovery_required] },
         doc_type: 'Boolean',
         docstring: <<-DOCS) do |cfg|
 When set to `true`, endpoint discovery will be enabled for operations when available.

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
@@ -123,11 +123,12 @@ module Seahorse
         attr_writer :doc_default
         attr_accessor :docstring
 
-        def doc_default
+        def doc_default(options)
           if @doc_default.nil? && !default.is_a?(Proc)
             default
           else
-            @doc_default
+            puts "doc_default for: #{name}, @doc_default=#{@doc_default}"
+            @doc_default.respond_to?(:call) ? @doc_default.call(options) : @doc_default
           end
         end
 

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
@@ -53,7 +53,7 @@ module Seahorse
           # For backwards-compat reasons, the default value can be passed as 2nd
           # positional argument (before the options hash) or as the `:default` option
           # in the options hash.
-          if Hash === default
+          if default.is_a? Hash
             options = default
           else
             options[:default] = default
@@ -127,7 +127,6 @@ module Seahorse
           if @doc_default.nil? && !default.is_a?(Proc)
             default
           else
-            puts "doc_default for: #{name}, @doc_default=#{@doc_default}"
             @doc_default.respond_to?(:call) ? @doc_default.call(options) : @doc_default
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/model/api.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/api.rb
@@ -7,6 +7,7 @@ module Seahorse
         @operations = {}
         @authorizers = {}
         @endpoint_operation = nil
+        @require_endpoint_discovery = false
       end
 
       # @return [String, nil]
@@ -17,6 +18,9 @@ module Seahorse
 
       # @return [Symbol|nil]
       attr_accessor :endpoint_operation
+
+      # @return [Boolean|nil]
+      attr_accessor :require_endpoint_discovery
 
       def operations(&block)
         if block_given?

--- a/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
@@ -96,15 +96,15 @@ module Aws
       end
 
       it 'enables endpoint discovery from ENV' do
-        # env['AWS_ENABLE_ENDPOINT_DISCOVERY'] = true
-        # expect(
-        #   EndpointDiscoveryClient.new(region: 'us-east-1').config.endpoint_discovery
-        # ).to be_truthy
-        #
-        # env['AWS_ENABLE_ENDPOINT_DISCOVERY'] = "true"
-        # expect(
-        #   EndpointDiscoveryClient.new(region: 'us-east-1').config.endpoint_discovery
-        # ).to be_truthy
+        env['AWS_ENABLE_ENDPOINT_DISCOVERY'] = true
+        expect(
+          EndpointDiscoveryClient.new(region: 'us-east-1').config.endpoint_discovery
+        ).to be_truthy
+
+        env['AWS_ENABLE_ENDPOINT_DISCOVERY'] = "true"
+        expect(
+          EndpointDiscoveryClient.new(region: 'us-east-1').config.endpoint_discovery
+        ).to be_truthy
 
         env['AWS_ENABLE_ENDPOINT_DISCOVERY'] = "false"
         expect(

--- a/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
@@ -122,13 +122,18 @@ module Aws
       it 'does nothing when :endpoint is specified' do
         stub_request(:post, "https://foo.com/")
           .to_return(:status => 200, :body => "", :headers => {})
-        c = EndpointDiscoveryClient.new(credentials: creds, endpoint: 'https://foo.com', region: 'us-east-1')
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, endpoint: 'https://foo.com', region: 'us-east-1'
+        )
         resp = c.operation_required(resource_name: 'foo', resource_id: '123')
         expect(resp.context.http_request.headers['user-agent']).not_to include('endpoint-discovery')
       end
 
       it 'fetches endpoint from cache when available' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1', endpoint_discovery: true, stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1', endpoint_discovery: true,
+          stub_responses: true
+        )
         c.config.endpoint_cache['akid_operation_not_required'] = {:address => "https://bar.com/foo", :cache_period_in_minutes => 20}
         c.config.endpoint_cache['akid_operation_required_123_foo'] = {:address => "https://bar.com/foo", :cache_period_in_minutes => 20}
 
@@ -150,7 +155,9 @@ module Aws
       end
 
       it 'caches endpoint when request endpoint succeed' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1', stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1', stub_responses: true
+        )
         c.stub_responses(
           :describe_endpoints,
           {
@@ -166,7 +173,10 @@ module Aws
       end
 
       it 'makes requests to fetch endpoints when required and enabled' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1', endpoint_discovery: true, stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1', endpoint_discovery: true,
+          stub_responses: true
+        )
         c.stub_responses(
           :describe_endpoints,
           {
@@ -180,17 +190,21 @@ module Aws
       end
 
       it 'raises an exception when required and disabled' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1',
-                                        endpoint_discovery: false,
-                                        stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1',
+          endpoint_discovery: false,
+          stub_responses: true
+        )
         expect do
           c.operation_required(resource_name: 'foo', resource_id: '123')
         end.to raise_exception(ArgumentError)
       end
 
       it 'fails when fetching endpoint failed but required' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1',
-                                        stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1',
+          stub_responses: true
+        )
         c.stub_responses(
           :describe_endpoints,
           'ServiceUnavaiable'
@@ -201,9 +215,10 @@ module Aws
       end
 
       it 'makes requests to fetch endpoints when enabled but not required' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1',
-                                        endpoint_discovery: true,
-                                        stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1',endpoint_discovery: true,
+          stub_responses: true
+        )
         c.stub_responses(
           :describe_endpoints,
           {
@@ -217,7 +232,10 @@ module Aws
       end
 
       it 'does not fail when fetching endpoint failed when enabled but not required' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1', endpoint_discovery: true, stub_responses: true)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1', endpoint_discovery: true,
+          stub_responses: true
+        )
         c.stub_responses(
           :describe_endpoints,
           'ServiceUnavaiable'
@@ -229,9 +247,10 @@ module Aws
       end
 
       it 'does nothing when disabled and not required' do
-        c = EndpointDiscoveryClient.new(credentials: creds, region: 'us-east-1',
-                                        stub_responses: true,
-                                        endpoint_discovery: false)
+        c = EndpointDiscoveryClient.new(
+          credentials: creds, region: 'us-east-1', stub_responses: true,
+          endpoint_discovery: false
+        )
         c.operation_not_required(foo: 'foo')
         expect(c.api_requests.size).to eq(1)
       end


### PR DESCRIPTION
Set endpoint_discovery default value to true for services with an operation that requires it. Change behavior of endpoint_discovery plugin: raise an error on operations that require endpoint discovery when disabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
