### PR TITLE
Enable frozen_string_literals

### DIFF
--- a/build_tools/aws-sdk-code-generator/templates/apig_endpoint_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/apig_endpoint_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module {{module_name}}
   module Plugins
 

--- a/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/async_client_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/authorizer_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/authorizer_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module {{module_name}}
   module Plugins
 

--- a/build_tools/aws-sdk-code-generator/templates/client_api_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_api_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/client_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/client_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/event_streams_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/event_streams_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/features/env.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/features/env.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/features/smoke_step_definitions.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/features/smoke_step_definitions.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/resource_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/root_resource_class.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/root_resource_class.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/service_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/service_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/spec/spec_helper.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/spec/spec_helper.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/types_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/types_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/build_tools/aws-sdk-code-generator/templates/waiters_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/waiters_module.mustache
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {{#generated_src_warning}}
 {{generated_src_warning}}
 {{/generated_src_warning}}

--- a/gems/aws-sdk-accessanalyzer/aws-sdk-accessanalyzer.gemspec
+++ b/gems/aws-sdk-accessanalyzer/aws-sdk-accessanalyzer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/features/env.rb
+++ b/gems/aws-sdk-accessanalyzer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/client.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/client_api.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/errors.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/resource.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/types.rb
+++ b/gems/aws-sdk-accessanalyzer/lib/aws-sdk-accessanalyzer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-accessanalyzer/spec/spec_helper.rb
+++ b/gems/aws-sdk-accessanalyzer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/aws-sdk-acm.gemspec
+++ b/gems/aws-sdk-acm/aws-sdk-acm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/features/env.rb
+++ b/gems/aws-sdk-acm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-acm/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/client.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/client_api.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/errors.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/resource.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/types.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/waiters.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acm/spec/spec_helper.rb
+++ b/gems/aws-sdk-acm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
+++ b/gems/aws-sdk-acmpca/aws-sdk-acmpca.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/features/env.rb
+++ b/gems/aws-sdk-acmpca/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/client.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/client_api.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/errors.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/resource.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/types.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/waiters.rb
+++ b/gems/aws-sdk-acmpca/lib/aws-sdk-acmpca/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-acmpca/spec/spec_helper.rb
+++ b/gems/aws-sdk-acmpca/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
+++ b/gems/aws-sdk-alexaforbusiness/aws-sdk-alexaforbusiness.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/features/env.rb
+++ b/gems/aws-sdk-alexaforbusiness/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client_api.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/errors.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/resource.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/types.rb
+++ b/gems/aws-sdk-alexaforbusiness/lib/aws-sdk-alexaforbusiness/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-alexaforbusiness/spec/spec_helper.rb
+++ b/gems/aws-sdk-alexaforbusiness/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
+++ b/gems/aws-sdk-amplify/aws-sdk-amplify.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/features/env.rb
+++ b/gems/aws-sdk-amplify/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify/client.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify/client_api.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify/errors.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify/resource.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/lib/aws-sdk-amplify/types.rb
+++ b/gems/aws-sdk-amplify/lib/aws-sdk-amplify/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-amplify/spec/spec_helper.rb
+++ b/gems/aws-sdk-amplify/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
+++ b/gems/aws-sdk-apigateway/aws-sdk-apigateway.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/features/env.rb
+++ b/gems/aws-sdk-apigateway/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-apigateway/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -314,7 +316,7 @@ module Aws::APIGateway
 
     # Create an ApiKey resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #
@@ -409,7 +411,7 @@ module Aws::APIGateway
 
     # Adds a new Authorizer resource to an existing RestApi resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #
@@ -1539,7 +1541,7 @@ module Aws::APIGateway
 
     # Deletes an existing Authorizer resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #
@@ -2298,7 +2300,7 @@ module Aws::APIGateway
 
     # Describe an existing Authorizer resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #
@@ -2355,7 +2357,7 @@ module Aws::APIGateway
 
     # Describe an existing Authorizers resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #
@@ -5424,7 +5426,7 @@ module Aws::APIGateway
     # Simulate the execution of an Authorizer in your RestApi with headers,
     # parameters, and an incoming request body.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Lambda Function as Authorizer][1] [Use Cognito User Pool as
     # Authorizer][2]
     # </div>
@@ -5728,7 +5730,7 @@ module Aws::APIGateway
 
     # Updates an existing Authorizer resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [AWS CLI][1]
     # </div>
     #

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client_api.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/errors.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/resource.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/types.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:
@@ -68,7 +70,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [API Gateway Limits][2] [Developer Guide][3], [AWS CLI][4]
     # </div>
     #
@@ -109,7 +111,7 @@ module Aws::APIGateway
     # on any RestApi, which indicates that the callers with the API key can
     # make requests to that stage.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use API Keys][1]
     # </div>
     #
@@ -193,7 +195,7 @@ module Aws::APIGateway
     # Represents a collection of API keys as represented by an ApiKeys
     # resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use API Keys][1]
     # </div>
     #
@@ -260,7 +262,7 @@ module Aws::APIGateway
     # API Gateway will activate the authorizer when a client calls the
     # method.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Lambda Function as Authorizer][1] [Use Cognito User Pool as
     # Authorizer][2]
     # </div>
@@ -376,7 +378,7 @@ module Aws::APIGateway
 
     # Represents a collection of Authorizer resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Lambda Function as Authorizer][1] [Use Cognito User Pool as
     # Authorizer][2]
     # </div>
@@ -414,12 +416,12 @@ module Aws::APIGateway
     # Represents the base path that callers of the API must provide as part
     # of the URL after the domain name.
     #
-    # <div class="remarks">
+    # <div class="remarks" markdown="1">
     # A custom domain name plus a `BasePathMapping` specification identifies
     # a deployed RestApi in a given stage of the owner Account.
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Custom Domain Names][1]
     # </div>
     #
@@ -449,7 +451,7 @@ module Aws::APIGateway
 
     # Represents a collection of BasePathMapping resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Custom Domain Names][1]
     # </div>
     #
@@ -521,7 +523,7 @@ module Aws::APIGateway
     # policies, a custom Authorizer or an Amazon Cognito user pool.
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Client-Side Certificate][1]
     # </div>
     #
@@ -568,7 +570,7 @@ module Aws::APIGateway
 
     # Represents a collection of ClientCertificate resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Client-Side Certificate][1]
     # </div>
     #
@@ -2103,14 +2105,14 @@ module Aws::APIGateway
     # by users using Stages. A deployment must be associated with a Stage
     # for it to be callable over the Internet.
     #
-    # <div class="remarks">
+    # <div class="remarks" markdown="1">
     # To create a deployment, call `POST` on the Deployments resource of a
     # RestApi. To view, update, or delete a deployment, call `GET`, `PATCH`,
     # or `DELETE` on the specified deployment resource
     # (`/restapis/\{restapi_id\}/deployments/\{deployment_id\}`).
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # RestApi, Deployments, Stage, [AWS CLI][1], [AWS SDKs][2]
     # </div>
     #
@@ -2187,14 +2189,14 @@ module Aws::APIGateway
     # interact with your collection. The collection offers a paginated view
     # of the contained deployments.
     #
-    # <div class="remarks">
+    # <div class="remarks" markdown="1">
     # To create a new deployment of a RestApi, make a `POST` request against
     # this resource. To view, update, or delete an existing deployment, make
     # a `GET`, `PATCH`, or `DELETE` request, respectively, on a specified
     # Deployment resource.
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Deploying an API][1], [AWS CLI][2], [AWS SDKs][3]
     # </div>
     #
@@ -2236,7 +2238,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Documenting an API][1], DocumentationParts
     # </div>
     #
@@ -2284,7 +2286,7 @@ module Aws::APIGateway
     # external (e.g., OpenAPI) file are imported into API Gateway
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Documenting an API][1], [documentationpart:import][2],
     # DocumentationPart
     # </div>
@@ -2385,7 +2387,7 @@ module Aws::APIGateway
     #
     # <div class="remarks"></div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Documenting an API][1], DocumentationPart
     # </div>
     #
@@ -2415,7 +2417,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Documenting an API][1], DocumentationPart, DocumentationVersions
     # </div>
     #
@@ -2450,7 +2452,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Documenting an API][1], DocumentationPart, DocumentationVersion
     # </div>
     #
@@ -2488,7 +2490,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Set a Custom Host Name for an API][1]
     # </div>
     #
@@ -2620,7 +2622,7 @@ module Aws::APIGateway
 
     # Represents a collection of DomainName resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Use Client-Side Certificate][1]
     # </div>
     #
@@ -2745,7 +2747,7 @@ module Aws::APIGateway
     # A gateway response of a given response type and status code, with
     # optional response parameters and mapping templates.
     #
-    # <div class="remarks">
+    # <div class="remarks" markdown="1">
     # For more information about valid gateway response types, see [Gateway
     # Response Types Supported by API Gateway][1]
     # <div class="example" markdown="1">
@@ -2772,7 +2774,7 @@ module Aws::APIGateway
     # </div>
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Customize Gateway Responses][2]
     # </div>
     #
@@ -2839,7 +2841,7 @@ module Aws::APIGateway
     # `responseType`-to-GatewayResponse object map of key-value pairs. As
     # such, pagination is not supported for querying this collection.
     #
-    # <div class="remarks">
+    # <div class="remarks" markdown="1">
     # For more information about valid gateway response types, see [Gateway
     # Response Types Supported by API Gateway][1]
     # <div class="example" markdown="1">
@@ -2866,7 +2868,7 @@ module Aws::APIGateway
     # </div>
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Customize Gateway Responses][2]
     # </div>
     #
@@ -4488,7 +4490,7 @@ module Aws::APIGateway
     # integration.
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Creating an API][1]
     # </div>
     #
@@ -4699,7 +4701,7 @@ module Aws::APIGateway
     #
     #   </div>
     #
-    #   <div class="seeAlso">
+    #   <div class="seeAlso" markdown="1">
     #   [Creating an API][1]
     #   </div>
     #
@@ -4735,7 +4737,7 @@ module Aws::APIGateway
     # existing MethodResponse, and parameters and templates can be used to
     # transform the back-end response.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Creating an API][1]
     # </div>
     #
@@ -4861,7 +4863,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # MethodResponse, Integration, IntegrationResponse, Resource, [Set up an
     # API's method][2]
     # </div>
@@ -4949,7 +4951,7 @@ module Aws::APIGateway
     #
     #   </div>
     #
-    #   <div class="seeAlso">
+    #   <div class="seeAlso" markdown="1">
     #   [AWS CLI][1]
     #   </div>
     #
@@ -4985,7 +4987,7 @@ module Aws::APIGateway
     #
     #   </div>
     #
-    #   <div class="seeAlso">
+    #   <div class="seeAlso" markdown="1">
     #   [AWS CLI][1]
     #   </div>
     #
@@ -5049,7 +5051,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # Method, IntegrationResponse, Integration [Creating an API][1]
     # </div>
     #
@@ -5217,7 +5219,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # Method, MethodResponse, [Models and Mappings][1]
     # </div>
     #
@@ -5265,7 +5267,7 @@ module Aws::APIGateway
 
     # Represents a collection of Model resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # Method, MethodResponse, [Models and Mappings][1]
     # </div>
     #
@@ -6008,7 +6010,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Enable Basic Request Validation in API Gateway][3]
     # </div>
     #
@@ -6052,7 +6054,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Enable Basic Request Validation in API Gateway][2]
     # </div>
     #
@@ -6076,7 +6078,7 @@ module Aws::APIGateway
 
     # Represents an API resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create an API][1]
     # </div>
     #
@@ -6141,7 +6143,7 @@ module Aws::APIGateway
 
     # Represents a collection of Resource resources.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create an API][1]
     # </div>
     #
@@ -6164,7 +6166,7 @@ module Aws::APIGateway
 
     # Represents a REST API.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create an API][1]
     # </div>
     #
@@ -6255,7 +6257,7 @@ module Aws::APIGateway
     # interact with your collection. A collection offers a paginated view of
     # your APIs.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create an API][1]
     # </div>
     #
@@ -6390,7 +6392,7 @@ module Aws::APIGateway
     # Represents a unique identifier for a version of a deployed RestApi
     # that is callable by users.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Deploy an API][1]
     # </div>
     #
@@ -6526,7 +6528,7 @@ module Aws::APIGateway
     # A list of Stage resources that are associated with the ApiKey
     # resource.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Deploying API in Stages][1]
     # </div>
     #
@@ -6587,7 +6589,7 @@ module Aws::APIGateway
 
     # Represents a mapping template used to transform a payload.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Mapping Templates][1]
     # </div>
     #
