### PR TITLE
Add frozen_string_literals comment aws-sdk-dynamodb*

### DIFF
--- a/gems/aws-sdk-dynamodb/features/step_definitions.rb
+++ b/gems/aws-sdk-dynamodb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dynamodb") do
   @service = Aws::DynamoDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bigdecimal'
 require 'stringio'
 require 'set'

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-dynamodb/attribute_value'
 

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     class Client

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/crc32_validation.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/crc32_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module DynamoDB
     module Plugins

--- a/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/attribute_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'bigdecimal'
 require 'set'

--- a/gems/aws-sdk-dynamodb/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'zlib'
 

--- a/gems/aws-sdk-dynamodbstreams/features/step_definitions.rb
+++ b/gems/aws-sdk-dynamodbstreams/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dynamodbstreams") do
   @service = Aws::DynamoDBStreams::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
@@ -1,7 +1,0 @@
-# WARNING ABOUT GENERATED CODE
-#
-# This file is generated. See the contributing for info on making contributions:
-# https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md
-#
-# WARNING ABOUT GENERATED CODE
-


### PR DESCRIPTION
Followup: https://github.com/aws/aws-sdk-ruby/pull/2328

As discussed here's a followup PR for some of the manually written code.

I simply ran:

```bash
rubocop -a --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment gems/aws-sdk-dynamo*/lib
```