### PR TITLE
Bump dependency of sigv4 for latest eventstream

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Bump `aws-eventstream` dependency to `~> 1`.
+
 1.1.4 (2020-05-28)
 ------------------
 
@@ -51,4 +53,3 @@ Unreleased Changes
 ------------------
 
 * Feature - Initial release of the `aws-sigv4` gem.
-

--- a/gems/aws-sigv4/aws-sigv4.gemspec
+++ b/gems/aws-sigv4/aws-sigv4.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['lib/**/*.rb']
 
-  spec.add_dependency('aws-eventstream', '~> 1.0', '>= 1.0.2') # For signning event stream events
+  spec.add_dependency('aws-eventstream', '~> 1', '>= 1.0.2') # For signing event stream events
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sigv4',


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.