@@ -6814,7 +6816,7 @@ module Aws::APIGateway
 
     # Represents the response of the test invoke request in the HTTP method.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Test API using the API Gateway console][1]
     # </div>
     #
@@ -7831,7 +7833,7 @@ module Aws::APIGateway
     #
     # <div class="remarks"></div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create and Use Usage Plans][1], [Manage Usage in a Usage Plan][2]
     # </div>
     #
@@ -7883,7 +7885,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create and Use Usage Plans][1]
     # </div>
     #
@@ -7946,7 +7948,7 @@ module Aws::APIGateway
     #
     # </div>
     #
-    # " <div class="seeAlso">
+    # " <div class="seeAlso" markdown="1">
     # [Create and Use Usage Plans][1]
     # </div>
     #
@@ -7982,7 +7984,7 @@ module Aws::APIGateway
     # Represents the collection of usage plan keys added to usage plans for
     # the associated API keys and, possibly, other types of keys.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create and Use Usage Plans][1]
     # </div>
     #
@@ -8005,7 +8007,7 @@ module Aws::APIGateway
 
     # Represents a collection of usage plans for an AWS account.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Create and Use Usage Plans][1]
     # </div>
     #
@@ -8088,7 +8090,7 @@ module Aws::APIGateway
 
     # The collection of VPC links under the caller's account in a region.
     #
-    # <div class="seeAlso">
+    # <div class="seeAlso" markdown="1">
     # [Getting Started with Private Integrations][1], [Set up Private
     # Integrations][2]
     # </div>

