### PR TITLE
Add frozen_string_literals comment in aws-sdk-core

### DIFF
--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -9,8 +9,8 @@ def whitelist
   {
     'core' => {
       'errors.rb' => 'SKIP_FILE',
-      'signature_v4.rb' => 35,
-      'stub_responses.rb' => 19
+      'signature_v4.rb' => 37,
+      'stub_responses.rb' => 21
     },
     's3' => {
       'location_constraint.rb' => 14,

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
 
   spec.name          = 'aws-sdk-core'

--- a/gems/aws-sdk-core/features/env.rb
+++ b/gems/aws-sdk-core/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-core/features/features_helper.rb
+++ b/gems/aws-sdk-core/features/features_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../../lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv4/lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-eventstream/lib',  __FILE__))

--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-partitions'
 require 'seahorse'
 require 'jmespath'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # Create and provide access to components of Amazon Resource Names (ARN).
   #

--- a/gems/aws-sdk-core/lib/aws-sdk-core/arn_parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/arn_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module ARNParser
     # Parse a string with an ARN format into an {Aws::ARN} object.

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'securerandom'
 require 'base64'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/async_client_stubs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module AsyncClientStubs 
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'binary/decode_handler'
 require_relative 'binary/encode_handler'
 require_relative 'binary/event_stream_decoder'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/decode_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/decode_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Binary
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/encode_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/encode_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Binary
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Binary
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Binary
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_stream_decoder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_stream_decoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-eventstream'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_stream_encoder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/binary/event_stream_encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-eventstream'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/publisher.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/publisher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'socket'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/request_metrics.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_side_monitoring/request_metrics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module ClientSideMonitoring
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module CredentialProvider
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class CredentialProviderChain

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   class Credentials
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/deprecations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # A utility module that provides a class method that wraps

--- a/gems/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'time'
 require 'net/http'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/endpoint_cache.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/endpoint_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   # a LRU cache caching endpoints data

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Errors
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/event_emitter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/event_emitter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   class EventEmitter
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ini_parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ini_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class IniParser

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'time'
 require 'net/http'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require_relative 'json/builder'
 require_relative 'json/error_handler'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class ErrorHandler < Xml::ErrorHandler

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class Handler < Seahorse::Client::Handler

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class OjEngine

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Json
     class JSONEngine

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'time'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Logging

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'set'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
 
   # Decorates a {Seahorse::Client::Response} with paging convenience methods.

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jmespath'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'date'
 require 'time'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class ParamValidator

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/api_key.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/api_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_authorizer_token.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_authorizer_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_credentials_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_credentials_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Plugins

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_user_agent.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/apig_user_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_plugin.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 require_relative 'retries/error_inspector'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_send_plugin.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/client_metrics_send_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/credentials_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/credentials_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Plugins

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_discovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_pattern.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/endpoint_pattern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/event_stream_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/event_stream_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/global_configuration.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/global_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/helpful_socket_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/http_checksum.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/http_checksum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/idempotency_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/invocation_id.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/invocation_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/jsonvalue_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/jsonvalue_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @see Log::Formatter

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_converter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/param_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/api_gateway.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/api_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../query'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/json_rpc.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/json_rpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../query'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/protocols/rest_xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/client_rate_limiter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/client_rate_limiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Retries

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/clock_skew.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/clock_skew.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Retries

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/error_inspector.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/error_inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Retries

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/retry_quota.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retries/retry_quota.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     module Retries

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require_relative 'retries/error_inspector'
 require_relative 'retries/retry_quota'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/transfer_encoding.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/transfer_encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/user_agent.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/user_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Plugins
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'query/ec2_param_builder'
 require_relative 'query/handler'
 require_relative 'query/param'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/ec2_param_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/ec2_param_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Query

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Query
     class Param

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/query/param_list.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/query/param_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/resources/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Resources
     class Collection

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rest/handler'
 require_relative 'rest/request/body'
 require_relative 'rest/request/builder'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Rest

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/body.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/headers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 require 'base64'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/request/querystring_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Request

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/body.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/body.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 require 'base64'
 require 'json'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/status_code.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/status_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Rest
     module Response

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class SharedConfig

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'ini_parser'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Structure

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/data_applicator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/data_applicator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class DataApplicator

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/empty_stub.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/empty_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class EmptyStub

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/api_gateway.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/api_gateway.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/ec2.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/ec2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-eventstream'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     module Protocols

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/stub_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Stubbing

--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/xml_error.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/xml_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Stubbing
     class XmlError

--- a/gems/aws-sdk-core/lib/aws-sdk-core/type_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/type_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   class TypeBuilder

--- a/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'waiters/errors'
 require_relative 'waiters/poller'
 require_relative 'waiters/waiter'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
     module Errors

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/waiter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Waiters
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'xml/builder'
 require_relative 'xml/default_list'
 require_relative 'xml/default_map'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_list.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_map.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/default_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     # @api private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     class DocBuilder

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   # @api private
   module Xml

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/libxml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/libxml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'libxml'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/nokogiri.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/nokogiri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/oga.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/oga.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'oga'
 
 module Aws

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ox'
 require 'stringio'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/rexml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 require 'rexml/streamlistener'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'time'
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/parsing_error.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/parsing_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     class Parser

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/stack.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Xml
     class Parser

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/customizations.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-sts/presigner'

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/plugins/sts_regional_endpoints.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/plugins/sts_regional_endpoints.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module STS
     module Plugins

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/presigner.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/presigner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-core/lib/seahorse.rb
+++ b/gems/aws-sdk-core/lib/seahorse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'seahorse/util'
 
 # client

--- a/gems/aws-sdk-core/lib/seahorse/client/async_base.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/async_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class AsyncBase < Seahorse::Client::Base

--- a/gems/aws-sdk-core/lib/seahorse/client/async_response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/async_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class AsyncResponse

--- a/gems/aws-sdk-core/lib/seahorse/client/base.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/block_io.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/block_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class BlockIO

--- a/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/events.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module EventEmitter

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION >= '2.1'
   begin
     require 'http/2'

--- a/gems/aws-sdk-core/lib/seahorse/client/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Handler

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_builder.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
 

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'set'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/handler_list_entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
 

--- a/gems/aws-sdk-core/lib/seahorse/client/http/async_response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/async_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Http

--- a/gems/aws-sdk-core/lib/seahorse/client/http/headers.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Http

--- a/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'uri'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/http/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Http

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/logging/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/logging/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     # @deprecated Use Aws::Logging instead.

--- a/gems/aws-sdk-core/lib/seahorse/client/managed_file.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/managed_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     # This utility class is used to track files opened by Seahorse.

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 require 'net/http'
 require 'net/https'

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/https'
 require 'openssl'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/networking_error.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/networking_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class NetworkingError < StandardError

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Plugin

--- a/gems/aws-sdk-core/lib/seahorse/client/plugin_list.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugin_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'thread'
 

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/endpoint.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/h2.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/h2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'seahorse/client/h2/handler'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/logging.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/net_http.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/net_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'seahorse/client/net_http/handler'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/operation_methods.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/operation_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/raise_response_errors.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/raise_response_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     module Plugins

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/response_target.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/response_target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/request.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Client
     class Request

--- a/gems/aws-sdk-core/lib/seahorse/client/request_context.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/request_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/client/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/model/api.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Api

--- a/gems/aws-sdk-core/lib/seahorse/model/authorizer.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/authorizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Authorizer

--- a/gems/aws-sdk-core/lib/seahorse/model/operation.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   module Model
     class Operation

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/util.rb
+++ b/gems/aws-sdk-core/lib/seahorse/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Seahorse

--- a/gems/aws-sdk-core/lib/seahorse/version.rb
+++ b/gems/aws-sdk-core/lib/seahorse/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Seahorse
   VERSION = '0.1.0'
 end

--- a/gems/aws-sdk-core/spec/api_helper.rb
+++ b/gems/aws-sdk-core/spec/api_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module ApiHelper

--- a/gems/aws-sdk-core/spec/aws/arn_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/arn_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/arn_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/arn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_metrics/publisher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'securerandom'
 

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/empty_structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/empty_structure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/endpoint_cache_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/endpoint_cache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/json/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/json/error_handler_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/error_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/json/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'base64'
 require 'time'

--- a/gems/aws-sdk-core/spec/aws/json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'pathname'
 

--- a/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/param_converter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/client_metrics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/endpoint_discovery_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/endpoint_pattern_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/endpoint_pattern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/global_configuration_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/global_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/aws/plugins/regional_endpoint_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/regional_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/plugins/retries/client_rate_limiter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retries/client_rate_limiter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require_relative '../../../support/retry_errors_helper'
 

--- a/gems/aws-sdk-core/spec/aws/plugins/retries/clock_skew_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retries/clock_skew_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require_relative '../../../spec_helper'
 require_relative '../../../support/retry_errors_helper'

--- a/gems/aws-sdk-core/spec/aws/plugins/retries/error_inspector_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retries/error_inspector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require_relative '../../../support/retry_errors_helper'
 

--- a/gems/aws-sdk-core/spec/aws/plugins/retries/retry_quota_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retries/retry_quota_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require_relative '../../../spec_helper'
 require_relative '../../../support/retry_errors_helper'

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_legacy_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_legacy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_relative '../../support/retry_errors_helper'
 

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_relative '../../support/retry_errors_helper'
 

--- a/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/ec2_param_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/ec2_param_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_list_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/query/param_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/query/param_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/resources/collection_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/resources/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerable
   class Enumerator; end
 end

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/sts/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sts/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/sts/presigner_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sts/presigner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/sts/sts_regional_endpoints_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sts/sts_regional_endpoints_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/ec2_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'rexml/document'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_json_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/protocols/rest_xml_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'json'
 

--- a/gems/aws-sdk-core/spec/aws/waiters_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/waiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/error_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'time'
 

--- a/gems/aws-sdk-core/spec/aws_spec.rb
+++ b/gems/aws-sdk-core/spec/aws_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 require 'pathname'

--- a/gems/aws-sdk-core/spec/fixtures/example.com/plugin.rb
+++ b/gems/aws-sdk-core/spec/fixtures/example.com/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YellowSeahorseFixtures
   class Plugin
   end

--- a/gems/aws-sdk-core/spec/fixtures/plugin.rb
+++ b/gems/aws-sdk-core/spec/fixtures/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SeahorseFixtures
   class Plugin
   end

--- a/gems/aws-sdk-core/spec/seahorse/client/async_base_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/async_base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/async_response_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/async_response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/base_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/configuration_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/h2/connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/h2/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/h2/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/http/headers_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/headers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/http/request_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/http/response_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/http/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'pathname'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/logging/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require 'logger'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'ostruct'
 require 'stringio'

--- a/gems/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugin_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugin_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'ostruct'
 

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/content_length_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/content_length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/endpoint_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/h2_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/h2_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/logging_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/logging_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/plugins/net_http_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/plugins/net_http_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/request_context_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/request_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'tempfile'
 require 'pathname'

--- a/gems/aws-sdk-core/spec/seahorse/client/response_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'pp'
 

--- a/gems/aws-sdk-core/spec/seahorse/model/api_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/authorizer_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/authorizer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/operation_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 module Seahorse

--- a/gems/aws-sdk-core/spec/seahorse/model/shapes_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/model/shapes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'set'
 

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../../lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv2/lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-sigv4/lib',  __FILE__))

--- a/gems/aws-sdk-core/spec/spec_helper.rb
+++ b/gems/aws-sdk-core/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared_spec_helper'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
+++ b/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RetryErrorsSvc = ApiHelper.sample_service
 
 # Sets up the handler to run retry tests


### PR DESCRIPTION
Followup: https://github.com/aws/aws-sdk-ruby/pull/2328

As discussed here's a followup PR for some of the manually written code.

I simply ran:

```bash
rubocop -a --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment gems/aws-sdk-core/
```

I also adjusted the line numbers in `region_spec.rb`.

That's pretty much the last big gem remaining, after that it's a couple files per gem.

@mullermp 