### PR TITLE
Add frozen_string_literals comment in aws-sdk-s3

### DIFF
--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -13,9 +13,9 @@ def whitelist
       'stub_responses.rb' => 19
     },
     's3' => {
-      'location_constraint.rb' => 12,
-      'bucket.rb' => 145,
-      'presigned_post.rb' => 587,
+      'location_constraint.rb' => 14,
+      'bucket.rb' => 147,
+      'presigned_post.rb' => 589,
       'iad_regional_endpoint.rb' => 'SKIP_FILE'
     },
     's3control' => {

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_region_cache.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/bucket_region_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-s3/bucket_region_cache'
 require 'aws-sdk-s3/encryption'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/bucket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/multipart_upload.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/multipart_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class MultipartUpload

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class Object

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object_summary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class ObjectSummary

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/list_object_versions_output.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/list_object_versions_output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aws::S3::Types::ListObjectVersionsOutput
 
   # TODO : Remove this customization once the resource code

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-s3/encryption/client'
 require 'aws-sdk-s3/encryption/decrypt_handler'
 require 'aws-sdk-s3/encryption/default_cipher_provider'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/decrypt_handler.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/decrypt_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_cipher_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_cipher_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_key_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/default_key_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/encrypt_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_auth_decrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_decrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_decrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/io_encrypter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/key_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/key_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Encryption

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/kms_cipher_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/kms_cipher_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/materials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryption/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'thread'
 require 'set'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_part.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/legacy_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/legacy_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'time'
 require 'openssl'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'set'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'set'
 require 'tempfile'

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_error.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_upload_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class MultipartUploadError < StandardError

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_copier.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_copier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/object_multipart_copier.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/object_multipart_copier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'cgi'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_arn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_dns.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_dns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_name_restrictions.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/bucket_name_restrictions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/dualstack.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/dualstack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/expect_100_continue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/http_200_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/location_constraint.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/location_constraint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/redirects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_host_id.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_host_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     module Plugins

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/s3_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/sse_cpk.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/sse_cpk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'openssl'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/url_encoded_keys.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/url_encoded_keys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'cgi'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigned_post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3
     class Presigner


### PR DESCRIPTION
Followup: https://github.com/aws/aws-sdk-ruby/pull/2328

As discussed here's a followup PR for some of the manually written code.

I simply ran:

```bash
rubocop -a --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment gems/aws-sdk-s3/lib/
```