--- a/gems/aws-sdk-apigateway/spec/spec_helper.rb
+++ b/gems/aws-sdk-apigateway/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
+++ b/gems/aws-sdk-apigatewaymanagementapi/aws-sdk-apigatewaymanagementapi.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/features/env.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client_api.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/errors.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/resource.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/types.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/lib/aws-sdk-apigatewaymanagementapi/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewaymanagementapi/spec/spec_helper.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
+++ b/gems/aws-sdk-apigatewayv2/aws-sdk-apigatewayv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/features/env.rb
+++ b/gems/aws-sdk-apigatewayv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/client.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/client_api.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/errors.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/resource.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/types.rb
+++ b/gems/aws-sdk-apigatewayv2/lib/aws-sdk-apigatewayv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-apigatewayv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-apigatewayv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/aws-sdk-appconfig.gemspec
+++ b/gems/aws-sdk-appconfig/aws-sdk-appconfig.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/features/env.rb
+++ b/gems/aws-sdk-appconfig/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/client.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/client_api.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/errors.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/resource.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/types.rb
+++ b/gems/aws-sdk-appconfig/lib/aws-sdk-appconfig/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appconfig/spec/spec_helper.rb
+++ b/gems/aws-sdk-appconfig/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
+++ b/gems/aws-sdk-applicationautoscaling/aws-sdk-applicationautoscaling.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/features/env.rb
+++ b/gems/aws-sdk-applicationautoscaling/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-applicationautoscaling/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client_api.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/errors.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/resource.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/types.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationautoscaling/spec/spec_helper.rb
+++ b/gems/aws-sdk-applicationautoscaling/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
+++ b/gems/aws-sdk-applicationdiscoveryservice/aws-sdk-applicationdiscoveryservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/features/env.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client_api.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/errors.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/resource.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/types.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationdiscoveryservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/aws-sdk-applicationinsights.gemspec
+++ b/gems/aws-sdk-applicationinsights/aws-sdk-applicationinsights.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/features/env.rb
+++ b/gems/aws-sdk-applicationinsights/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/client.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/client_api.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/errors.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/resource.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/types.rb
+++ b/gems/aws-sdk-applicationinsights/lib/aws-sdk-applicationinsights/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-applicationinsights/spec/spec_helper.rb
+++ b/gems/aws-sdk-applicationinsights/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
+++ b/gems/aws-sdk-appmesh/aws-sdk-appmesh.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/features/env.rb
+++ b/gems/aws-sdk-appmesh/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/client.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/client_api.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/errors.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/resource.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/types.rb
+++ b/gems/aws-sdk-appmesh/lib/aws-sdk-appmesh/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appmesh/spec/spec_helper.rb
+++ b/gems/aws-sdk-appmesh/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
+++ b/gems/aws-sdk-appstream/aws-sdk-appstream.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/features/env.rb
+++ b/gems/aws-sdk-appstream/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-appstream/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client_api.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/errors.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/resource.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/types.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/lib/aws-sdk-appstream/waiters.rb
+++ b/gems/aws-sdk-appstream/lib/aws-sdk-appstream/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appstream/spec/spec_helper.rb
+++ b/gems/aws-sdk-appstream/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
+++ b/gems/aws-sdk-appsync/aws-sdk-appsync.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/features/env.rb
+++ b/gems/aws-sdk-appsync/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client_api.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/errors.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/resource.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/lib/aws-sdk-appsync/types.rb
+++ b/gems/aws-sdk-appsync/lib/aws-sdk-appsync/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-appsync/spec/spec_helper.rb
+++ b/gems/aws-sdk-appsync/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/aws-sdk-athena.gemspec
+++ b/gems/aws-sdk-athena/aws-sdk-athena.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/features/env.rb
+++ b/gems/aws-sdk-athena/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-athena/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/client.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/client_api.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/errors.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/resource.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/lib/aws-sdk-athena/types.rb
+++ b/gems/aws-sdk-athena/lib/aws-sdk-athena/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-athena/spec/spec_helper.rb
+++ b/gems/aws-sdk-athena/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/aws-sdk-augmentedairuntime.gemspec
+++ b/gems/aws-sdk-augmentedairuntime/aws-sdk-augmentedairuntime.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/features/env.rb
+++ b/gems/aws-sdk-augmentedairuntime/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/client.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/client_api.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/errors.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/resource.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/types.rb
+++ b/gems/aws-sdk-augmentedairuntime/lib/aws-sdk-augmentedairuntime/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-augmentedairuntime/spec/spec_helper.rb
+++ b/gems/aws-sdk-augmentedairuntime/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
+++ b/gems/aws-sdk-autoscaling/aws-sdk-autoscaling.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/features/env.rb
+++ b/gems/aws-sdk-autoscaling/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-autoscaling/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/activity.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/activity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/auto_scaling_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client_api.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/errors.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/instance.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/launch_configuration.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/launch_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/lifecycle_hook.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/lifecycle_hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/load_balancer.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/load_balancer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/notification_configuration.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/notification_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scaling_policy.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scaling_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scheduled_action.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/scheduled_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/tag.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/types.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/waiters.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscaling/spec/spec_helper.rb
+++ b/gems/aws-sdk-autoscaling/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
+++ b/gems/aws-sdk-autoscalingplans/aws-sdk-autoscalingplans.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/features/env.rb
+++ b/gems/aws-sdk-autoscalingplans/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client_api.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/errors.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/resource.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/types.rb
+++ b/gems/aws-sdk-autoscalingplans/lib/aws-sdk-autoscalingplans/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-autoscalingplans/spec/spec_helper.rb
+++ b/gems/aws-sdk-autoscalingplans/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/aws-sdk-backup.gemspec
+++ b/gems/aws-sdk-backup/aws-sdk-backup.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/features/env.rb
+++ b/gems/aws-sdk-backup/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup/client.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup/client_api.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup/errors.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup/resource.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/lib/aws-sdk-backup/types.rb
+++ b/gems/aws-sdk-backup/lib/aws-sdk-backup/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-backup/spec/spec_helper.rb
+++ b/gems/aws-sdk-backup/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/aws-sdk-batch.gemspec
+++ b/gems/aws-sdk-batch/aws-sdk-batch.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/features/env.rb
+++ b/gems/aws-sdk-batch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-batch/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/client.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/client_api.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/errors.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/resource.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/lib/aws-sdk-batch/types.rb
+++ b/gems/aws-sdk-batch/lib/aws-sdk-batch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-batch/spec/spec_helper.rb
+++ b/gems/aws-sdk-batch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
+++ b/gems/aws-sdk-budgets/aws-sdk-budgets.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/features/env.rb
+++ b/gems/aws-sdk-budgets/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client_api.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/errors.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/resource.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/types.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-budgets/spec/spec_helper.rb
+++ b/gems/aws-sdk-budgets/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/aws-sdk-chime.gemspec
+++ b/gems/aws-sdk-chime/aws-sdk-chime.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/features/env.rb
+++ b/gems/aws-sdk-chime/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime/client.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime/client_api.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime/errors.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime/resource.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/lib/aws-sdk-chime/types.rb
+++ b/gems/aws-sdk-chime/lib/aws-sdk-chime/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-chime/spec/spec_helper.rb
+++ b/gems/aws-sdk-chime/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
+++ b/gems/aws-sdk-cloud9/aws-sdk-cloud9.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/features/env.rb
+++ b/gems/aws-sdk-cloud9/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/resource.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
+++ b/gems/aws-sdk-cloud9/lib/aws-sdk-cloud9/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloud9/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloud9/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
+++ b/gems/aws-sdk-clouddirectory/aws-sdk-clouddirectory.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/features/env.rb
+++ b/gems/aws-sdk-clouddirectory/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client_api.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/errors.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/resource.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/types.rb
+++ b/gems/aws-sdk-clouddirectory/lib/aws-sdk-clouddirectory/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-clouddirectory/spec/spec_helper.rb
+++ b/gems/aws-sdk-clouddirectory/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
+++ b/gems/aws-sdk-cloudformation/aws-sdk-cloudformation.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/features/env.rb
+++ b/gems/aws-sdk-cloudformation/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudformation/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/event.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource_summary.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/stack_resource_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudformation/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudformation/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
+++ b/gems/aws-sdk-cloudfront/aws-sdk-cloudfront.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/features/env.rb
+++ b/gems/aws-sdk-cloudfront/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudfront/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/errors.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/resource.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/types.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/waiters.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudfront/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudfront/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
+++ b/gems/aws-sdk-cloudhsm/aws-sdk-cloudhsm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/features/env.rb
+++ b/gems/aws-sdk-cloudhsm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/resource.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsm/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudhsm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
+++ b/gems/aws-sdk-cloudhsmv2/aws-sdk-cloudhsmv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/features/env.rb
+++ b/gems/aws-sdk-cloudhsmv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudhsmv2/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client_api.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/errors.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/resource.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/types.rb
+++ b/gems/aws-sdk-cloudhsmv2/lib/aws-sdk-cloudhsmv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudhsmv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudhsmv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
+++ b/gems/aws-sdk-cloudsearch/aws-sdk-cloudsearch.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/features/env.rb
+++ b/gems/aws-sdk-cloudsearch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudsearch/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/resource.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearch/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudsearch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
+++ b/gems/aws-sdk-cloudsearchdomain/aws-sdk-cloudsearchdomain.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/features/env.rb
+++ b/gems/aws-sdk-cloudsearchdomain/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client_api.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/errors.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/resource.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/types.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudsearchdomain/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudsearchdomain/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
+++ b/gems/aws-sdk-cloudtrail/aws-sdk-cloudtrail.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/features/env.rb
+++ b/gems/aws-sdk-cloudtrail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudtrail/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/resource.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudtrail/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudtrail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
+++ b/gems/aws-sdk-cloudwatch/aws-sdk-cloudwatch.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/features/env.rb
+++ b/gems/aws-sdk-cloudwatch/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudwatch/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/alarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/composite_alarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/metric.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/resource.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/waiters.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatch/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatch/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
+++ b/gems/aws-sdk-cloudwatchevents/aws-sdk-cloudwatchevents.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/features/env.rb
+++ b/gems/aws-sdk-cloudwatchevents/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchevents/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/resource.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchevents/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatchevents/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
+++ b/gems/aws-sdk-cloudwatchlogs/aws-sdk-cloudwatchlogs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/features/env.rb
+++ b/gems/aws-sdk-cloudwatchlogs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchlogs/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/resource.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cloudwatchlogs/spec/spec_helper.rb
+++ b/gems/aws-sdk-cloudwatchlogs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/aws-sdk-codeartifact.gemspec
+++ b/gems/aws-sdk-codeartifact/aws-sdk-codeartifact.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/features/env.rb
+++ b/gems/aws-sdk-codeartifact/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/client.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/client_api.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/errors.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/resource.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/types.rb
+++ b/gems/aws-sdk-codeartifact/lib/aws-sdk-codeartifact/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeartifact/spec/spec_helper.rb
+++ b/gems/aws-sdk-codeartifact/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
+++ b/gems/aws-sdk-codebuild/aws-sdk-codebuild.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/features/env.rb
+++ b/gems/aws-sdk-codebuild/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-codebuild/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/resource.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
+++ b/gems/aws-sdk-codebuild/lib/aws-sdk-codebuild/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codebuild/spec/spec_helper.rb
+++ b/gems/aws-sdk-codebuild/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
+++ b/gems/aws-sdk-codecommit/aws-sdk-codecommit.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/features/env.rb
+++ b/gems/aws-sdk-codecommit/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-codecommit/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/resource.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codecommit/spec/spec_helper.rb
+++ b/gems/aws-sdk-codecommit/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
+++ b/gems/aws-sdk-codedeploy/aws-sdk-codedeploy.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/features/env.rb
+++ b/gems/aws-sdk-codedeploy/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-codedeploy/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/resource.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/waiters.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codedeploy/spec/spec_helper.rb
+++ b/gems/aws-sdk-codedeploy/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/aws-sdk-codeguruprofiler.gemspec
+++ b/gems/aws-sdk-codeguruprofiler/aws-sdk-codeguruprofiler.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/features/env.rb
+++ b/gems/aws-sdk-codeguruprofiler/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/client.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/client_api.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/errors.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/resource.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/types.rb
+++ b/gems/aws-sdk-codeguruprofiler/lib/aws-sdk-codeguruprofiler/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codeguruprofiler/spec/spec_helper.rb
+++ b/gems/aws-sdk-codeguruprofiler/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/aws-sdk-codegurureviewer.gemspec
+++ b/gems/aws-sdk-codegurureviewer/aws-sdk-codegurureviewer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/features/env.rb
+++ b/gems/aws-sdk-codegurureviewer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/client.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/client_api.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/errors.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/resource.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/types.rb
+++ b/gems/aws-sdk-codegurureviewer/lib/aws-sdk-codegurureviewer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codegurureviewer/spec/spec_helper.rb
+++ b/gems/aws-sdk-codegurureviewer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
+++ b/gems/aws-sdk-codepipeline/aws-sdk-codepipeline.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/features/env.rb
+++ b/gems/aws-sdk-codepipeline/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-codepipeline/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/resource.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codepipeline/spec/spec_helper.rb
+++ b/gems/aws-sdk-codepipeline/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
+++ b/gems/aws-sdk-codestar/aws-sdk-codestar.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/features/env.rb
+++ b/gems/aws-sdk-codestar/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-codestar/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/resource.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
+++ b/gems/aws-sdk-codestar/lib/aws-sdk-codestar/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestar/spec/spec_helper.rb
+++ b/gems/aws-sdk-codestar/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/aws-sdk-codestarconnections.gemspec
+++ b/gems/aws-sdk-codestarconnections/aws-sdk-codestarconnections.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/features/env.rb
+++ b/gems/aws-sdk-codestarconnections/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/client.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/client_api.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/errors.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/resource.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/types.rb
+++ b/gems/aws-sdk-codestarconnections/lib/aws-sdk-codestarconnections/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarconnections/spec/spec_helper.rb
+++ b/gems/aws-sdk-codestarconnections/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/aws-sdk-codestarnotifications.gemspec
+++ b/gems/aws-sdk-codestarnotifications/aws-sdk-codestarnotifications.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/features/env.rb
+++ b/gems/aws-sdk-codestarnotifications/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/client.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/client_api.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/errors.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/resource.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/types.rb
+++ b/gems/aws-sdk-codestarnotifications/lib/aws-sdk-codestarnotifications/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-codestarnotifications/spec/spec_helper.rb
+++ b/gems/aws-sdk-codestarnotifications/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
+++ b/gems/aws-sdk-cognitoidentity/aws-sdk-cognitoidentity.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/features/env.rb
+++ b/gems/aws-sdk-cognitoidentity/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client_api.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/errors.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/resource.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/types.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentity/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
+++ b/gems/aws-sdk-cognitoidentityprovider/aws-sdk-cognitoidentityprovider.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/features/env.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/errors.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/resource.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/types.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitoidentityprovider/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
+++ b/gems/aws-sdk-cognitosync/aws-sdk-cognitosync.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/features/env.rb
+++ b/gems/aws-sdk-cognitosync/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client_api.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/errors.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/resource.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/types.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-cognitosync/spec/spec_helper.rb
+++ b/gems/aws-sdk-cognitosync/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
+++ b/gems/aws-sdk-comprehend/aws-sdk-comprehend.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/features/env.rb
+++ b/gems/aws-sdk-comprehend/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client_api.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/errors.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/resource.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/types.rb
+++ b/gems/aws-sdk-comprehend/lib/aws-sdk-comprehend/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehend/spec/spec_helper.rb
+++ b/gems/aws-sdk-comprehend/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
+++ b/gems/aws-sdk-comprehendmedical/aws-sdk-comprehendmedical.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/features/env.rb
+++ b/gems/aws-sdk-comprehendmedical/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/client.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/client_api.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/errors.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/resource.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/types.rb
+++ b/gems/aws-sdk-comprehendmedical/lib/aws-sdk-comprehendmedical/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-comprehendmedical/spec/spec_helper.rb
+++ b/gems/aws-sdk-comprehendmedical/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/aws-sdk-computeoptimizer.gemspec
+++ b/gems/aws-sdk-computeoptimizer/aws-sdk-computeoptimizer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/features/env.rb
+++ b/gems/aws-sdk-computeoptimizer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/client.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/client_api.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/errors.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/resource.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/types.rb
+++ b/gems/aws-sdk-computeoptimizer/lib/aws-sdk-computeoptimizer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-computeoptimizer/spec/spec_helper.rb
+++ b/gems/aws-sdk-computeoptimizer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
+++ b/gems/aws-sdk-configservice/aws-sdk-configservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/features/env.rb
+++ b/gems/aws-sdk-configservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-configservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/resource.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-configservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-configservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/aws-sdk-connect.gemspec
+++ b/gems/aws-sdk-connect/aws-sdk-connect.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/features/env.rb
+++ b/gems/aws-sdk-connect/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect/client.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect/client_api.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect/errors.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect/resource.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/lib/aws-sdk-connect/types.rb
+++ b/gems/aws-sdk-connect/lib/aws-sdk-connect/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connect/spec/spec_helper.rb
+++ b/gems/aws-sdk-connect/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/aws-sdk-connectparticipant.gemspec
+++ b/gems/aws-sdk-connectparticipant/aws-sdk-connectparticipant.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/features/env.rb
+++ b/gems/aws-sdk-connectparticipant/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/client.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/client_api.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/errors.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/resource.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/types.rb
+++ b/gems/aws-sdk-connectparticipant/lib/aws-sdk-connectparticipant/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-connectparticipant/spec/spec_helper.rb
+++ b/gems/aws-sdk-connectparticipant/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/client.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/client_api.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/resource.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/types.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
+++ b/gems/aws-sdk-costandusagereportservice/aws-sdk-costandusagereportservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/features/env.rb
+++ b/gems/aws-sdk-costandusagereportservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-costandusagereportservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client_api.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/errors.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/resource.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/types.rb
+++ b/gems/aws-sdk-costandusagereportservice/lib/aws-sdk-costandusagereportservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costandusagereportservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-costandusagereportservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
+++ b/gems/aws-sdk-costexplorer/aws-sdk-costexplorer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/features/env.rb
+++ b/gems/aws-sdk-costexplorer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client_api.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/errors.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/resource.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/types.rb
+++ b/gems/aws-sdk-costexplorer/lib/aws-sdk-costexplorer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-costexplorer/spec/spec_helper.rb
+++ b/gems/aws-sdk-costexplorer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
+++ b/gems/aws-sdk-databasemigrationservice/aws-sdk-databasemigrationservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/features/env.rb
+++ b/gems/aws-sdk-databasemigrationservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-databasemigrationservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client_api.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/errors.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/resource.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/types.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-databasemigrationservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-databasemigrationservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/aws-sdk-dataexchange.gemspec
+++ b/gems/aws-sdk-dataexchange/aws-sdk-dataexchange.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/features/env.rb
+++ b/gems/aws-sdk-dataexchange/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/client.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/client_api.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/errors.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/resource.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/types.rb
+++ b/gems/aws-sdk-dataexchange/lib/aws-sdk-dataexchange/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dataexchange/spec/spec_helper.rb
+++ b/gems/aws-sdk-dataexchange/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
+++ b/gems/aws-sdk-datapipeline/aws-sdk-datapipeline.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/features/env.rb
+++ b/gems/aws-sdk-datapipeline/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client_api.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/errors.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/resource.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/types.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datapipeline/spec/spec_helper.rb
+++ b/gems/aws-sdk-datapipeline/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
+++ b/gems/aws-sdk-datasync/aws-sdk-datasync.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/features/env.rb
+++ b/gems/aws-sdk-datasync/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync/client.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync/client_api.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync/errors.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync/resource.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/lib/aws-sdk-datasync/types.rb
+++ b/gems/aws-sdk-datasync/lib/aws-sdk-datasync/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-datasync/spec/spec_helper.rb
+++ b/gems/aws-sdk-datasync/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/aws-sdk-dax.gemspec
+++ b/gems/aws-sdk-dax/aws-sdk-dax.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/features/env.rb
+++ b/gems/aws-sdk-dax/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/resource.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dax/spec/spec_helper.rb
+++ b/gems/aws-sdk-dax/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/aws-sdk-detective.gemspec
+++ b/gems/aws-sdk-detective/aws-sdk-detective.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/features/env.rb
+++ b/gems/aws-sdk-detective/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective/client.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective/client_api.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective/errors.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective/resource.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/lib/aws-sdk-detective/types.rb
+++ b/gems/aws-sdk-detective/lib/aws-sdk-detective/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-detective/spec/spec_helper.rb
+++ b/gems/aws-sdk-detective/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
+++ b/gems/aws-sdk-devicefarm/aws-sdk-devicefarm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/features/env.rb
+++ b/gems/aws-sdk-devicefarm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-devicefarm/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client_api.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/errors.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/resource.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/types.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-devicefarm/spec/spec_helper.rb
+++ b/gems/aws-sdk-devicefarm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
+++ b/gems/aws-sdk-directconnect/aws-sdk-directconnect.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/features/env.rb
+++ b/gems/aws-sdk-directconnect/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-directconnect/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/resource.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directconnect/spec/spec_helper.rb
+++ b/gems/aws-sdk-directconnect/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
+++ b/gems/aws-sdk-directoryservice/aws-sdk-directoryservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/features/env.rb
+++ b/gems/aws-sdk-directoryservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-directoryservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client_api.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/errors.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/resource.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/types.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-directoryservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-directoryservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
+++ b/gems/aws-sdk-dlm/aws-sdk-dlm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/features/env.rb
+++ b/gems/aws-sdk-dlm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm/client.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm/client_api.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm/errors.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm/resource.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/lib/aws-sdk-dlm/types.rb
+++ b/gems/aws-sdk-dlm/lib/aws-sdk-dlm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dlm/spec/spec_helper.rb
+++ b/gems/aws-sdk-dlm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
+++ b/gems/aws-sdk-docdb/aws-sdk-docdb.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/features/env.rb
+++ b/gems/aws-sdk-docdb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-docdb/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client_api.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/errors.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/resource.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/types.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/lib/aws-sdk-docdb/waiters.rb
+++ b/gems/aws-sdk-docdb/lib/aws-sdk-docdb/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-docdb/spec/spec_helper.rb
+++ b/gems/aws-sdk-docdb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
+++ b/gems/aws-sdk-dynamodb/aws-sdk-dynamodb.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/features/env.rb
+++ b/gems/aws-sdk-dynamodb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-dynamodb/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/errors.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/resource.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/table.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/waiters.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodb/spec/spec_helper.rb
+++ b/gems/aws-sdk-dynamodb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
+++ b/gems/aws-sdk-dynamodbstreams/aws-sdk-dynamodbstreams.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/features/env.rb
+++ b/gems/aws-sdk-dynamodbstreams/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client_api.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/errors.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/resource.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/types.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-dynamodbstreams/spec/spec_helper.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/aws-sdk-ebs.gemspec
+++ b/gems/aws-sdk-ebs/aws-sdk-ebs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/features/env.rb
+++ b/gems/aws-sdk-ebs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs/client.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs/client_api.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs/errors.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs/resource.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/lib/aws-sdk-ebs/types.rb
+++ b/gems/aws-sdk-ebs/lib/aws-sdk-ebs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ebs/spec/spec_helper.rb
+++ b/gems/aws-sdk-ebs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
+++ b/gems/aws-sdk-ec2/aws-sdk-ec2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/features/env.rb
+++ b/gems/aws-sdk-ec2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/classic_address.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/classic_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client_api.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/dhcp_options.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/dhcp_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/errors.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/internet_gateway.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/internet_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair_info.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/key_pair_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/nat_gateway.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/nat_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_acl.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface_association.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/network_interface_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/placement_group.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/placement_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table_association.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/route_table_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/security_group.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/security_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/subnet.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/subnet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/tag.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/volume.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_address.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/vpc_peering_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2/spec/spec_helper.rb
+++ b/gems/aws-sdk-ec2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/aws-sdk-ec2instanceconnect.gemspec
+++ b/gems/aws-sdk-ec2instanceconnect/aws-sdk-ec2instanceconnect.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/features/env.rb
+++ b/gems/aws-sdk-ec2instanceconnect/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/client.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/client_api.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/errors.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/resource.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/types.rb
+++ b/gems/aws-sdk-ec2instanceconnect/lib/aws-sdk-ec2instanceconnect/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ec2instanceconnect/spec/spec_helper.rb
+++ b/gems/aws-sdk-ec2instanceconnect/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
+++ b/gems/aws-sdk-ecr/aws-sdk-ecr.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/features/env.rb
+++ b/gems/aws-sdk-ecr/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-ecr/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client_api.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/errors.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/resource.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/types.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/waiters.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecr/spec/spec_helper.rb
+++ b/gems/aws-sdk-ecr/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
+++ b/gems/aws-sdk-ecs/aws-sdk-ecs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/features/env.rb
+++ b/gems/aws-sdk-ecs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-ecs/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/resource.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ecs/spec/spec_helper.rb
+++ b/gems/aws-sdk-ecs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/aws-sdk-efs.gemspec
+++ b/gems/aws-sdk-efs/aws-sdk-efs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/features/env.rb
+++ b/gems/aws-sdk-efs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-efs/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/client.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/client_api.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/errors.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/resource.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/types.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-efs/spec/spec_helper.rb
+++ b/gems/aws-sdk-efs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/aws-sdk-eks.gemspec
+++ b/gems/aws-sdk-eks/aws-sdk-eks.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/features/env.rb
+++ b/gems/aws-sdk-eks/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/client.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/client_api.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/errors.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/resource.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/types.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/lib/aws-sdk-eks/waiters.rb
+++ b/gems/aws-sdk-eks/lib/aws-sdk-eks/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eks/spec/spec_helper.rb
+++ b/gems/aws-sdk-eks/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
+++ b/gems/aws-sdk-elasticache/aws-sdk-elasticache.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/features/env.rb
+++ b/gems/aws-sdk-elasticache/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elasticache/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/resource.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/waiters.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticache/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticache/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
+++ b/gems/aws-sdk-elasticbeanstalk/aws-sdk-elasticbeanstalk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/features/env.rb
+++ b/gems/aws-sdk-elasticbeanstalk/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elasticbeanstalk/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/resource.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticbeanstalk/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticbeanstalk/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/aws-sdk-elasticinference.gemspec
+++ b/gems/aws-sdk-elasticinference/aws-sdk-elasticinference.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/features/env.rb
+++ b/gems/aws-sdk-elasticinference/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/client.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/client_api.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/errors.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/resource.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/types.rb
+++ b/gems/aws-sdk-elasticinference/lib/aws-sdk-elasticinference/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticinference/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticinference/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
+++ b/gems/aws-sdk-elasticloadbalancing/aws-sdk-elasticloadbalancing.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/features/env.rb
+++ b/gems/aws-sdk-elasticloadbalancing/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancing/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/resource.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/waiters.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancing/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticloadbalancing/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
+++ b/gems/aws-sdk-elasticloadbalancingv2/aws-sdk-elasticloadbalancingv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/features/env.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/resource.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/waiters.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticloadbalancingv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
+++ b/gems/aws-sdk-elasticsearchservice/aws-sdk-elasticsearchservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/features/env.rb
+++ b/gems/aws-sdk-elasticsearchservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elasticsearchservice/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/resource.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elasticsearchservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-elasticsearchservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
+++ b/gems/aws-sdk-elastictranscoder/aws-sdk-elastictranscoder.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/features/env.rb
+++ b/gems/aws-sdk-elastictranscoder/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-elastictranscoder/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/resource.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/waiters.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-elastictranscoder/spec/spec_helper.rb
+++ b/gems/aws-sdk-elastictranscoder/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/aws-sdk-emr.gemspec
+++ b/gems/aws-sdk-emr/aws-sdk-emr.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/features/env.rb
+++ b/gems/aws-sdk-emr/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-emr/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/client.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/resource.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/waiters.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-emr/spec/spec_helper.rb
+++ b/gems/aws-sdk-emr/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/aws-sdk-eventbridge.gemspec
+++ b/gems/aws-sdk-eventbridge/aws-sdk-eventbridge.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/features/env.rb
+++ b/gems/aws-sdk-eventbridge/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-eventbridge/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client_api.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/errors.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/resource.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/types.rb
+++ b/gems/aws-sdk-eventbridge/lib/aws-sdk-eventbridge/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-eventbridge/spec/spec_helper.rb
+++ b/gems/aws-sdk-eventbridge/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
+++ b/gems/aws-sdk-firehose/aws-sdk-firehose.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/features/env.rb
+++ b/gems/aws-sdk-firehose/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-firehose/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client_api.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/errors.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/resource.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/types.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-firehose/spec/spec_helper.rb
+++ b/gems/aws-sdk-firehose/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/aws-sdk-fms.gemspec
+++ b/gems/aws-sdk-fms/aws-sdk-fms.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/features/env.rb
+++ b/gems/aws-sdk-fms/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms/client.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms/client_api.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms/errors.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms/resource.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/lib/aws-sdk-fms/types.rb
+++ b/gems/aws-sdk-fms/lib/aws-sdk-fms/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fms/spec/spec_helper.rb
+++ b/gems/aws-sdk-fms/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/aws-sdk-forecastqueryservice.gemspec
+++ b/gems/aws-sdk-forecastqueryservice/aws-sdk-forecastqueryservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/features/env.rb
+++ b/gems/aws-sdk-forecastqueryservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/client.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/client_api.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/errors.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/resource.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/types.rb
+++ b/gems/aws-sdk-forecastqueryservice/lib/aws-sdk-forecastqueryservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastqueryservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-forecastqueryservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/aws-sdk-forecastservice.gemspec
+++ b/gems/aws-sdk-forecastservice/aws-sdk-forecastservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/features/env.rb
+++ b/gems/aws-sdk-forecastservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/client.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/client_api.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/errors.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/resource.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/types.rb
+++ b/gems/aws-sdk-forecastservice/lib/aws-sdk-forecastservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-forecastservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-forecastservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/aws-sdk-frauddetector.gemspec
+++ b/gems/aws-sdk-frauddetector/aws-sdk-frauddetector.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/features/env.rb
+++ b/gems/aws-sdk-frauddetector/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/client.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/client_api.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/errors.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/resource.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/types.rb
+++ b/gems/aws-sdk-frauddetector/lib/aws-sdk-frauddetector/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-frauddetector/spec/spec_helper.rb
+++ b/gems/aws-sdk-frauddetector/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
+++ b/gems/aws-sdk-fsx/aws-sdk-fsx.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/features/env.rb
+++ b/gems/aws-sdk-fsx/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx/client.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx/client_api.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx/errors.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx/resource.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/lib/aws-sdk-fsx/types.rb
+++ b/gems/aws-sdk-fsx/lib/aws-sdk-fsx/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-fsx/spec/spec_helper.rb
+++ b/gems/aws-sdk-fsx/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
+++ b/gems/aws-sdk-gamelift/aws-sdk-gamelift.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/features/env.rb
+++ b/gems/aws-sdk-gamelift/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-gamelift/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client_api.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/errors.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/resource.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/types.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-gamelift/spec/spec_helper.rb
+++ b/gems/aws-sdk-gamelift/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
+++ b/gems/aws-sdk-glacier/aws-sdk-glacier.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/features/env.rb
+++ b/gems/aws-sdk-glacier/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-glacier/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/archive.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/archive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client_api.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/errors.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/job.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/multipart_upload.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/notification.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/types.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/vault.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/vault.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/waiters.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glacier/spec/spec_helper.rb
+++ b/gems/aws-sdk-glacier/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
+++ b/gems/aws-sdk-globalaccelerator/aws-sdk-globalaccelerator.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/features/env.rb
+++ b/gems/aws-sdk-globalaccelerator/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/client.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/client_api.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/errors.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/resource.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/types.rb
+++ b/gems/aws-sdk-globalaccelerator/lib/aws-sdk-globalaccelerator/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-globalaccelerator/spec/spec_helper.rb
+++ b/gems/aws-sdk-globalaccelerator/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/aws-sdk-glue.gemspec
+++ b/gems/aws-sdk-glue/aws-sdk-glue.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/features/env.rb
+++ b/gems/aws-sdk-glue/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-glue/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/client.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/client_api.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/errors.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/resource.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/lib/aws-sdk-glue/types.rb
+++ b/gems/aws-sdk-glue/lib/aws-sdk-glue/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-glue/spec/spec_helper.rb
+++ b/gems/aws-sdk-glue/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
+++ b/gems/aws-sdk-greengrass/aws-sdk-greengrass.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/features/env.rb
+++ b/gems/aws-sdk-greengrass/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client_api.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/errors.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/resource.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/types.rb
+++ b/gems/aws-sdk-greengrass/lib/aws-sdk-greengrass/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-greengrass/spec/spec_helper.rb
+++ b/gems/aws-sdk-greengrass/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/aws-sdk-groundstation.gemspec
+++ b/gems/aws-sdk-groundstation/aws-sdk-groundstation.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/features/env.rb
+++ b/gems/aws-sdk-groundstation/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/client.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/client_api.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/errors.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/resource.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/types.rb
+++ b/gems/aws-sdk-groundstation/lib/aws-sdk-groundstation/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-groundstation/spec/spec_helper.rb
+++ b/gems/aws-sdk-groundstation/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
+++ b/gems/aws-sdk-guardduty/aws-sdk-guardduty.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/features/env.rb
+++ b/gems/aws-sdk-guardduty/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client_api.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/errors.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/resource.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/types.rb
+++ b/gems/aws-sdk-guardduty/lib/aws-sdk-guardduty/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-guardduty/spec/spec_helper.rb
+++ b/gems/aws-sdk-guardduty/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/aws-sdk-health.gemspec
+++ b/gems/aws-sdk-health/aws-sdk-health.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/features/env.rb
+++ b/gems/aws-sdk-health/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/client.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/client_api.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/errors.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/resource.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/lib/aws-sdk-health/types.rb
+++ b/gems/aws-sdk-health/lib/aws-sdk-health/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/spec/spec_helper.rb
+++ b/gems/aws-sdk-health/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/aws-sdk-iam.gemspec
+++ b/gems/aws-sdk-iam/aws-sdk-iam.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/features/env.rb
+++ b/gems/aws-sdk-iam/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-iam/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key_pair.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/access_key_pair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/account_password_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/account_password_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/account_summary.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/account_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/assume_role_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/assume_role_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/client.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/client_api.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/current_user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/current_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/group_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/group_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/instance_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/login_profile.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/login_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/mfa_device.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/mfa_device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/policy_version.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/policy_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/role.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/role_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/role_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/saml_provider.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/saml_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/server_certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/signing_certificate.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/signing_certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/types.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/user_policy.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/user_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/virtual_mfa_device.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/virtual_mfa_device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/waiters.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iam/spec/spec_helper.rb
+++ b/gems/aws-sdk-iam/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/aws-sdk-imagebuilder.gemspec
+++ b/gems/aws-sdk-imagebuilder/aws-sdk-imagebuilder.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/features/env.rb
+++ b/gems/aws-sdk-imagebuilder/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/client.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/client_api.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/errors.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/resource.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/types.rb
+++ b/gems/aws-sdk-imagebuilder/lib/aws-sdk-imagebuilder/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-imagebuilder/spec/spec_helper.rb
+++ b/gems/aws-sdk-imagebuilder/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
+++ b/gems/aws-sdk-importexport/aws-sdk-importexport.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/features/env.rb
+++ b/gems/aws-sdk-importexport/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client_api.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/errors.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/resource.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/types.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-importexport/spec/spec_helper.rb
+++ b/gems/aws-sdk-importexport/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
+++ b/gems/aws-sdk-inspector/aws-sdk-inspector.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/features/env.rb
+++ b/gems/aws-sdk-inspector/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-inspector/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client_api.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/errors.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/resource.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/types.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-inspector/spec/spec_helper.rb
+++ b/gems/aws-sdk-inspector/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/aws-sdk-iot.gemspec
+++ b/gems/aws-sdk-iot/aws-sdk-iot.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/features/env.rb
+++ b/gems/aws-sdk-iot/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-iot/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/client.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/client_api.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/errors.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/resource.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/types.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot/spec/spec_helper.rb
+++ b/gems/aws-sdk-iot/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
+++ b/gems/aws-sdk-iot1clickdevicesservice/aws-sdk-iot1clickdevicesservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/features/env.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/client.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/client_api.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/errors.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/resource.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/types.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/lib/aws-sdk-iot1clickdevicesservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickdevicesservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
+++ b/gems/aws-sdk-iot1clickprojects/aws-sdk-iot1clickprojects.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/features/env.rb
+++ b/gems/aws-sdk-iot1clickprojects/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/client.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/client_api.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/errors.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/resource.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/types.rb
+++ b/gems/aws-sdk-iot1clickprojects/lib/aws-sdk-iot1clickprojects/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iot1clickprojects/spec/spec_helper.rb
+++ b/gems/aws-sdk-iot1clickprojects/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
+++ b/gems/aws-sdk-iotanalytics/aws-sdk-iotanalytics.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/features/env.rb
+++ b/gems/aws-sdk-iotanalytics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/client.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/client_api.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/errors.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/resource.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/types.rb
+++ b/gems/aws-sdk-iotanalytics/lib/aws-sdk-iotanalytics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotanalytics/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotanalytics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
+++ b/gems/aws-sdk-iotdataplane/aws-sdk-iotdataplane.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/features/env.rb
+++ b/gems/aws-sdk-iotdataplane/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-iotdataplane/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client_api.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/errors.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/resource.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/types.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotdataplane/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotdataplane/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/aws-sdk-iotevents.gemspec
+++ b/gems/aws-sdk-iotevents/aws-sdk-iotevents.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/features/env.rb
+++ b/gems/aws-sdk-iotevents/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/client.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/client_api.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/errors.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/resource.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/types.rb
+++ b/gems/aws-sdk-iotevents/lib/aws-sdk-iotevents/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotevents/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotevents/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/aws-sdk-ioteventsdata.gemspec
+++ b/gems/aws-sdk-ioteventsdata/aws-sdk-ioteventsdata.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/features/env.rb
+++ b/gems/aws-sdk-ioteventsdata/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/client.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/client_api.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/errors.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/resource.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/types.rb
+++ b/gems/aws-sdk-ioteventsdata/lib/aws-sdk-ioteventsdata/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ioteventsdata/spec/spec_helper.rb
+++ b/gems/aws-sdk-ioteventsdata/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
+++ b/gems/aws-sdk-iotjobsdataplane/aws-sdk-iotjobsdataplane.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/features/env.rb
+++ b/gems/aws-sdk-iotjobsdataplane/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client_api.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/errors.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/resource.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/types.rb
+++ b/gems/aws-sdk-iotjobsdataplane/lib/aws-sdk-iotjobsdataplane/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotjobsdataplane/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotjobsdataplane/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/aws-sdk-iotsecuretunneling.gemspec
+++ b/gems/aws-sdk-iotsecuretunneling/aws-sdk-iotsecuretunneling.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/features/env.rb
+++ b/gems/aws-sdk-iotsecuretunneling/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/client.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/client_api.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/errors.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/resource.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/types.rb
+++ b/gems/aws-sdk-iotsecuretunneling/lib/aws-sdk-iotsecuretunneling/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsecuretunneling/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotsecuretunneling/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/aws-sdk-iotsitewise.gemspec
+++ b/gems/aws-sdk-iotsitewise/aws-sdk-iotsitewise.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/features/env.rb
+++ b/gems/aws-sdk-iotsitewise/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/client.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/client_api.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/errors.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/resource.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/types.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/waiters.rb
+++ b/gems/aws-sdk-iotsitewise/lib/aws-sdk-iotsitewise/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotsitewise/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotsitewise/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/aws-sdk-iotthingsgraph.gemspec
+++ b/gems/aws-sdk-iotthingsgraph/aws-sdk-iotthingsgraph.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/features/env.rb
+++ b/gems/aws-sdk-iotthingsgraph/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/client.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/client_api.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/errors.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/resource.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/types.rb
+++ b/gems/aws-sdk-iotthingsgraph/lib/aws-sdk-iotthingsgraph/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-iotthingsgraph/spec/spec_helper.rb
+++ b/gems/aws-sdk-iotthingsgraph/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
+++ b/gems/aws-sdk-kafka/aws-sdk-kafka.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/features/env.rb
+++ b/gems/aws-sdk-kafka/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka/client.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka/client_api.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka/errors.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka/resource.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/lib/aws-sdk-kafka/types.rb
+++ b/gems/aws-sdk-kafka/lib/aws-sdk-kafka/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kafka/spec/spec_helper.rb
+++ b/gems/aws-sdk-kafka/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/aws-sdk-kendra.gemspec
+++ b/gems/aws-sdk-kendra/aws-sdk-kendra.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/features/env.rb
+++ b/gems/aws-sdk-kendra/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra/client.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra/client_api.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra/errors.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra/resource.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/lib/aws-sdk-kendra/types.rb
+++ b/gems/aws-sdk-kendra/lib/aws-sdk-kendra/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kendra/spec/spec_helper.rb
+++ b/gems/aws-sdk-kendra/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
+++ b/gems/aws-sdk-kinesis/aws-sdk-kinesis.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/features/env.rb
+++ b/gems/aws-sdk-kinesis/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-kinesis/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client_api.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/errors.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/event_streams.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/event_streams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/resource.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/types.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/waiters.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesis/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesis/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
+++ b/gems/aws-sdk-kinesisanalytics/aws-sdk-kinesisanalytics.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/features/env.rb
+++ b/gems/aws-sdk-kinesisanalytics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client_api.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/errors.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/resource.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/types.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalytics/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisanalytics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
+++ b/gems/aws-sdk-kinesisanalyticsv2/aws-sdk-kinesisanalyticsv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/features/env.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/client.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/client_api.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/errors.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/resource.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/types.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/lib/aws-sdk-kinesisanalyticsv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisanalyticsv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
+++ b/gems/aws-sdk-kinesisvideo/aws-sdk-kinesisvideo.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/features/env.rb
+++ b/gems/aws-sdk-kinesisvideo/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client_api.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/errors.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/resource.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/types.rb
+++ b/gems/aws-sdk-kinesisvideo/lib/aws-sdk-kinesisvideo/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideo/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideo/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/aws-sdk-kinesisvideoarchivedmedia.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/features/env.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client_api.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/errors.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/resource.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/types.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/lib/aws-sdk-kinesisvideoarchivedmedia/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
+++ b/gems/aws-sdk-kinesisvideomedia/aws-sdk-kinesisvideomedia.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/features/env.rb
+++ b/gems/aws-sdk-kinesisvideomedia/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client_api.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/errors.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/resource.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/types.rb
+++ b/gems/aws-sdk-kinesisvideomedia/lib/aws-sdk-kinesisvideomedia/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideomedia/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideomedia/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/aws-sdk-kinesisvideosignalingchannels.gemspec
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/aws-sdk-kinesisvideosignalingchannels.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/features/env.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/client.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/client_api.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/errors.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/resource.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/types.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/lib/aws-sdk-kinesisvideosignalingchannels/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kinesisvideosignalingchannels/spec/spec_helper.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/aws-sdk-kms.gemspec
+++ b/gems/aws-sdk-kms/aws-sdk-kms.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/features/env.rb
+++ b/gems/aws-sdk-kms/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-kms/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/client.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/client_api.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/errors.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/resource.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/types.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-kms/spec/spec_helper.rb
+++ b/gems/aws-sdk-kms/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/aws-sdk-lakeformation.gemspec
+++ b/gems/aws-sdk-lakeformation/aws-sdk-lakeformation.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/features/env.rb
+++ b/gems/aws-sdk-lakeformation/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/client.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/client_api.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/errors.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/resource.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/types.rb
+++ b/gems/aws-sdk-lakeformation/lib/aws-sdk-lakeformation/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lakeformation/spec/spec_helper.rb
+++ b/gems/aws-sdk-lakeformation/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
+++ b/gems/aws-sdk-lambda/aws-sdk-lambda.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/features/env.rb
+++ b/gems/aws-sdk-lambda/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-lambda/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client_api.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/errors.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/resource.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/types.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/waiters.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambda/spec/spec_helper.rb
+++ b/gems/aws-sdk-lambda/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
+++ b/gems/aws-sdk-lambdapreview/aws-sdk-lambdapreview.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/features/env.rb
+++ b/gems/aws-sdk-lambdapreview/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client_api.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/errors.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/resource.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/types.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lambdapreview/spec/spec_helper.rb
+++ b/gems/aws-sdk-lambdapreview/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/aws-sdk-lex.gemspec
+++ b/gems/aws-sdk-lex/aws-sdk-lex.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/features/env.rb
+++ b/gems/aws-sdk-lex/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/client.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/client_api.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/errors.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/resource.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/lib/aws-sdk-lex/types.rb
+++ b/gems/aws-sdk-lex/lib/aws-sdk-lex/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lex/spec/spec_helper.rb
+++ b/gems/aws-sdk-lex/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
+++ b/gems/aws-sdk-lexmodelbuildingservice/aws-sdk-lexmodelbuildingservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/features/env.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client_api.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/errors.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/resource.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/types.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/lib/aws-sdk-lexmodelbuildingservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexmodelbuildingservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
+++ b/gems/aws-sdk-licensemanager/aws-sdk-licensemanager.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/features/env.rb
+++ b/gems/aws-sdk-licensemanager/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/client.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/client_api.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/errors.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/resource.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/types.rb
+++ b/gems/aws-sdk-licensemanager/lib/aws-sdk-licensemanager/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/spec/spec_helper.rb
+++ b/gems/aws-sdk-licensemanager/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
+++ b/gems/aws-sdk-lightsail/aws-sdk-lightsail.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/features/env.rb
+++ b/gems/aws-sdk-lightsail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-lightsail/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client_api.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/errors.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/resource.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/types.rb
+++ b/gems/aws-sdk-lightsail/lib/aws-sdk-lightsail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lightsail/spec/spec_helper.rb
+++ b/gems/aws-sdk-lightsail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
+++ b/gems/aws-sdk-machinelearning/aws-sdk-machinelearning.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/features/env.rb
+++ b/gems/aws-sdk-machinelearning/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client_api.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/errors.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/resource.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/types.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/waiters.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-machinelearning/spec/spec_helper.rb
+++ b/gems/aws-sdk-machinelearning/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/aws-sdk-macie.gemspec
+++ b/gems/aws-sdk-macie/aws-sdk-macie.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/features/env.rb
+++ b/gems/aws-sdk-macie/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie/client.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie/client_api.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie/errors.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie/resource.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/lib/aws-sdk-macie/types.rb
+++ b/gems/aws-sdk-macie/lib/aws-sdk-macie/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie/spec/spec_helper.rb
+++ b/gems/aws-sdk-macie/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/aws-sdk-macie2.gemspec
+++ b/gems/aws-sdk-macie2/aws-sdk-macie2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/features/env.rb
+++ b/gems/aws-sdk-macie2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2/client.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2/client_api.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2/errors.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2/resource.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/lib/aws-sdk-macie2/types.rb
+++ b/gems/aws-sdk-macie2/lib/aws-sdk-macie2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-macie2/spec/spec_helper.rb
+++ b/gems/aws-sdk-macie2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/aws-sdk-managedblockchain.gemspec
+++ b/gems/aws-sdk-managedblockchain/aws-sdk-managedblockchain.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/features/env.rb
+++ b/gems/aws-sdk-managedblockchain/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client_api.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/errors.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/resource.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/types.rb
+++ b/gems/aws-sdk-managedblockchain/lib/aws-sdk-managedblockchain/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-managedblockchain/spec/spec_helper.rb
+++ b/gems/aws-sdk-managedblockchain/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/aws-sdk-marketplacecatalog.gemspec
+++ b/gems/aws-sdk-marketplacecatalog/aws-sdk-marketplacecatalog.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/features/env.rb
+++ b/gems/aws-sdk-marketplacecatalog/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/client.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/client_api.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/errors.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/resource.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/types.rb
+++ b/gems/aws-sdk-marketplacecatalog/lib/aws-sdk-marketplacecatalog/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecatalog/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplacecatalog/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
+++ b/gems/aws-sdk-marketplacecommerceanalytics/aws-sdk-marketplacecommerceanalytics.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/features/env.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client_api.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/errors.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/resource.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/types.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacecommerceanalytics/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
+++ b/gems/aws-sdk-marketplaceentitlementservice/aws-sdk-marketplaceentitlementservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/features/env.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client_api.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/errors.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/resource.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/types.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/lib/aws-sdk-marketplaceentitlementservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplaceentitlementservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
+++ b/gems/aws-sdk-marketplacemetering/aws-sdk-marketplacemetering.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/features/env.rb
+++ b/gems/aws-sdk-marketplacemetering/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client_api.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/errors.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/resource.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/types.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-marketplacemetering/spec/spec_helper.rb
+++ b/gems/aws-sdk-marketplacemetering/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
+++ b/gems/aws-sdk-mediaconnect/aws-sdk-mediaconnect.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/features/env.rb
+++ b/gems/aws-sdk-mediaconnect/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/client.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/client_api.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/errors.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/resource.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/types.rb
+++ b/gems/aws-sdk-mediaconnect/lib/aws-sdk-mediaconnect/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconnect/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediaconnect/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
+++ b/gems/aws-sdk-mediaconvert/aws-sdk-mediaconvert.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/features/env.rb
+++ b/gems/aws-sdk-mediaconvert/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client_api.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/errors.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/resource.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/types.rb
+++ b/gems/aws-sdk-mediaconvert/lib/aws-sdk-mediaconvert/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediaconvert/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediaconvert/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
+++ b/gems/aws-sdk-medialive/aws-sdk-medialive.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/features/env.rb
+++ b/gems/aws-sdk-medialive/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client_api.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/errors.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/resource.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/types.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/lib/aws-sdk-medialive/waiters.rb
+++ b/gems/aws-sdk-medialive/lib/aws-sdk-medialive/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-medialive/spec/spec_helper.rb
+++ b/gems/aws-sdk-medialive/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
+++ b/gems/aws-sdk-mediapackage/aws-sdk-mediapackage.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/features/env.rb
+++ b/gems/aws-sdk-mediapackage/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client_api.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/errors.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/resource.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/types.rb
+++ b/gems/aws-sdk-mediapackage/lib/aws-sdk-mediapackage/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackage/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediapackage/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/aws-sdk-mediapackagevod.gemspec
+++ b/gems/aws-sdk-mediapackagevod/aws-sdk-mediapackagevod.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/features/env.rb
+++ b/gems/aws-sdk-mediapackagevod/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/client.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/client_api.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/errors.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/resource.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/types.rb
+++ b/gems/aws-sdk-mediapackagevod/lib/aws-sdk-mediapackagevod/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediapackagevod/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediapackagevod/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
+++ b/gems/aws-sdk-mediastore/aws-sdk-mediastore.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/features/env.rb
+++ b/gems/aws-sdk-mediastore/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client_api.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/errors.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/resource.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/types.rb
+++ b/gems/aws-sdk-mediastore/lib/aws-sdk-mediastore/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastore/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediastore/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
+++ b/gems/aws-sdk-mediastoredata/aws-sdk-mediastoredata.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/features/env.rb
+++ b/gems/aws-sdk-mediastoredata/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client_api.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/errors.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/resource.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/types.rb
+++ b/gems/aws-sdk-mediastoredata/lib/aws-sdk-mediastoredata/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediastoredata/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediastoredata/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
+++ b/gems/aws-sdk-mediatailor/aws-sdk-mediatailor.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/features/env.rb
+++ b/gems/aws-sdk-mediatailor/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/client.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/client_api.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/errors.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/resource.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/types.rb
+++ b/gems/aws-sdk-mediatailor/lib/aws-sdk-mediatailor/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mediatailor/spec/spec_helper.rb
+++ b/gems/aws-sdk-mediatailor/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
+++ b/gems/aws-sdk-migrationhub/aws-sdk-migrationhub.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/features/env.rb
+++ b/gems/aws-sdk-migrationhub/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client_api.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/errors.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/resource.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/types.rb
+++ b/gems/aws-sdk-migrationhub/lib/aws-sdk-migrationhub/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhub/spec/spec_helper.rb
+++ b/gems/aws-sdk-migrationhub/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/aws-sdk-migrationhubconfig.gemspec
+++ b/gems/aws-sdk-migrationhubconfig/aws-sdk-migrationhubconfig.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/features/env.rb
+++ b/gems/aws-sdk-migrationhubconfig/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/client.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/client_api.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/errors.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/resource.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/types.rb
+++ b/gems/aws-sdk-migrationhubconfig/lib/aws-sdk-migrationhubconfig/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-migrationhubconfig/spec/spec_helper.rb
+++ b/gems/aws-sdk-migrationhubconfig/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
+++ b/gems/aws-sdk-mobile/aws-sdk-mobile.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/features/env.rb
+++ b/gems/aws-sdk-mobile/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client_api.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/errors.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/resource.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/lib/aws-sdk-mobile/types.rb
+++ b/gems/aws-sdk-mobile/lib/aws-sdk-mobile/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mobile/spec/spec_helper.rb
+++ b/gems/aws-sdk-mobile/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/aws-sdk-mq.gemspec
+++ b/gems/aws-sdk-mq/aws-sdk-mq.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/features/env.rb
+++ b/gems/aws-sdk-mq/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/client.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/client_api.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/errors.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/resource.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/lib/aws-sdk-mq/types.rb
+++ b/gems/aws-sdk-mq/lib/aws-sdk-mq/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mq/spec/spec_helper.rb
+++ b/gems/aws-sdk-mq/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
+++ b/gems/aws-sdk-mturk/aws-sdk-mturk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/features/env.rb
+++ b/gems/aws-sdk-mturk/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client_api.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/errors.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/resource.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/lib/aws-sdk-mturk/types.rb
+++ b/gems/aws-sdk-mturk/lib/aws-sdk-mturk/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-mturk/spec/spec_helper.rb
+++ b/gems/aws-sdk-mturk/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
+++ b/gems/aws-sdk-neptune/aws-sdk-neptune.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/features/env.rb
+++ b/gems/aws-sdk-neptune/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-neptune/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client_api.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/errors.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/resource.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/types.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/lib/aws-sdk-neptune/waiters.rb
+++ b/gems/aws-sdk-neptune/lib/aws-sdk-neptune/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-neptune/spec/spec_helper.rb
+++ b/gems/aws-sdk-neptune/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/aws-sdk-networkmanager.gemspec
+++ b/gems/aws-sdk-networkmanager/aws-sdk-networkmanager.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/features/env.rb
+++ b/gems/aws-sdk-networkmanager/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/client.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/client_api.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/errors.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/resource.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/types.rb
+++ b/gems/aws-sdk-networkmanager/lib/aws-sdk-networkmanager/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-networkmanager/spec/spec_helper.rb
+++ b/gems/aws-sdk-networkmanager/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
+++ b/gems/aws-sdk-opsworks/aws-sdk-opsworks.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/features/env.rb
+++ b/gems/aws-sdk-opsworks/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-opsworks/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client_api.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/errors.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/layer.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/layer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/resource.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack_summary.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/stack_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/types.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/waiters.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworks/spec/spec_helper.rb
+++ b/gems/aws-sdk-opsworks/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
+++ b/gems/aws-sdk-opsworkscm/aws-sdk-opsworkscm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/features/env.rb
+++ b/gems/aws-sdk-opsworkscm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client_api.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/errors.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/resource.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/types.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/waiters.rb
+++ b/gems/aws-sdk-opsworkscm/lib/aws-sdk-opsworkscm/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-opsworkscm/spec/spec_helper.rb
+++ b/gems/aws-sdk-opsworkscm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
+++ b/gems/aws-sdk-organizations/aws-sdk-organizations.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/features/env.rb
+++ b/gems/aws-sdk-organizations/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client_api.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/errors.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/resource.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/lib/aws-sdk-organizations/types.rb
+++ b/gems/aws-sdk-organizations/lib/aws-sdk-organizations/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-organizations/spec/spec_helper.rb
+++ b/gems/aws-sdk-organizations/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/aws-sdk-outposts.gemspec
+++ b/gems/aws-sdk-outposts/aws-sdk-outposts.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/features/env.rb
+++ b/gems/aws-sdk-outposts/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts/client.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts/client_api.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts/errors.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts/resource.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/lib/aws-sdk-outposts/types.rb
+++ b/gems/aws-sdk-outposts/lib/aws-sdk-outposts/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-outposts/spec/spec_helper.rb
+++ b/gems/aws-sdk-outposts/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/aws-sdk-personalize.gemspec
+++ b/gems/aws-sdk-personalize/aws-sdk-personalize.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/features/env.rb
+++ b/gems/aws-sdk-personalize/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize/client.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize/client_api.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize/errors.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize/resource.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/lib/aws-sdk-personalize/types.rb
+++ b/gems/aws-sdk-personalize/lib/aws-sdk-personalize/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalize/spec/spec_helper.rb
+++ b/gems/aws-sdk-personalize/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/aws-sdk-personalizeevents.gemspec
+++ b/gems/aws-sdk-personalizeevents/aws-sdk-personalizeevents.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/features/env.rb
+++ b/gems/aws-sdk-personalizeevents/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/client.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/client_api.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/errors.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/resource.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/types.rb
+++ b/gems/aws-sdk-personalizeevents/lib/aws-sdk-personalizeevents/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeevents/spec/spec_helper.rb
+++ b/gems/aws-sdk-personalizeevents/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/aws-sdk-personalizeruntime.gemspec
+++ b/gems/aws-sdk-personalizeruntime/aws-sdk-personalizeruntime.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/features/env.rb
+++ b/gems/aws-sdk-personalizeruntime/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/client.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/client_api.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/errors.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/resource.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/types.rb
+++ b/gems/aws-sdk-personalizeruntime/lib/aws-sdk-personalizeruntime/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-personalizeruntime/spec/spec_helper.rb
+++ b/gems/aws-sdk-personalizeruntime/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/aws-sdk-pi.gemspec
+++ b/gems/aws-sdk-pi/aws-sdk-pi.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/features/env.rb
+++ b/gems/aws-sdk-pi/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi/client.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi/client_api.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi/errors.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi/resource.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/lib/aws-sdk-pi/types.rb
+++ b/gems/aws-sdk-pi/lib/aws-sdk-pi/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pi/spec/spec_helper.rb
+++ b/gems/aws-sdk-pi/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
+++ b/gems/aws-sdk-pinpoint/aws-sdk-pinpoint.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/features/env.rb
+++ b/gems/aws-sdk-pinpoint/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client_api.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/errors.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/resource.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/types.rb
+++ b/gems/aws-sdk-pinpoint/lib/aws-sdk-pinpoint/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpoint/spec/spec_helper.rb
+++ b/gems/aws-sdk-pinpoint/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
+++ b/gems/aws-sdk-pinpointemail/aws-sdk-pinpointemail.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/features/env.rb
+++ b/gems/aws-sdk-pinpointemail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client_api.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/errors.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/resource.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/types.rb
+++ b/gems/aws-sdk-pinpointemail/lib/aws-sdk-pinpointemail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointemail/spec/spec_helper.rb
+++ b/gems/aws-sdk-pinpointemail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
+++ b/gems/aws-sdk-pinpointsmsvoice/aws-sdk-pinpointsmsvoice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/features/env.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/client.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/client_api.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/errors.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/resource.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/types.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/lib/aws-sdk-pinpointsmsvoice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pinpointsmsvoice/spec/spec_helper.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/aws-sdk-polly.gemspec
+++ b/gems/aws-sdk-polly/aws-sdk-polly.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/features/env.rb
+++ b/gems/aws-sdk-polly/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-polly/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/client.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/client_api.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/errors.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/resource.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/types.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-polly/spec/spec_helper.rb
+++ b/gems/aws-sdk-polly/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
+++ b/gems/aws-sdk-pricing/aws-sdk-pricing.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/features/env.rb
+++ b/gems/aws-sdk-pricing/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client_api.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/errors.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/resource.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/lib/aws-sdk-pricing/types.rb
+++ b/gems/aws-sdk-pricing/lib/aws-sdk-pricing/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-pricing/spec/spec_helper.rb
+++ b/gems/aws-sdk-pricing/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/aws-sdk-qldb.gemspec
+++ b/gems/aws-sdk-qldb/aws-sdk-qldb.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/features/env.rb
+++ b/gems/aws-sdk-qldb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb/client.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb/client_api.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb/errors.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb/resource.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/lib/aws-sdk-qldb/types.rb
+++ b/gems/aws-sdk-qldb/lib/aws-sdk-qldb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldb/spec/spec_helper.rb
+++ b/gems/aws-sdk-qldb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/aws-sdk-qldbsession.gemspec
+++ b/gems/aws-sdk-qldbsession/aws-sdk-qldbsession.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/features/env.rb
+++ b/gems/aws-sdk-qldbsession/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/client.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/client_api.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/errors.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/resource.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/types.rb
+++ b/gems/aws-sdk-qldbsession/lib/aws-sdk-qldbsession/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-qldbsession/spec/spec_helper.rb
+++ b/gems/aws-sdk-qldbsession/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
+++ b/gems/aws-sdk-quicksight/aws-sdk-quicksight.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/features/env.rb
+++ b/gems/aws-sdk-quicksight/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/client.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/client_api.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/errors.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/resource.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/types.rb
+++ b/gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-quicksight/spec/spec_helper.rb
+++ b/gems/aws-sdk-quicksight/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/aws-sdk-ram.gemspec
+++ b/gems/aws-sdk-ram/aws-sdk-ram.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/features/env.rb
+++ b/gems/aws-sdk-ram/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram/client.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram/client_api.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram/errors.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram/resource.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/lib/aws-sdk-ram/types.rb
+++ b/gems/aws-sdk-ram/lib/aws-sdk-ram/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ram/spec/spec_helper.rb
+++ b/gems/aws-sdk-ram/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/aws-sdk-rds.gemspec
+++ b/gems/aws-sdk-rds/aws-sdk-rds.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/features/env.rb
+++ b/gems/aws-sdk-rds/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-rds/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/account_quota.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/account_quota.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/certificate.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/client.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_parameter_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_parameter_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_snapshot.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_cluster_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine_version.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_engine_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_instance.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_log_file.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_log_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group_family.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_parameter_group_family.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_security_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_security_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot_attribute.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_snapshot_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/db_subnet_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/db_subnet_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event_category_map.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event_category_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/event_subscription.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/event_subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group_option.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/option_group_option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/parameter.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/parameter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/pending_maintenance_action.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/pending_maintenance_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instance.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instances_offering.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/reserved_db_instances_offering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/resource_pending_maintenance_action_list.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/resource_pending_maintenance_action_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/waiters.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rds/spec/spec_helper.rb
+++ b/gems/aws-sdk-rds/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
+++ b/gems/aws-sdk-rdsdataservice/aws-sdk-rdsdataservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/features/env.rb
+++ b/gems/aws-sdk-rdsdataservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client_api.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/errors.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/resource.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/types.rb
+++ b/gems/aws-sdk-rdsdataservice/lib/aws-sdk-rdsdataservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rdsdataservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-rdsdataservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
+++ b/gems/aws-sdk-redshift/aws-sdk-redshift.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/features/env.rb
+++ b/gems/aws-sdk-redshift/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-redshift/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/resource.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/waiters.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-redshift/spec/spec_helper.rb
+++ b/gems/aws-sdk-redshift/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
+++ b/gems/aws-sdk-rekognition/aws-sdk-rekognition.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/features/env.rb
+++ b/gems/aws-sdk-rekognition/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-rekognition/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/resource.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/waiters.rb
+++ b/gems/aws-sdk-rekognition/lib/aws-sdk-rekognition/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-rekognition/spec/spec_helper.rb
+++ b/gems/aws-sdk-rekognition/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
+++ b/gems/aws-sdk-resourcegroups/aws-sdk-resourcegroups.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/features/env.rb
+++ b/gems/aws-sdk-resourcegroups/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client_api.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/errors.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/resource.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/types.rb
+++ b/gems/aws-sdk-resourcegroups/lib/aws-sdk-resourcegroups/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroups/spec/spec_helper.rb
+++ b/gems/aws-sdk-resourcegroups/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
+++ b/gems/aws-sdk-resourcegroupstaggingapi/aws-sdk-resourcegroupstaggingapi.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/features/env.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client_api.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/errors.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/resource.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/types.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/lib/aws-sdk-resourcegroupstaggingapi/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-resourcegroupstaggingapi/spec/spec_helper.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
+++ b/gems/aws-sdk-robomaker/aws-sdk-robomaker.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/features/env.rb
+++ b/gems/aws-sdk-robomaker/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/client.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/client_api.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/errors.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/resource.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/types.rb
+++ b/gems/aws-sdk-robomaker/lib/aws-sdk-robomaker/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-robomaker/spec/spec_helper.rb
+++ b/gems/aws-sdk-robomaker/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/aws-sdk-route53.gemspec
+++ b/gems/aws-sdk-route53/aws-sdk-route53.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/features/env.rb
+++ b/gems/aws-sdk-route53/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-route53/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/client.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/client_api.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/errors.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/resource.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/types.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/waiters.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53/spec/spec_helper.rb
+++ b/gems/aws-sdk-route53/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
+++ b/gems/aws-sdk-route53domains/aws-sdk-route53domains.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/features/env.rb
+++ b/gems/aws-sdk-route53domains/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-route53domains/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client_api.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/errors.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/resource.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/types.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53domains/spec/spec_helper.rb
+++ b/gems/aws-sdk-route53domains/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
+++ b/gems/aws-sdk-route53resolver/aws-sdk-route53resolver.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/features/env.rb
+++ b/gems/aws-sdk-route53resolver/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-route53resolver/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/client.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/client_api.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/errors.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/resource.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/types.rb
+++ b/gems/aws-sdk-route53resolver/lib/aws-sdk-route53resolver/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-route53resolver/spec/spec_helper.rb
+++ b/gems/aws-sdk-route53resolver/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/aws-sdk-s3.gemspec
+++ b/gems/aws-sdk-s3/aws-sdk-s3.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/features/env.rb
+++ b/gems/aws-sdk-s3/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-s3/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_acl.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_cors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle_configuration.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_lifecycle_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_logging.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_notification.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_policy.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_request_payment.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_request_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_tagging.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_tagging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_versioning.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_versioning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_website.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_website.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/event_streams.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/event_streams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_part.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_acl.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_acl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_version.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/waiters.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3/spec/spec_helper.rb
+++ b/gems/aws-sdk-s3/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
+++ b/gems/aws-sdk-s3control/aws-sdk-s3control.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/features/env.rb
+++ b/gems/aws-sdk-s3control/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/client.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/client_api.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/errors.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/resource.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/types.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-s3control/spec/spec_helper.rb
+++ b/gems/aws-sdk-s3control/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
+++ b/gems/aws-sdk-sagemaker/aws-sdk-sagemaker.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/features/env.rb
+++ b/gems/aws-sdk-sagemaker/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client_api.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/errors.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/resource.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/types.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/waiters.rb
+++ b/gems/aws-sdk-sagemaker/lib/aws-sdk-sagemaker/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemaker/spec/spec_helper.rb
+++ b/gems/aws-sdk-sagemaker/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
+++ b/gems/aws-sdk-sagemakerruntime/aws-sdk-sagemakerruntime.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/features/env.rb
+++ b/gems/aws-sdk-sagemakerruntime/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client_api.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/errors.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/resource.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/types.rb
+++ b/gems/aws-sdk-sagemakerruntime/lib/aws-sdk-sagemakerruntime/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sagemakerruntime/spec/spec_helper.rb
+++ b/gems/aws-sdk-sagemakerruntime/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/aws-sdk-savingsplans.gemspec
+++ b/gems/aws-sdk-savingsplans/aws-sdk-savingsplans.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/features/env.rb
+++ b/gems/aws-sdk-savingsplans/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/client.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/client_api.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/errors.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/resource.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/types.rb
+++ b/gems/aws-sdk-savingsplans/lib/aws-sdk-savingsplans/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-savingsplans/spec/spec_helper.rb
+++ b/gems/aws-sdk-savingsplans/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/aws-sdk-schemas.gemspec
+++ b/gems/aws-sdk-schemas/aws-sdk-schemas.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/features/env.rb
+++ b/gems/aws-sdk-schemas/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/client.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/client_api.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/errors.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/resource.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/types.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/lib/aws-sdk-schemas/waiters.rb
+++ b/gems/aws-sdk-schemas/lib/aws-sdk-schemas/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-schemas/spec/spec_helper.rb
+++ b/gems/aws-sdk-schemas/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
+++ b/gems/aws-sdk-secretsmanager/aws-sdk-secretsmanager.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/features/env.rb
+++ b/gems/aws-sdk-secretsmanager/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-secretsmanager/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/client.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/client_api.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/errors.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/resource.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/types.rb
+++ b/gems/aws-sdk-secretsmanager/lib/aws-sdk-secretsmanager/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-secretsmanager/spec/spec_helper.rb
+++ b/gems/aws-sdk-secretsmanager/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
+++ b/gems/aws-sdk-securityhub/aws-sdk-securityhub.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/features/env.rb
+++ b/gems/aws-sdk-securityhub/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/client.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/client_api.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/errors.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/resource.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/types.rb
+++ b/gems/aws-sdk-securityhub/lib/aws-sdk-securityhub/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-securityhub/spec/spec_helper.rb
+++ b/gems/aws-sdk-securityhub/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
+++ b/gems/aws-sdk-serverlessapplicationrepository/aws-sdk-serverlessapplicationrepository.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/features/env.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client_api.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/errors.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/resource.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/types.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/lib/aws-sdk-serverlessapplicationrepository/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-serverlessapplicationrepository/spec/spec_helper.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
+++ b/gems/aws-sdk-servicecatalog/aws-sdk-servicecatalog.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/features/env.rb
+++ b/gems/aws-sdk-servicecatalog/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-servicecatalog/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/resource.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicecatalog/spec/spec_helper.rb
+++ b/gems/aws-sdk-servicecatalog/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
+++ b/gems/aws-sdk-servicediscovery/aws-sdk-servicediscovery.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/features/env.rb
+++ b/gems/aws-sdk-servicediscovery/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client_api.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/errors.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/resource.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/types.rb
+++ b/gems/aws-sdk-servicediscovery/lib/aws-sdk-servicediscovery/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicediscovery/spec/spec_helper.rb
+++ b/gems/aws-sdk-servicediscovery/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/aws-sdk-servicequotas.gemspec
+++ b/gems/aws-sdk-servicequotas/aws-sdk-servicequotas.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/features/env.rb
+++ b/gems/aws-sdk-servicequotas/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/client.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/client_api.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/errors.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/resource.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/types.rb
+++ b/gems/aws-sdk-servicequotas/lib/aws-sdk-servicequotas/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-servicequotas/spec/spec_helper.rb
+++ b/gems/aws-sdk-servicequotas/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/aws-sdk-ses.gemspec
+++ b/gems/aws-sdk-ses/aws-sdk-ses.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/features/env.rb
+++ b/gems/aws-sdk-ses/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-ses/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/client.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/resource.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/waiters.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ses/spec/spec_helper.rb
+++ b/gems/aws-sdk-ses/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/aws-sdk-sesv2.gemspec
+++ b/gems/aws-sdk-sesv2/aws-sdk-sesv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/features/env.rb
+++ b/gems/aws-sdk-sesv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client_api.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/errors.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/resource.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/types.rb
+++ b/gems/aws-sdk-sesv2/lib/aws-sdk-sesv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sesv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-sesv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/aws-sdk-shield.gemspec
+++ b/gems/aws-sdk-shield/aws-sdk-shield.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/features/env.rb
+++ b/gems/aws-sdk-shield/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-shield/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/client.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/client_api.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/errors.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/resource.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/lib/aws-sdk-shield/types.rb
+++ b/gems/aws-sdk-shield/lib/aws-sdk-shield/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-shield/spec/spec_helper.rb
+++ b/gems/aws-sdk-shield/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/aws-sdk-signer.gemspec
+++ b/gems/aws-sdk-signer/aws-sdk-signer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/features/env.rb
+++ b/gems/aws-sdk-signer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/client.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/client_api.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/errors.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/resource.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/types.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/lib/aws-sdk-signer/waiters.rb
+++ b/gems/aws-sdk-signer/lib/aws-sdk-signer/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-signer/spec/spec_helper.rb
+++ b/gems/aws-sdk-signer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
+++ b/gems/aws-sdk-simpledb/aws-sdk-simpledb.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/features/env.rb
+++ b/gems/aws-sdk-simpledb/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client_api.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/errors.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/resource.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/types.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-simpledb/spec/spec_helper.rb
+++ b/gems/aws-sdk-simpledb/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/aws-sdk-sms.gemspec
+++ b/gems/aws-sdk-sms/aws-sdk-sms.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/features/env.rb
+++ b/gems/aws-sdk-sms/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-sms/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/client.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/resource.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sms/spec/spec_helper.rb
+++ b/gems/aws-sdk-sms/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
+++ b/gems/aws-sdk-snowball/aws-sdk-snowball.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/features/env.rb
+++ b/gems/aws-sdk-snowball/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-snowball/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client_api.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/errors.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/resource.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/types.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-snowball/spec/spec_helper.rb
+++ b/gems/aws-sdk-snowball/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/aws-sdk-sns.gemspec
+++ b/gems/aws-sdk-sns/aws-sdk-sns.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/features/env.rb
+++ b/gems/aws-sdk-sns/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-sns/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/client.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/client_api.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/errors.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_application.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_endpoint.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/platform_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/resource.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/subscription.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/topic.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/topic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/types.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sns/spec/spec_helper.rb
+++ b/gems/aws-sdk-sns/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
+++ b/gems/aws-sdk-sqs/aws-sdk-sqs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/features/env.rb
+++ b/gems/aws-sdk-sqs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-sqs/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/message.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/resource.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sqs/spec/spec_helper.rb
+++ b/gems/aws-sdk-sqs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
+++ b/gems/aws-sdk-ssm/aws-sdk-ssm.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/features/env.rb
+++ b/gems/aws-sdk-ssm/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-ssm/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/resource.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssm/spec/spec_helper.rb
+++ b/gems/aws-sdk-ssm/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/aws-sdk-sso.gemspec
+++ b/gems/aws-sdk-sso/aws-sdk-sso.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/features/env.rb
+++ b/gems/aws-sdk-sso/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/client.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/client_api.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/errors.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/resource.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/types.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-sso/spec/spec_helper.rb
+++ b/gems/aws-sdk-sso/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/aws-sdk-ssooidc.gemspec
+++ b/gems/aws-sdk-ssooidc/aws-sdk-ssooidc.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/features/env.rb
+++ b/gems/aws-sdk-ssooidc/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/client.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/client_api.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/errors.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/resource.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/types.rb
+++ b/gems/aws-sdk-ssooidc/lib/aws-sdk-ssooidc/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-ssooidc/spec/spec_helper.rb
+++ b/gems/aws-sdk-ssooidc/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/aws-sdk-states.gemspec
+++ b/gems/aws-sdk-states/aws-sdk-states.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/features/env.rb
+++ b/gems/aws-sdk-states/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-states/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/client.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/client_api.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/errors.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/resource.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/lib/aws-sdk-states/types.rb
+++ b/gems/aws-sdk-states/lib/aws-sdk-states/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-states/spec/spec_helper.rb
+++ b/gems/aws-sdk-states/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
+++ b/gems/aws-sdk-storagegateway/aws-sdk-storagegateway.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/features/env.rb
+++ b/gems/aws-sdk-storagegateway/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client_api.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/errors.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/resource.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/types.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-storagegateway/spec/spec_helper.rb
+++ b/gems/aws-sdk-storagegateway/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/aws-sdk-support.gemspec
+++ b/gems/aws-sdk-support/aws-sdk-support.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/features/env.rb
+++ b/gems/aws-sdk-support/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-support/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/client.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/client_api.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/errors.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/resource.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/lib/aws-sdk-support/types.rb
+++ b/gems/aws-sdk-support/lib/aws-sdk-support/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-support/spec/spec_helper.rb
+++ b/gems/aws-sdk-support/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/aws-sdk-swf.gemspec
+++ b/gems/aws-sdk-swf/aws-sdk-swf.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/features/env.rb
+++ b/gems/aws-sdk-swf/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/client.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/client_api.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/errors.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/resource.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/types.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-swf/spec/spec_helper.rb
+++ b/gems/aws-sdk-swf/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/aws-sdk-synthetics.gemspec
+++ b/gems/aws-sdk-synthetics/aws-sdk-synthetics.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/features/env.rb
+++ b/gems/aws-sdk-synthetics/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/client.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/client_api.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/errors.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/resource.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/types.rb
+++ b/gems/aws-sdk-synthetics/lib/aws-sdk-synthetics/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-synthetics/spec/spec_helper.rb
+++ b/gems/aws-sdk-synthetics/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/aws-sdk-textract.gemspec
+++ b/gems/aws-sdk-textract/aws-sdk-textract.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/features/env.rb
+++ b/gems/aws-sdk-textract/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/client.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/client_api.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/errors.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/resource.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/lib/aws-sdk-textract/types.rb
+++ b/gems/aws-sdk-textract/lib/aws-sdk-textract/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-textract/spec/spec_helper.rb
+++ b/gems/aws-sdk-textract/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
+++ b/gems/aws-sdk-transcribeservice/aws-sdk-transcribeservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/features/env.rb
+++ b/gems/aws-sdk-transcribeservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client_api.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/errors.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/resource.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/types.rb
+++ b/gems/aws-sdk-transcribeservice/lib/aws-sdk-transcribeservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribeservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-transcribeservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/aws-sdk-transcribestreamingservice.gemspec
+++ b/gems/aws-sdk-transcribestreamingservice/aws-sdk-transcribestreamingservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/features/env.rb
+++ b/gems/aws-sdk-transcribestreamingservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/client.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/client_api.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/errors.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/event_streams.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/event_streams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/resource.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/types.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transcribestreamingservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-transcribestreamingservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
+++ b/gems/aws-sdk-transfer/aws-sdk-transfer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/features/env.rb
+++ b/gems/aws-sdk-transfer/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer/client.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer/client_api.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer/errors.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer/resource.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/lib/aws-sdk-transfer/types.rb
+++ b/gems/aws-sdk-transfer/lib/aws-sdk-transfer/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-transfer/spec/spec_helper.rb
+++ b/gems/aws-sdk-transfer/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/aws-sdk-translate.gemspec
+++ b/gems/aws-sdk-translate/aws-sdk-translate.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/features/env.rb
+++ b/gems/aws-sdk-translate/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/client.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/client_api.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/errors.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/resource.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/lib/aws-sdk-translate/types.rb
+++ b/gems/aws-sdk-translate/lib/aws-sdk-translate/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-translate/spec/spec_helper.rb
+++ b/gems/aws-sdk-translate/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/aws-sdk-waf.gemspec
+++ b/gems/aws-sdk-waf/aws-sdk-waf.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/features/env.rb
+++ b/gems/aws-sdk-waf/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-waf/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/client.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/resource.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
+++ b/gems/aws-sdk-waf/lib/aws-sdk-waf/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-waf/spec/spec_helper.rb
+++ b/gems/aws-sdk-waf/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
+++ b/gems/aws-sdk-wafregional/aws-sdk-wafregional.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/features/env.rb
+++ b/gems/aws-sdk-wafregional/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-wafregional/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/resource.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
+++ b/gems/aws-sdk-wafregional/lib/aws-sdk-wafregional/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafregional/spec/spec_helper.rb
+++ b/gems/aws-sdk-wafregional/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/aws-sdk-wafv2.gemspec
+++ b/gems/aws-sdk-wafv2/aws-sdk-wafv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/features/env.rb
+++ b/gems/aws-sdk-wafv2/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-wafv2/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/client.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/client_api.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/errors.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/resource.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/types.rb
+++ b/gems/aws-sdk-wafv2/lib/aws-sdk-wafv2/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-wafv2/spec/spec_helper.rb
+++ b/gems/aws-sdk-wafv2/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
+++ b/gems/aws-sdk-workdocs/aws-sdk-workdocs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/features/env.rb
+++ b/gems/aws-sdk-workdocs/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/resource.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
+++ b/gems/aws-sdk-workdocs/lib/aws-sdk-workdocs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workdocs/spec/spec_helper.rb
+++ b/gems/aws-sdk-workdocs/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
+++ b/gems/aws-sdk-worklink/aws-sdk-worklink.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/features/env.rb
+++ b/gems/aws-sdk-worklink/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink/client.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink/client_api.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink/errors.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink/resource.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/lib/aws-sdk-worklink/types.rb
+++ b/gems/aws-sdk-worklink/lib/aws-sdk-worklink/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-worklink/spec/spec_helper.rb
+++ b/gems/aws-sdk-worklink/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
+++ b/gems/aws-sdk-workmail/aws-sdk-workmail.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/features/env.rb
+++ b/gems/aws-sdk-workmail/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client_api.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/errors.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/resource.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/lib/aws-sdk-workmail/types.rb
+++ b/gems/aws-sdk-workmail/lib/aws-sdk-workmail/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmail/spec/spec_helper.rb
+++ b/gems/aws-sdk-workmail/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/aws-sdk-workmailmessageflow.gemspec
+++ b/gems/aws-sdk-workmailmessageflow/aws-sdk-workmailmessageflow.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/features/env.rb
+++ b/gems/aws-sdk-workmailmessageflow/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/client.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/client_api.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/errors.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/resource.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/types.rb
+++ b/gems/aws-sdk-workmailmessageflow/lib/aws-sdk-workmailmessageflow/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workmailmessageflow/spec/spec_helper.rb
+++ b/gems/aws-sdk-workmailmessageflow/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
+++ b/gems/aws-sdk-workspaces/aws-sdk-workspaces.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/features/env.rb
+++ b/gems/aws-sdk-workspaces/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-workspaces/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client_api.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/errors.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/resource.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/types.rb
+++ b/gems/aws-sdk-workspaces/lib/aws-sdk-workspaces/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-workspaces/spec/spec_helper.rb
+++ b/gems/aws-sdk-workspaces/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/aws-sdk-xray.gemspec
+++ b/gems/aws-sdk-xray/aws-sdk-xray.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/features/env.rb
+++ b/gems/aws-sdk-xray/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/client.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/client_api.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/errors.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/resource.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/lib/aws-sdk-xray/types.rb
+++ b/gems/aws-sdk-xray/lib/aws-sdk-xray/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-xray/spec/spec_helper.rb
+++ b/gems/aws-sdk-xray/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:


### PR DESCRIPTION
### Context

We profile the memory usage of our application on a regular basis using `memory_profiler`, and while it probably doesn't amount to much in total, the `aws-sdk` gems is resposible for a lot of noise in the reports. Just a couple examples but there are lots of these:

```
 314  "header"
   1  /tmp/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.65.0/lib/aws-sdk-s3/client_api.rb:1080
   .... snip 305 lines of aws-sdk-s3/client_api.rb
   1  /tmp/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.65.0/lib/aws-sdk-s3/client_api.rb:886
   1  /tmp/bundle/ruby/2.7.0/gems/bootsnap-1.4.6/lib/bootsnap/compile_cache/iseq.rb:19
   1  /tmp/bundle/ruby/2.7.0/gems/fastly-2.5.2/lib/fastly/util.rb:6
   1  /tmp/bundle/ruby/2.7.0/gems/kramdown-1.13.2/lib/kramdown/parser/html.rb:200
   1  /tmp/bundle/ruby/2.7.0/gems/kramdown-1.13.2/lib/kramdown/parser/html.rb:202
   1  /tmp/bundle/ruby/2.7.0/gems/kramdown-1.13.2/lib/kramdown/parser/html.rb:205
   1  /tmp/bundle/ruby/2.7.0/gems/kramdown-1.13.2/lib/kramdown/parser/html.rb:38
   1  /tmp/bundle/ruby/2.7.0/gems/kramdown-1.13.2/lib/kramdown/parser/html.rb:59
 
 112  "uri"
   1  /tmp/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.65.0/lib/aws-sdk-s3/client_api.rb:1005
   .... snip 110 lines of aws-sdk-s3/client_api.rb
   1  /tmp/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.65.0/lib/aws-sdk-s3/client_api.rb:1011
```

In the end 300 instances of `"header"` is about 12KB of memory usage, not a lot, but it's also super easy to fix, and it adds on.

### This PR

I simply edited the code generator templates to prepend `# frozen_string_literal: true` and then ran `rubocop -a --only Style/FrozenStringLiteralComment`. I fully expect CI to fail in various ways, but it will probably be easy to fix in followup commits.

And regardless I wanted to open the discussion on this change. 