### PR TITLE
Add the last missing frozen_string_literals comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 if RUBY_VERSION == '1.9.3'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $REPO_ROOT = File.dirname(__FILE__)
 $GEMS_DIR = "#{$REPO_ROOT}/gems"
 $CORE_LIB = "#{$REPO_ROOT}/gems/aws-sdk-core/lib"

--- a/build_tools/aws-sdk-code-generator/aws-sdk-code-generator.gemspec
+++ b/build_tools/aws-sdk-code-generator/aws-sdk-code-generator.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'aws-sdk-code-generator'
   spec.version       = '0.1.0.pre'

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sdk-code-generator/api'
 require_relative 'aws-sdk-code-generator/apply_docs'
 require_relative 'aws-sdk-code-generator/client_constructor'

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Api
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/apply_docs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ApplyDocs
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_constructor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientConstructor
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientOperationDocumentation
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ClientOperationList
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_response_structure_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/code_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class CodeBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/crosslink.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/crosslink.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Crosslink
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/docstring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # kramdown
 require 'kramdown'
 # end kramdown

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ErrorList
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/errors.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Errors
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/eventstream_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/eventstream_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class EventStreamExample
     

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/gem_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/gem_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class GemBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/hash_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class HashFormatter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 # kramdown
 require 'kramdown'

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class PluginList
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAction
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_action_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceActionCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_attribute.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceAttribute
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchAction
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchActionCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_action_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBatchActionDocumentation
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_batch_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_builder.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceBuilder
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceClientRequest
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_params.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_client_request_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceClientRequestParams < String
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_data_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_data_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceDataMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasManyAssociation
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association_code.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_has_many_association_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceHasManyAssociationCode
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifier.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceIdentifier
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifiers_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_identifiers_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceIdentifiersMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_load_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_load_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceLoadMethod
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_method.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceMethod
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_skip_params.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_skip_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceSkipParams
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_value_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceValueSource < String
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_waiter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/resource_waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class ResourceWaiter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class Service
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/shared_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/shared_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class SharedExample
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example_hash.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/syntax_example_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/underscore.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/underscore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Underscore
     class << self

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/view.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mustache'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gemspec'
 
 module Views; end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_endpoint_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_endpoint_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_readme.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/apig_readme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class APIGReadme < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/async_client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/async_client_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class AsyncClientClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/authorizer_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/authorizer_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ClientApiModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ClientClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/docstring.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/docstring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ErrorsModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/event_streams_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/event_streams_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class EventStreamsModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/env.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/smoke.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/smoke.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/smoke_step_definitions.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/step_definitions.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Features

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class Gemspec < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/resource_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class ResourceClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/root_resource_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/root_resource_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class RootResourceClass < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/service_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/service_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/spec_helper.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     module Spec

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/version.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class Version < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/waiters_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/waiters_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   module Views
     class WaitersModule < View

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/waiter.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class Waiter
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/yard_option_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AwsSdkCodeGenerator
   class YardOptionTag
 

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/hash_formatter_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/hash_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/shared_example_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/shared_example_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/syntax_example_hash.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/syntax_example_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/underscore_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/aws-sdk-code-generator/underscore_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module AwsSdkCodeGenerator

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/async_client_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/async_client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/event_stream_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/event_stream_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/idempotency_tokens_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/idempotency_tokens_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/jsonvalue_converter_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/jsonvalue_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/query_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/streaming_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/streaming_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/transfer_encoding_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/transfer_encoding_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Client Interface:' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/errors_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'Interfaces' do

--- a/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/resources_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'Interfaces' do

--- a/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'rexml/document'
 

--- a/build_tools/aws-sdk-code-generator/spec/spec_helper.rb
+++ b/build_tools/aws-sdk-code-generator/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../gems/aws-sdk-core/spec/shared_spec_helper'
 
 $:.unshift(File.expand_path('../../lib', __FILE__))

--- a/build_tools/build_tools.rb
+++ b/build_tools/build_tools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../aws-sdk-code-generator/lib', __FILE__))
 
 require 'aws-sdk-code-generator'

--- a/build_tools/changelog.rb
+++ b/build_tools/changelog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
   # A utility class for managing a CHANGELOG file.
   class Changelog

--- a/build_tools/custom_service.rb
+++ b/build_tools/custom_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'cgi'
 

--- a/build_tools/customizations.rb
+++ b/build_tools/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
   module Customizations
 

--- a/build_tools/file_writer.rb
+++ b/build_tools/file_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module BuildTools

--- a/build_tools/load_client_examples.rb
+++ b/build_tools/load_client_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BuildTools
 
   # @return [Hash]

--- a/build_tools/replace_lines.rb
+++ b/build_tools/replace_lines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/build_tools/spec/changelog_spec.rb
+++ b/build_tools/spec/changelog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module BuildTools

--- a/build_tools/spec/changelog_verifier_spec.rb
+++ b/build_tools/spec/changelog_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 # Note: this spec test helps checking all gems CHANGELOG.mds 

--- a/build_tools/spec/custom_service_spec.rb
+++ b/build_tools/spec/custom_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module BuildTools

--- a/build_tools/spec/region_spec.rb
+++ b/build_tools/spec/region_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Note: these specs check all source code for hard-coded regions.
 def gem_lib_paths
   gems_dir = File.expand_path('../../../gems/', __FILE__)
@@ -19,7 +21,7 @@ def whitelist
       'iad_regional_endpoint.rb' => 'SKIP_FILE'
     },
     's3control' => {
-      's3_signer.rb' => 72
+      's3_signer.rb' => 74
     }
   }
 end

--- a/build_tools/spec/spec_helper.rb
+++ b/build_tools/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../changelog'
 require_relative '../custom_service'
 

--- a/build_tools/wrap_list.rb
+++ b/build_tools/wrap_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module BuildTools

--- a/gems/aws-eventstream/aws-eventstream.gemspec
+++ b/gems/aws-eventstream/aws-eventstream.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'aws-eventstream'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip

--- a/gems/aws-eventstream/lib/aws-eventstream.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-eventstream/decoder'
 require_relative 'aws-eventstream/encoder'
 

--- a/gems/aws-eventstream/lib/aws-eventstream/decoder.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/decoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'tempfile'
 require 'zlib'

--- a/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zlib'
 
 module Aws

--- a/gems/aws-eventstream/lib/aws-eventstream/errors.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EventStream
     module Errors

--- a/gems/aws-eventstream/lib/aws-eventstream/header_value.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/header_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EventStream
 

--- a/gems/aws-eventstream/lib/aws-eventstream/message.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EventStream
     class Message

--- a/gems/aws-eventstream/lib/aws-eventstream/types.rb
+++ b/gems/aws-eventstream/lib/aws-eventstream/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EventStream
 

--- a/gems/aws-eventstream/spec/decoder_spec.rb
+++ b/gems/aws-eventstream/spec/decoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-eventstream/spec/encoder_spec.rb
+++ b/gems/aws-eventstream/spec/encoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'tempfile'
 require_relative 'spec_helper'

--- a/gems/aws-eventstream/spec/header_value_spec.rb
+++ b/gems/aws-eventstream/spec/header_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-eventstream/spec/spec_helper.rb
+++ b/gems/aws-eventstream/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 $:.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'json'

--- a/gems/aws-partitions/aws-partitions.gemspec
+++ b/gems/aws-partitions/aws-partitions.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'aws-partitions'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip

--- a/gems/aws-partitions/lib/aws-partitions.rb
+++ b/gems/aws-partitions/lib/aws-partitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-partitions/endpoint_provider'
 require_relative 'aws-partitions/partition'
 require_relative 'aws-partitions/partition_list'

--- a/gems/aws-partitions/lib/aws-partitions/endpoint_provider.rb
+++ b/gems/aws-partitions/lib/aws-partitions/endpoint_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     # @api private

--- a/gems/aws-partitions/lib/aws-partitions/partition.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class Partition

--- a/gems/aws-partitions/lib/aws-partitions/partition_list.rb
+++ b/gems/aws-partitions/lib/aws-partitions/partition_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Partitions
     class PartitionList

--- a/gems/aws-partitions/lib/aws-partitions/region.rb
+++ b/gems/aws-partitions/lib/aws-partitions/region.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-partitions/lib/aws-partitions/service.rb
+++ b/gems/aws-partitions/lib/aws-partitions/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-partitions/spec/aws_partitions_spec.rb
+++ b/gems/aws-partitions/spec/aws_partitions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-partitions/spec/spec_helper.rb
+++ b/gems/aws-partitions/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require_relative '../lib/aws-partitions'
 require 'rspec'

--- a/gems/aws-sdk-accessanalyzer/features/step_definitions.rb
+++ b/gems/aws-sdk-accessanalyzer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@accessanalyzer") do
   @service = Aws::AccessAnalyzer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-acm/features/step_definitions.rb
+++ b/gems/aws-sdk-acm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@acm") do
   @service = Aws::ACM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-acm/lib/aws-sdk-acm/customizations.rb
+++ b/gems/aws-sdk-acm/lib/aws-sdk-acm/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-acmpca/features/step_definitions.rb
+++ b/gems/aws-sdk-acmpca/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@acmpca") do
   @service = Aws::ACMPCA::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-alexaforbusiness/features/step_definitions.rb
+++ b/gems/aws-sdk-alexaforbusiness/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@alexaforbusiness") do
   @service = Aws::AlexaForBusiness::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-amplify/features/step_definitions.rb
+++ b/gems/aws-sdk-amplify/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@amplify") do
   @service = Aws::Amplify::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-apigateway/features/step_definitions.rb
+++ b/gems/aws-sdk-apigateway/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@apigateway") do
   @service = Aws::APIGateway::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/customizations.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/plugins/apply_content_type_header.rb
+++ b/gems/aws-sdk-apigateway/lib/aws-sdk-apigateway/plugins/apply_content_type_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module APIGateway
     module Plugins

--- a/gems/aws-sdk-apigateway/spec/client_spec.rb
+++ b/gems/aws-sdk-apigateway/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-apigatewaymanagementapi/features/step_definitions.rb
+++ b/gems/aws-sdk-apigatewaymanagementapi/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@apigatewaymanagementapi") do
   @service = Aws::ApiGatewayManagementApi::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-apigatewayv2/features/step_definitions.rb
+++ b/gems/aws-sdk-apigatewayv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@apigatewayv2") do
   @service = Aws::ApiGatewayV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appconfig/features/step_definitions.rb
+++ b/gems/aws-sdk-appconfig/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appconfig") do
   @service = Aws::AppConfig::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-applicationautoscaling/features/step_definitions.rb
+++ b/gems/aws-sdk-applicationautoscaling/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@applicationautoscaling") do
   @service = Aws::ApplicationAutoScaling::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/customizations.rb
+++ b/gems/aws-sdk-applicationautoscaling/lib/aws-sdk-applicationautoscaling/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-applicationdiscoveryservice/features/step_definitions.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@applicationdiscoveryservice") do
   @service = Aws::ApplicationDiscoveryService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/customizations.rb
+++ b/gems/aws-sdk-applicationdiscoveryservice/lib/aws-sdk-applicationdiscoveryservice/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-applicationinsights/features/step_definitions.rb
+++ b/gems/aws-sdk-applicationinsights/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@applicationinsights") do
   @service = Aws::ApplicationInsights::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appmesh/features/step_definitions.rb
+++ b/gems/aws-sdk-appmesh/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appmesh") do
   @service = Aws::AppMesh::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appstream/features/step_definitions.rb
+++ b/gems/aws-sdk-appstream/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appstream") do
   @service = Aws::AppStream::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-appsync/features/step_definitions.rb
+++ b/gems/aws-sdk-appsync/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@appsync") do
   @service = Aws::AppSync::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-athena/features/step_definitions.rb
+++ b/gems/aws-sdk-athena/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@athena") do
   @service = Aws::Athena::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-augmentedairuntime/features/step_definitions.rb
+++ b/gems/aws-sdk-augmentedairuntime/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@augmentedairuntime") do
   @service = Aws::AugmentedAIRuntime::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-autoscaling/features/step_definitions.rb
+++ b/gems/aws-sdk-autoscaling/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@autoscaling") do
   @service = Aws::AutoScaling::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/customizations.rb
+++ b/gems/aws-sdk-autoscaling/lib/aws-sdk-autoscaling/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-autoscaling/spec/client_spec.rb
+++ b/gems/aws-sdk-autoscaling/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-autoscalingplans/features/step_definitions.rb
+++ b/gems/aws-sdk-autoscalingplans/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@autoscalingplans") do
   @service = Aws::AutoScalingPlans::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-backup/features/step_definitions.rb
+++ b/gems/aws-sdk-backup/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@backup") do
   @service = Aws::Backup::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-batch/features/step_definitions.rb
+++ b/gems/aws-sdk-batch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@batch") do
   @service = Aws::Batch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-budgets/features/step_definitions.rb
+++ b/gems/aws-sdk-budgets/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-budgets/lib/aws-sdk-budgets/customizations.rb
+++ b/gems/aws-sdk-budgets/lib/aws-sdk-budgets/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-chime/features/step_definitions.rb
+++ b/gems/aws-sdk-chime/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@chime") do
   @service = Aws::Chime::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloud9/features/step_definitions.rb
+++ b/gems/aws-sdk-cloud9/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloud9") do
   @service = Aws::Cloud9::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-clouddirectory/features/step_definitions.rb
+++ b/gems/aws-sdk-clouddirectory/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@clouddirectory") do
   @service = Aws::CloudDirectory::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudformation/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudformation/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudformation") do
   @service = Aws::CloudFormation::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/customizations.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudfront/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudfront/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudfront") do
   @client = Aws::CloudFront::Client.new
 end

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/cookie_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/customizations.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-cloudfront/signer'
 require 'aws-sdk-cloudfront/url_signer'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'uri'
 require 'time'

--- a/gems/aws-sdk-cloudfront/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/cookie_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
+++ b/gems/aws-sdk-cloudfront/spec/url_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cloudhsm/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudhsm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudhsm") do
   @service = Aws::CloudHSM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/customizations.rb
+++ b/gems/aws-sdk-cloudhsm/lib/aws-sdk-cloudhsm/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudhsmv2/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudhsmv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudhsmv2") do
   @service = Aws::CloudHSMV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudsearch/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudsearch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudsearch") do
   @service = Aws::CloudSearch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/customizations.rb
+++ b/gems/aws-sdk-cloudsearch/lib/aws-sdk-cloudsearch/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudsearchdomain/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudsearchdomain/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudsearchdomain") do
   @service = Aws::CloudSearchDomain::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/customizations.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/conditional_signing.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/conditional_signing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/switch_to_post.rb
+++ b/gems/aws-sdk-cloudsearchdomain/lib/aws-sdk-cloudsearchdomain/plugins/switch_to_post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module CloudSearchDomain
     module Plugins

--- a/gems/aws-sdk-cloudsearchdomain/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudsearchdomain/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 # Simply returns the request context without any http response info.

--- a/gems/aws-sdk-cloudtrail/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudtrail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudtrail") do
   @service = Aws::CloudTrail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/customizations.rb
+++ b/gems/aws-sdk-cloudtrail/lib/aws-sdk-cloudtrail/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatch/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatch/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatch") do
   @service = Aws::CloudWatch::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/customizations.rb
+++ b/gems/aws-sdk-cloudwatch/lib/aws-sdk-cloudwatch/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatchevents/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchevents/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatchevents") do
   @service = Aws::CloudWatchEvents::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/customizations.rb
+++ b/gems/aws-sdk-cloudwatchevents/lib/aws-sdk-cloudwatchevents/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatchlogs/features/step_definitions.rb
+++ b/gems/aws-sdk-cloudwatchlogs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cloudwatchlogs") do
   @service = Aws::CloudWatchLogs::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/customizations.rb
+++ b/gems/aws-sdk-cloudwatchlogs/lib/aws-sdk-cloudwatchlogs/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cloudwatchlogs/spec/client_spec.rb
+++ b/gems/aws-sdk-cloudwatchlogs/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-codeartifact/features/step_definitions.rb
+++ b/gems/aws-sdk-codeartifact/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codeartifact") do
   @service = Aws::CodeArtifact::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codebuild/features/step_definitions.rb
+++ b/gems/aws-sdk-codebuild/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codebuild") do
   @service = Aws::CodeBuild::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codecommit/features/step_definitions.rb
+++ b/gems/aws-sdk-codecommit/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codecommit") do
   @service = Aws::CodeCommit::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/customizations.rb
+++ b/gems/aws-sdk-codecommit/lib/aws-sdk-codecommit/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codedeploy/features/step_definitions.rb
+++ b/gems/aws-sdk-codedeploy/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codedeploy") do
   @service = Aws::CodeDeploy::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/customizations.rb
+++ b/gems/aws-sdk-codedeploy/lib/aws-sdk-codedeploy/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codeguruprofiler/features/step_definitions.rb
+++ b/gems/aws-sdk-codeguruprofiler/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codeguruprofiler") do
   @service = Aws::CodeGuruProfiler::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codegurureviewer/features/step_definitions.rb
+++ b/gems/aws-sdk-codegurureviewer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codegurureviewer") do
   @service = Aws::CodeGuruReviewer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codepipeline/features/step_definitions.rb
+++ b/gems/aws-sdk-codepipeline/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codepipeline") do
   @service = Aws::CodePipeline::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/customizations.rb
+++ b/gems/aws-sdk-codepipeline/lib/aws-sdk-codepipeline/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-codestar/features/step_definitions.rb
+++ b/gems/aws-sdk-codestar/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codestar") do
   @service = Aws::CodeStar::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codestarconnections/features/step_definitions.rb
+++ b/gems/aws-sdk-codestarconnections/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codestarconnections") do
   @service = Aws::CodeStarconnections::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-codestarnotifications/features/step_definitions.rb
+++ b/gems/aws-sdk-codestarnotifications/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@codestarnotifications") do
   @service = Aws::CodeStarNotifications::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cognitoidentity/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitoidentity/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitoidentity") do
   @client = Aws::CognitoIdentity::Client.new
 end

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-cognitoidentity/customizations/cognito_identity_credentials'

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'securerandom'
 require 'base64'

--- a/gems/aws-sdk-cognitoidentity/spec/client_spec.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cognitoidentity/spec/cognito_identity_credentials_spec.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/cognito_identity_credentials_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require_relative 'spec_helper'
 

--- a/gems/aws-sdk-cognitoidentityprovider/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitoidentityprovider") do
   @service = Aws::CognitoIdentityProvider::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/customizations.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/lib/aws-sdk-cognitoidentityprovider/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
+++ b/gems/aws-sdk-cognitoidentityprovider/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-cognitosync/features/step_definitions.rb
+++ b/gems/aws-sdk-cognitosync/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@cognitosync") do
   @service = Aws::CognitoSync::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/customizations.rb
+++ b/gems/aws-sdk-cognitosync/lib/aws-sdk-cognitosync/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-comprehend/features/step_definitions.rb
+++ b/gems/aws-sdk-comprehend/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@comprehend") do
   @service = Aws::Comprehend::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-comprehendmedical/features/step_definitions.rb
+++ b/gems/aws-sdk-comprehendmedical/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@comprehendmedical") do
   @service = Aws::ComprehendMedical::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-computeoptimizer/features/step_definitions.rb
+++ b/gems/aws-sdk-computeoptimizer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@computeoptimizer") do
   @service = Aws::ComputeOptimizer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-configservice/features/step_definitions.rb
+++ b/gems/aws-sdk-configservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@configservice") do
   @service = Aws::ConfigService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-configservice/lib/aws-sdk-configservice/customizations.rb
+++ b/gems/aws-sdk-configservice/lib/aws-sdk-configservice/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-connect/features/step_definitions.rb
+++ b/gems/aws-sdk-connect/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@connect") do
   @service = Aws::Connect::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-connectparticipant/features/step_definitions.rb
+++ b/gems/aws-sdk-connectparticipant/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@connectparticipant") do
   @service = Aws::ConnectParticipant::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-costandusagereportservice/features/step_definitions.rb
+++ b/gems/aws-sdk-costandusagereportservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@costandusagereportservice") do
   @service = Aws::CostandUsageReportService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-costexplorer/features/step_definitions.rb
+++ b/gems/aws-sdk-costexplorer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@costexplorer") do
   @service = Aws::CostExplorer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-databasemigrationservice/features/step_definitions.rb
+++ b/gems/aws-sdk-databasemigrationservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@databasemigrationservice") do
   @service = Aws::DatabaseMigrationService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/customizations.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-dataexchange/features/step_definitions.rb
+++ b/gems/aws-sdk-dataexchange/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dataexchange") do
   @service = Aws::DataExchange::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-datapipeline/features/step_definitions.rb
+++ b/gems/aws-sdk-datapipeline/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@datapipeline") do
   @service = Aws::DataPipeline::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/customizations.rb
+++ b/gems/aws-sdk-datapipeline/lib/aws-sdk-datapipeline/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-datasync/features/step_definitions.rb
+++ b/gems/aws-sdk-datasync/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@datasync") do
   @service = Aws::DataSync::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-dax/features/step_definitions.rb
+++ b/gems/aws-sdk-dax/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dax") do
   @service = Aws::DAX::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-detective/features/step_definitions.rb
+++ b/gems/aws-sdk-detective/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@detective") do
   @service = Aws::Detective::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-devicefarm/features/step_definitions.rb
+++ b/gems/aws-sdk-devicefarm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@devicefarm") do
   @service = Aws::DeviceFarm::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/customizations.rb
+++ b/gems/aws-sdk-devicefarm/lib/aws-sdk-devicefarm/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-directconnect/features/step_definitions.rb
+++ b/gems/aws-sdk-directconnect/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@directconnect") do
   @service = Aws::DirectConnect::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/customizations.rb
+++ b/gems/aws-sdk-directconnect/lib/aws-sdk-directconnect/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-directoryservice/features/step_definitions.rb
+++ b/gems/aws-sdk-directoryservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@directoryservice") do
   @service = Aws::DirectoryService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/customizations.rb
+++ b/gems/aws-sdk-directoryservice/lib/aws-sdk-directoryservice/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-dlm/features/step_definitions.rb
+++ b/gems/aws-sdk-dlm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@dlm") do
   @service = Aws::DLM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-docdb/features/step_definitions.rb
+++ b/gems/aws-sdk-docdb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@docdb") do
   @service = Aws::DocDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ebs/features/step_definitions.rb
+++ b/gems/aws-sdk-ebs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ebs") do
   @service = Aws::EBS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ec2/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before('@ec2') do
   @service = Aws::EC2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-ec2/customizations/resource'
 require 'aws-sdk-ec2/customizations/instance'

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/instance.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EC2
     class Resource

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/copy_encrypted_snapshot.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/copy_encrypted_snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/plugins/region_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module EC2
     module Plugins

--- a/gems/aws-sdk-ec2/spec/client_spec.rb
+++ b/gems/aws-sdk-ec2/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2/spec/instance/decrypt_windows_password_spec.rb
+++ b/gems/aws-sdk-ec2/spec/instance/decrypt_windows_password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2/spec/resource_spec.rb
+++ b/gems/aws-sdk-ec2/spec/resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ec2instanceconnect/features/step_definitions.rb
+++ b/gems/aws-sdk-ec2instanceconnect/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ec2instanceconnect") do
   @service = Aws::EC2InstanceConnect::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ecr/features/step_definitions.rb
+++ b/gems/aws-sdk-ecr/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ecr") do
   @service = Aws::ECR::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ecr/lib/aws-sdk-ecr/customizations.rb
+++ b/gems/aws-sdk-ecr/lib/aws-sdk-ecr/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-ecs/features/step_definitions.rb
+++ b/gems/aws-sdk-ecs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ecs") do
   @service = Aws::ECS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/customizations.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-efs/features/step_definitions.rb
+++ b/gems/aws-sdk-efs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@efs") do
   @service = Aws::EFS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-efs/lib/aws-sdk-efs/customizations.rb
+++ b/gems/aws-sdk-efs/lib/aws-sdk-efs/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-eks/features/step_definitions.rb
+++ b/gems/aws-sdk-eks/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@eks") do
   @service = Aws::EKS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticache/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticache/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticache") do
   @service = Aws::ElastiCache::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/customizations.rb
+++ b/gems/aws-sdk-elasticache/lib/aws-sdk-elasticache/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticbeanstalk/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticbeanstalk/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticbeanstalk") do
   @service = Aws::ElasticBeanstalk::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/customizations.rb
+++ b/gems/aws-sdk-elasticbeanstalk/lib/aws-sdk-elasticbeanstalk/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticinference/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticinference/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticinference") do
   @service = Aws::ElasticInference::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticloadbalancing/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancing/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticloadbalancing") do
   @service = Aws::ElasticLoadBalancing::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/customizations.rb
+++ b/gems/aws-sdk-elasticloadbalancing/lib/aws-sdk-elasticloadbalancing/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticloadbalancingv2/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticloadbalancingv2") do
   @service = Aws::ElasticLoadBalancingV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/customizations.rb
+++ b/gems/aws-sdk-elasticloadbalancingv2/lib/aws-sdk-elasticloadbalancingv2/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elasticsearchservice/features/step_definitions.rb
+++ b/gems/aws-sdk-elasticsearchservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elasticsearchservice") do
   @service = Aws::ElasticsearchService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/customizations.rb
+++ b/gems/aws-sdk-elasticsearchservice/lib/aws-sdk-elasticsearchservice/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-elastictranscoder/features/step_definitions.rb
+++ b/gems/aws-sdk-elastictranscoder/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@elastictranscoder") do
   @service = Aws::ElasticTranscoder::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/customizations.rb
+++ b/gems/aws-sdk-elastictranscoder/lib/aws-sdk-elastictranscoder/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-emr/features/step_definitions.rb
+++ b/gems/aws-sdk-emr/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@emr") do
   @service = Aws::EMR::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-emr/lib/aws-sdk-emr/customizations.rb
+++ b/gems/aws-sdk-emr/lib/aws-sdk-emr/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-eventbridge/features/step_definitions.rb
+++ b/gems/aws-sdk-eventbridge/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@eventbridge") do
   @service = Aws::EventBridge::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-firehose/features/step_definitions.rb
+++ b/gems/aws-sdk-firehose/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@firehose") do
   @service = Aws::Firehose::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-firehose/lib/aws-sdk-firehose/customizations.rb
+++ b/gems/aws-sdk-firehose/lib/aws-sdk-firehose/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-fms/features/step_definitions.rb
+++ b/gems/aws-sdk-fms/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@fms") do
   @service = Aws::FMS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-forecastqueryservice/features/step_definitions.rb
+++ b/gems/aws-sdk-forecastqueryservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@forecastqueryservice") do
   @service = Aws::ForecastQueryService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-forecastservice/features/step_definitions.rb
+++ b/gems/aws-sdk-forecastservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@forecastservice") do
   @service = Aws::ForecastService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-frauddetector/features/step_definitions.rb
+++ b/gems/aws-sdk-frauddetector/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@frauddetector") do
   @service = Aws::FraudDetector::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-fsx/features/step_definitions.rb
+++ b/gems/aws-sdk-fsx/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@fsx") do
   @service = Aws::FSx::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-gamelift/features/step_definitions.rb
+++ b/gems/aws-sdk-gamelift/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@gamelift") do
   @service = Aws::GameLift::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/customizations.rb
+++ b/gems/aws-sdk-gamelift/lib/aws-sdk-gamelift/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-glacier/features/step_definitions.rb
+++ b/gems/aws-sdk-glacier/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@glacier") do
   @client = Aws::Glacier::Client.new
 end

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/customizations.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/account_id.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/account_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Glacier
     module Plugins

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/api_version.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/api_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Glacier
     module Plugins

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/checksums.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/plugins/checksums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../tree_hash'
 require 'openssl'
 

--- a/gems/aws-sdk-glacier/lib/aws-sdk-glacier/tree_hash.rb
+++ b/gems/aws-sdk-glacier/lib/aws-sdk-glacier/tree_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-glacier/spec/client_spec.rb
+++ b/gems/aws-sdk-glacier/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-globalaccelerator/features/step_definitions.rb
+++ b/gems/aws-sdk-globalaccelerator/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@globalaccelerator") do
   @service = Aws::GlobalAccelerator::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-glue/features/step_definitions.rb
+++ b/gems/aws-sdk-glue/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@glue") do
   @service = Aws::Glue::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-greengrass/features/step_definitions.rb
+++ b/gems/aws-sdk-greengrass/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@greengrass") do
   @service = Aws::Greengrass::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-groundstation/features/step_definitions.rb
+++ b/gems/aws-sdk-groundstation/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@groundstation") do
   @service = Aws::GroundStation::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-guardduty/features/step_definitions.rb
+++ b/gems/aws-sdk-guardduty/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@guardduty") do
   @service = Aws::GuardDuty::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-health/features/smoke_step_definitions.rb
+++ b/gems/aws-sdk-health/features/smoke_step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-health/features/step_definitions.rb
+++ b/gems/aws-sdk-health/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@health") do
   @service = Aws::Health::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iam/features/step_definitions.rb
+++ b/gems/aws-sdk-iam/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iam") do
   @service = Aws::IAM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-iam/customizations/resource'

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations/resource.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/customizations/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module IAM
     class Resource

--- a/gems/aws-sdk-iam/spec/client_spec.rb
+++ b/gems/aws-sdk-iam/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-iam/spec/resource_spec.rb
+++ b/gems/aws-sdk-iam/spec/resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-imagebuilder/features/step_definitions.rb
+++ b/gems/aws-sdk-imagebuilder/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@imagebuilder") do
   @service = Aws::Imagebuilder::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-importexport/features/step_definitions.rb
+++ b/gems/aws-sdk-importexport/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@importexport") do
   @service = Aws::ImportExport::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-importexport/lib/aws-sdk-importexport/customizations.rb
+++ b/gems/aws-sdk-importexport/lib/aws-sdk-importexport/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-inspector/features/step_definitions.rb
+++ b/gems/aws-sdk-inspector/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@inspector") do
   @service = Aws::Inspector::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-inspector/lib/aws-sdk-inspector/customizations.rb
+++ b/gems/aws-sdk-inspector/lib/aws-sdk-inspector/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-iot/features/step_definitions.rb
+++ b/gems/aws-sdk-iot/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iot") do
   @service = Aws::IoT::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iot/lib/aws-sdk-iot/customizations.rb
+++ b/gems/aws-sdk-iot/lib/aws-sdk-iot/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-iot1clickdevicesservice/features/step_definitions.rb
+++ b/gems/aws-sdk-iot1clickdevicesservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iot1clickdevicesservice") do
   @service = Aws::IoT1ClickDevicesService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iot1clickprojects/features/step_definitions.rb
+++ b/gems/aws-sdk-iot1clickprojects/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iot1clickprojects") do
   @service = Aws::IoT1ClickProjects::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotanalytics/features/step_definitions.rb
+++ b/gems/aws-sdk-iotanalytics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotanalytics") do
   @service = Aws::IoTAnalytics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotdataplane/features/step_definitions.rb
+++ b/gems/aws-sdk-iotdataplane/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotdataplane") do
   @service = Aws::IoTDataPlane::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/customizations.rb
+++ b/gems/aws-sdk-iotdataplane/lib/aws-sdk-iotdataplane/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-iotdataplane/spec/client_spec.rb
+++ b/gems/aws-sdk-iotdataplane/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-iotevents/features/step_definitions.rb
+++ b/gems/aws-sdk-iotevents/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotevents") do
   @service = Aws::IoTEvents::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ioteventsdata/features/step_definitions.rb
+++ b/gems/aws-sdk-ioteventsdata/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ioteventsdata") do
   @service = Aws::IoTEventsData::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotjobsdataplane/features/step_definitions.rb
+++ b/gems/aws-sdk-iotjobsdataplane/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotjobsdataplane") do
   @service = Aws::IoTJobsDataPlane::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotsecuretunneling/features/step_definitions.rb
+++ b/gems/aws-sdk-iotsecuretunneling/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotsecuretunneling") do
   @service = Aws::IoTSecureTunneling::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotsitewise/features/step_definitions.rb
+++ b/gems/aws-sdk-iotsitewise/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotsitewise") do
   @service = Aws::IoTSiteWise::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-iotthingsgraph/features/step_definitions.rb
+++ b/gems/aws-sdk-iotthingsgraph/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@iotthingsgraph") do
   @service = Aws::IoTThingsGraph::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kafka/features/step_definitions.rb
+++ b/gems/aws-sdk-kafka/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kafka") do
   @service = Aws::Kafka::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kendra/features/step_definitions.rb
+++ b/gems/aws-sdk-kendra/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kendra") do
   @service = Aws::Kendra::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesis/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesis/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesis") do
   @service = Aws::Kinesis::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/customizations.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-kinesisanalytics/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisanalytics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisanalytics") do
   @service = Aws::KinesisAnalytics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/customizations.rb
+++ b/gems/aws-sdk-kinesisanalytics/lib/aws-sdk-kinesisanalytics/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-kinesisanalyticsv2/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisanalyticsv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisanalyticsv2") do
   @service = Aws::KinesisAnalyticsV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideo/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideo/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideo") do
   @service = Aws::KinesisVideo::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideoarchivedmedia/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideoarchivedmedia/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideoarchivedmedia") do
   @service = Aws::KinesisVideoArchivedMedia::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideomedia/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideomedia/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideomedia") do
   @service = Aws::KinesisVideoMedia::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kinesisvideosignalingchannels/features/step_definitions.rb
+++ b/gems/aws-sdk-kinesisvideosignalingchannels/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kinesisvideosignalingchannels") do
   @service = Aws::KinesisVideoSignalingChannels::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kms/features/step_definitions.rb
+++ b/gems/aws-sdk-kms/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@kms") do
   @service = Aws::KMS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-kms/lib/aws-sdk-kms/customizations.rb
+++ b/gems/aws-sdk-kms/lib/aws-sdk-kms/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-lakeformation/features/step_definitions.rb
+++ b/gems/aws-sdk-lakeformation/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lakeformation") do
   @service = Aws::LakeFormation::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lambda/features/step_definitions.rb
+++ b/gems/aws-sdk-lambda/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lambda") do
   @service = Aws::Lambda::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lambda/lib/aws-sdk-lambda/customizations.rb
+++ b/gems/aws-sdk-lambda/lib/aws-sdk-lambda/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-lambda/spec/client_spec.rb
+++ b/gems/aws-sdk-lambda/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-lambdapreview/features/step_definitions.rb
+++ b/gems/aws-sdk-lambdapreview/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lambdapreview") do
   @service = Aws::LambdaPreview::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/customizations.rb
+++ b/gems/aws-sdk-lambdapreview/lib/aws-sdk-lambdapreview/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-lambdapreview/spec/client_spec.rb
+++ b/gems/aws-sdk-lambdapreview/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-lex/features/step_definitions.rb
+++ b/gems/aws-sdk-lex/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lex") do
   @service = Aws::Lex::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lexmodelbuildingservice/features/step_definitions.rb
+++ b/gems/aws-sdk-lexmodelbuildingservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lexmodelbuildingservice") do
   @service = Aws::LexModelBuildingService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lexruntimeservice/aws-sdk-lexruntimeservice.gemspec
+++ b/gems/aws-sdk-lexruntimeservice/aws-sdk-lexruntimeservice.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/features/env.rb
+++ b/gems/aws-sdk-lexruntimeservice/features/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/features/step_definitions.rb
+++ b/gems/aws-sdk-lexruntimeservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lexruntimeservice") do
   @service = Aws::LexRuntimeService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client_api.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/client_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/errors.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/resource.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/types.rb
+++ b/gems/aws-sdk-lexruntimeservice/lib/aws-sdk-lexruntimeservice/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-lexruntimeservice/spec/spec_helper.rb
+++ b/gems/aws-sdk-lexruntimeservice/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing guide for more information:

--- a/gems/aws-sdk-licensemanager/features/step_definitions.rb
+++ b/gems/aws-sdk-licensemanager/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@licensemanager") do
   @service = Aws::LicenseManager::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-lightsail/features/step_definitions.rb
+++ b/gems/aws-sdk-lightsail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@lightsail") do
   @service = Aws::Lightsail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-machinelearning/features/step_definitions.rb
+++ b/gems/aws-sdk-machinelearning/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@machinelearning") do
   @service = Aws::MachineLearning::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/customizations.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/plugins/predict_endpoint.rb
+++ b/gems/aws-sdk-machinelearning/lib/aws-sdk-machinelearning/plugins/predict_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module MachineLearning
     module Plugins

--- a/gems/aws-sdk-machinelearning/spec/client_spec.rb
+++ b/gems/aws-sdk-machinelearning/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-macie/features/step_definitions.rb
+++ b/gems/aws-sdk-macie/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@macie") do
   @service = Aws::Macie::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-macie2/features/step_definitions.rb
+++ b/gems/aws-sdk-macie2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@macie2") do
   @service = Aws::Macie2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-managedblockchain/features/step_definitions.rb
+++ b/gems/aws-sdk-managedblockchain/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@managedblockchain") do
   @service = Aws::ManagedBlockchain::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacecatalog/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplacecatalog/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplacecatalog") do
   @service = Aws::MarketplaceCatalog::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacecommerceanalytics/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplacecommerceanalytics") do
   @service = Aws::MarketplaceCommerceAnalytics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/customizations.rb
+++ b/gems/aws-sdk-marketplacecommerceanalytics/lib/aws-sdk-marketplacecommerceanalytics/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-marketplaceentitlementservice/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplaceentitlementservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplaceentitlementservice") do
   @service = Aws::MarketplaceEntitlementService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacemetering/features/step_definitions.rb
+++ b/gems/aws-sdk-marketplacemetering/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@marketplacemetering") do
   @service = Aws::MarketplaceMetering::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/customizations.rb
+++ b/gems/aws-sdk-marketplacemetering/lib/aws-sdk-marketplacemetering/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-mediaconnect/features/step_definitions.rb
+++ b/gems/aws-sdk-mediaconnect/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediaconnect") do
   @service = Aws::MediaConnect::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediaconvert/features/step_definitions.rb
+++ b/gems/aws-sdk-mediaconvert/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediaconvert") do
   @service = Aws::MediaConvert::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-medialive/features/step_definitions.rb
+++ b/gems/aws-sdk-medialive/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@medialive") do
   @service = Aws::MediaLive::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediapackage/features/step_definitions.rb
+++ b/gems/aws-sdk-mediapackage/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediapackage") do
   @service = Aws::MediaPackage::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediapackagevod/features/step_definitions.rb
+++ b/gems/aws-sdk-mediapackagevod/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediapackagevod") do
   @service = Aws::MediaPackageVod::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediastore/features/step_definitions.rb
+++ b/gems/aws-sdk-mediastore/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediastore") do
   @service = Aws::MediaStore::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediastoredata/features/step_definitions.rb
+++ b/gems/aws-sdk-mediastoredata/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediastoredata") do
   @service = Aws::MediaStoreData::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mediatailor/features/step_definitions.rb
+++ b/gems/aws-sdk-mediatailor/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mediatailor") do
   @service = Aws::MediaTailor::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-migrationhub/features/step_definitions.rb
+++ b/gems/aws-sdk-migrationhub/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@migrationhub") do
   @service = Aws::MigrationHub::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-migrationhubconfig/features/step_definitions.rb
+++ b/gems/aws-sdk-migrationhubconfig/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@migrationhubconfig") do
   @service = Aws::MigrationHubConfig::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mobile/features/step_definitions.rb
+++ b/gems/aws-sdk-mobile/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mobile") do
   @service = Aws::Mobile::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mq/features/step_definitions.rb
+++ b/gems/aws-sdk-mq/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mq") do
   @service = Aws::MQ::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-mturk/features/step_definitions.rb
+++ b/gems/aws-sdk-mturk/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@mturk") do
   @service = Aws::MTurk::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-neptune/features/step_definitions.rb
+++ b/gems/aws-sdk-neptune/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@neptune") do
   @service = Aws::Neptune::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-networkmanager/features/step_definitions.rb
+++ b/gems/aws-sdk-networkmanager/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@networkmanager") do
   @service = Aws::NetworkManager::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-opsworks/features/step_definitions.rb
+++ b/gems/aws-sdk-opsworks/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@opsworks") do
   @service = Aws::OpsWorks::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/customizations.rb
+++ b/gems/aws-sdk-opsworks/lib/aws-sdk-opsworks/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-opsworkscm/features/step_definitions.rb
+++ b/gems/aws-sdk-opsworkscm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@opsworkscm") do
   @service = Aws::OpsWorksCM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-organizations/features/step_definitions.rb
+++ b/gems/aws-sdk-organizations/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@organizations") do
   @service = Aws::Organizations::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-outposts/features/step_definitions.rb
+++ b/gems/aws-sdk-outposts/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@outposts") do
   @service = Aws::Outposts::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-personalize/features/step_definitions.rb
+++ b/gems/aws-sdk-personalize/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@personalize") do
   @service = Aws::Personalize::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-personalizeevents/features/step_definitions.rb
+++ b/gems/aws-sdk-personalizeevents/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@personalizeevents") do
   @service = Aws::PersonalizeEvents::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-personalizeruntime/features/step_definitions.rb
+++ b/gems/aws-sdk-personalizeruntime/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@personalizeruntime") do
   @service = Aws::PersonalizeRuntime::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pi/features/step_definitions.rb
+++ b/gems/aws-sdk-pi/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pi") do
   @service = Aws::PI::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pinpoint/features/step_definitions.rb
+++ b/gems/aws-sdk-pinpoint/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pinpoint") do
   @service = Aws::Pinpoint::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pinpointemail/features/step_definitions.rb
+++ b/gems/aws-sdk-pinpointemail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pinpointemail") do
   @service = Aws::PinpointEmail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-pinpointsmsvoice/features/step_definitions.rb
+++ b/gems/aws-sdk-pinpointsmsvoice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pinpointsmsvoice") do
   @service = Aws::PinpointSMSVoice::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-polly/features/step_definitions.rb
+++ b/gems/aws-sdk-polly/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@polly") do
   @service = Aws::Polly::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/customizations.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-polly/presigner'

--- a/gems/aws-sdk-polly/lib/aws-sdk-polly/presigner.rb
+++ b/gems/aws-sdk-polly/lib/aws-sdk-polly/presigner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-polly/spec/presigner_spec.rb
+++ b/gems/aws-sdk-polly/spec/presigner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './spec_helper'
 
 module Aws

--- a/gems/aws-sdk-pricing/features/step_definitions.rb
+++ b/gems/aws-sdk-pricing/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@pricing") do
   @service = Aws::Pricing::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-qldb/features/step_definitions.rb
+++ b/gems/aws-sdk-qldb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@qldb") do
   @service = Aws::QLDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-qldbsession/features/step_definitions.rb
+++ b/gems/aws-sdk-qldbsession/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@qldbsession") do
   @service = Aws::QLDBSession::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-quicksight/features/step_definitions.rb
+++ b/gems/aws-sdk-quicksight/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@quicksight") do
   @service = Aws::QuickSight::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ram/features/step_definitions.rb
+++ b/gems/aws-sdk-ram/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ram") do
   @service = Aws::RAM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-rds/features/step_definitions.rb
+++ b/gems/aws-sdk-rds/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@rds") do
   @service = Aws::RDS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # customizations to generated classes
 require 'aws-sdk-rds/customizations/auth_token_generator'

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations/auth_token_generator.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations/auth_token_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/plugins/cross_region_copying.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/plugins/cross_region_copying.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
+++ b/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-rds/spec/client_spec.rb
+++ b/gems/aws-sdk-rds/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './spec_helper'
 
 module Aws

--- a/gems/aws-sdk-rdsdataservice/features/step_definitions.rb
+++ b/gems/aws-sdk-rdsdataservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@rdsdataservice") do
   @service = Aws::RDSDataService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-redshift/features/step_definitions.rb
+++ b/gems/aws-sdk-redshift/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@redshift") do
   @service = Aws::Redshift::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-redshift/lib/aws-sdk-redshift/customizations.rb
+++ b/gems/aws-sdk-redshift/lib/aws-sdk-redshift/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-rekognition/features/step_definitions.rb
+++ b/gems/aws-sdk-rekognition/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@rekognition") do
   @service = Aws::Rekognition::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-resourcegroups/features/step_definitions.rb
+++ b/gems/aws-sdk-resourcegroups/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@resourcegroups") do
   @service = Aws::ResourceGroups::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-resourcegroupstaggingapi/features/step_definitions.rb
+++ b/gems/aws-sdk-resourcegroupstaggingapi/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@resourcegroupstaggingapi") do
   @service = Aws::ResourceGroupsTaggingAPI::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-resources/aws-sdk-resources.gemspec
+++ b/gems/aws-sdk-resources/aws-sdk-resources.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
 
   spec.name          = 'aws-sdk-resources'

--- a/gems/aws-sdk-resources/bin/aws-v3.rb
+++ b/gems/aws-sdk-resources/bin/aws-v3.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rubygems'
 require 'optparse'

--- a/gems/aws-sdk-resources/lib/aws-sdk-resources.rb
+++ b/gems/aws-sdk-resources/lib/aws-sdk-resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-core'
 
 # Aws module documentation.

--- a/gems/aws-sdk-robomaker/features/step_definitions.rb
+++ b/gems/aws-sdk-robomaker/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@robomaker") do
   @service = Aws::RoboMaker::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-route53/features/step_definitions.rb
+++ b/gems/aws-sdk-route53/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@route53") do
   @service = Aws::Route53::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/customizations.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
+++ b/gems/aws-sdk-route53/lib/aws-sdk-route53/plugins/id_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Route53
     module Plugins

--- a/gems/aws-sdk-route53/spec/client_spec.rb
+++ b/gems/aws-sdk-route53/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-route53domains/features/step_definitions.rb
+++ b/gems/aws-sdk-route53domains/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@route53domains") do
   @service = Aws::Route53Domains::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/customizations.rb
+++ b/gems/aws-sdk-route53domains/lib/aws-sdk-route53domains/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-route53resolver/features/step_definitions.rb
+++ b/gems/aws-sdk-route53resolver/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@route53resolver") do
   @service = Aws::Route53Resolver::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-s3/features/client/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/client/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'csv'
 

--- a/gems/aws-sdk-s3/features/resources/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/resources/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'tempfile'
 require 'fileutils'

--- a/gems/aws-sdk-s3/features/step_definitions.rb
+++ b/gems/aws-sdk-s3/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-s3/spec/bucket/delete_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/load_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/load_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/presigned_post_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/presigned_post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/url_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/bucket/waiters_spec.rb
+++ b/gems/aws-sdk-s3/spec/bucket/waiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client/bucket_arn_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/bucket_arn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/dualstack_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/dualstack_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/client/md5s_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/md5s_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'stringio'
 

--- a/gems/aws-sdk-s3/spec/client/url_pattern_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/url_pattern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 def suites

--- a/gems/aws-sdk-s3/spec/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'stringio'
 require 'tempfile'

--- a/gems/aws-sdk-s3/spec/encryption/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'base64'
 require 'openssl'

--- a/gems/aws-sdk-s3/spec/encryption/io_encrypter_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/io_encrypter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'openssl'
 

--- a/gems/aws-sdk-s3/spec/file_part_spec.rb
+++ b/gems/aws-sdk-s3/spec/file_part_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/legacy_signer_spec.rb
+++ b/gems/aws-sdk-s3/spec/legacy_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/multipart_upload_spec.rb
+++ b/gems/aws-sdk-s3/spec/multipart_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object/exists_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/exists_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object/move_to_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/move_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/presigned_post_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/presigned_post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/presigned_url_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/presigned_url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/public_url_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/public_url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'tempfile'
 

--- a/gems/aws-sdk-s3/spec/object_summary_spec.rb
+++ b/gems/aws-sdk-s3/spec/object_summary_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3/spec/presigned_post_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigned_post_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 require 'base64'
 

--- a/gems/aws-sdk-s3/spec/presigner_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-s3control/features/step_definitions.rb
+++ b/gems/aws-sdk-s3control/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@s3control") do
   @service = Aws::S3Control::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/dualstack.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/dualstack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3Control
     module Plugins

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_control_dns.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_control_dns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3Control
     module Plugins

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_host_id.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_host_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module S3Control
     module Plugins

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_signer.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sigv4'
 
 module Aws

--- a/gems/aws-sdk-sagemaker/features/step_definitions.rb
+++ b/gems/aws-sdk-sagemaker/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sagemaker") do
   @service = Aws::SageMaker::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sagemakerruntime/features/step_definitions.rb
+++ b/gems/aws-sdk-sagemakerruntime/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sagemakerruntime") do
   @service = Aws::SageMakerRuntime::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-savingsplans/features/step_definitions.rb
+++ b/gems/aws-sdk-savingsplans/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@savingsplans") do
   @service = Aws::SavingsPlans::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-schemas/features/step_definitions.rb
+++ b/gems/aws-sdk-schemas/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@schemas") do
   @service = Aws::Schemas::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-secretsmanager/features/step_definitions.rb
+++ b/gems/aws-sdk-secretsmanager/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@secretsmanager") do
   @service = Aws::SecretsManager::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-securityhub/features/step_definitions.rb
+++ b/gems/aws-sdk-securityhub/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@securityhub") do
   @service = Aws::SecurityHub::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-serverlessapplicationrepository/features/step_definitions.rb
+++ b/gems/aws-sdk-serverlessapplicationrepository/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@serverlessapplicationrepository") do
   @service = Aws::ServerlessApplicationRepository::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-servicecatalog/features/step_definitions.rb
+++ b/gems/aws-sdk-servicecatalog/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@servicecatalog") do
   @service = Aws::ServiceCatalog::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/customizations.rb
+++ b/gems/aws-sdk-servicecatalog/lib/aws-sdk-servicecatalog/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-servicediscovery/features/step_definitions.rb
+++ b/gems/aws-sdk-servicediscovery/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@servicediscovery") do
   @service = Aws::ServiceDiscovery::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-servicequotas/features/step_definitions.rb
+++ b/gems/aws-sdk-servicequotas/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@servicequotas") do
   @service = Aws::ServiceQuotas::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ses/features/step_definitions.rb
+++ b/gems/aws-sdk-ses/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ses") do
   @service = Aws::SES::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ses/lib/aws-sdk-ses/customizations.rb
+++ b/gems/aws-sdk-ses/lib/aws-sdk-ses/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sesv2/features/step_definitions.rb
+++ b/gems/aws-sdk-sesv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sesv2") do
   @service = Aws::SESV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-shield/features/step_definitions.rb
+++ b/gems/aws-sdk-shield/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@shield") do
   @service = Aws::Shield::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-signer/features/step_definitions.rb
+++ b/gems/aws-sdk-signer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@signer") do
   @service = Aws::Signer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-simpledb/features/step_definitions.rb
+++ b/gems/aws-sdk-simpledb/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@simpledb") do
   @service = Aws::SimpleDB::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/customizations.rb
+++ b/gems/aws-sdk-simpledb/lib/aws-sdk-simpledb/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sms/features/step_definitions.rb
+++ b/gems/aws-sdk-sms/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sms/lib/aws-sdk-sms/customizations.rb
+++ b/gems/aws-sdk-sms/lib/aws-sdk-sms/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-snowball/features/step_definitions.rb
+++ b/gems/aws-sdk-snowball/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@snowball") do
   @service = Aws::Snowball::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-snowball/lib/aws-sdk-snowball/customizations.rb
+++ b/gems/aws-sdk-snowball/lib/aws-sdk-snowball/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sns/features/step_definitions.rb
+++ b/gems/aws-sdk-sns/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sns") do
   @service = Aws::SNS::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/customizations.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-sns/message_verifier'

--- a/gems/aws-sdk-sns/lib/aws-sdk-sns/message_verifier.rb
+++ b/gems/aws-sdk-sns/lib/aws-sdk-sns/message_verifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'openssl'
 require 'base64'

--- a/gems/aws-sdk-sns/spec/message_verifier_spec.rb
+++ b/gems/aws-sdk-sns/spec/message_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-sqs/features/step_definitions.rb
+++ b/gems/aws-sdk-sqs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sqs") do
   @client = Aws::SQS::Client.new
   @sqs_created_queues = []

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/customizations.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/customizations.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # utility classes
 require 'aws-sdk-sqs/queue_poller'

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/md5s.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Aws

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/plugins/queue_urls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module SQS
     module Plugins

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Aws

--- a/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/queue_urls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'uri'
 

--- a/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client/verify_checksums_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require_relative '../spec_helper'
 

--- a/gems/aws-sdk-sqs/spec/client_spec.rb
+++ b/gems/aws-sdk-sqs/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/gems/aws-sdk-ssm/features/step_definitions.rb
+++ b/gems/aws-sdk-ssm/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ssm") do
   @service = Aws::SSM::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/customizations.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-sso/features/step_definitions.rb
+++ b/gems/aws-sdk-sso/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@sso") do
   @service = Aws::SSO::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
+++ b/gems/aws-sdk-sso/lib/aws-sdk-sso/plugins/content_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module SSO
     module Plugins

--- a/gems/aws-sdk-ssooidc/features/step_definitions.rb
+++ b/gems/aws-sdk-ssooidc/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@ssooidc") do
   @service = Aws::SSOOIDC::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-states/features/step_definitions.rb
+++ b/gems/aws-sdk-states/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@states") do
   @service = Aws::States::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-storagegateway/features/step_definitions.rb
+++ b/gems/aws-sdk-storagegateway/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@storagegateway") do
   @service = Aws::StorageGateway::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/customizations.rb
+++ b/gems/aws-sdk-storagegateway/lib/aws-sdk-storagegateway/customizations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # WARNING ABOUT GENERATED CODE
 #
 # This file is generated. See the contributing for info on making contributions:

--- a/gems/aws-sdk-support/features/step_definitions.rb
+++ b/gems/aws-sdk-support/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@support") do
   @service = Aws::Support::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-swf/features/step_definitions.rb
+++ b/gems/aws-sdk-swf/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@swf") do
   @service = Aws::SWF::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-swf/lib/aws-sdk-swf/plugins/read_timeouts.rb
+++ b/gems/aws-sdk-swf/lib/aws-sdk-swf/plugins/read_timeouts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module SWF
     module Plugins

--- a/gems/aws-sdk-synthetics/features/step_definitions.rb
+++ b/gems/aws-sdk-synthetics/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@synthetics") do
   @service = Aws::Synthetics::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-textract/features/step_definitions.rb
+++ b/gems/aws-sdk-textract/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@textract") do
   @service = Aws::Textract::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-transcribeservice/features/step_definitions.rb
+++ b/gems/aws-sdk-transcribeservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@transcribeservice") do
   @service = Aws::TranscribeService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-transcribestreamingservice/features/step_definitions.rb
+++ b/gems/aws-sdk-transcribestreamingservice/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@transcribestreamingservice") do
   @service = Aws::TranscribeStreamingService::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-transfer/features/step_definitions.rb
+++ b/gems/aws-sdk-transfer/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@transfer") do
   @service = Aws::Transfer::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-translate/features/step_definitions.rb
+++ b/gems/aws-sdk-translate/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@translate") do
   @service = Aws::Translate::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-waf/features/step_definitions.rb
+++ b/gems/aws-sdk-waf/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@waf") do
   @service = Aws::WAF::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-wafregional/features/step_definitions.rb
+++ b/gems/aws-sdk-wafregional/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@wafregional") do
   @service = Aws::WAFRegional::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-wafv2/features/step_definitions.rb
+++ b/gems/aws-sdk-wafv2/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@wafv2") do
   @service = Aws::WAFV2::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workdocs/features/step_definitions.rb
+++ b/gems/aws-sdk-workdocs/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workdocs") do
   @service = Aws::WorkDocs::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-worklink/features/step_definitions.rb
+++ b/gems/aws-sdk-worklink/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@worklink") do
   @service = Aws::WorkLink::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workmail/features/step_definitions.rb
+++ b/gems/aws-sdk-workmail/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workmail") do
   @service = Aws::WorkMail::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workmailmessageflow/features/step_definitions.rb
+++ b/gems/aws-sdk-workmailmessageflow/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workmailmessageflow") do
   @service = Aws::WorkMailMessageFlow::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-workspaces/features/step_definitions.rb
+++ b/gems/aws-sdk-workspaces/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@workspaces") do
   @service = Aws::WorkSpaces::Resource.new
   @client = @service.client

--- a/gems/aws-sdk-xray/features/step_definitions.rb
+++ b/gems/aws-sdk-xray/features/step_definitions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@xray") do
   @service = Aws::XRay::Resource.new
   @client = @service.client

--- a/gems/aws-sdk/aws-sdk.gemspec
+++ b/gems/aws-sdk/aws-sdk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
 
   spec.name          = 'aws-sdk'

--- a/gems/aws-sdk/lib/aws-sdk.rb
+++ b/gems/aws-sdk/lib/aws-sdk.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-resources'

--- a/gems/aws-sigv2/aws-sigv2.gemspec
+++ b/gems/aws-sigv2/aws-sigv2.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'aws-sigv2'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip

--- a/gems/aws-sigv2/lib/aws-sigv2.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sigv2/credentials'
 require_relative 'aws-sigv2/signer'
 

--- a/gems/aws-sigv2/lib/aws-sigv2/credentials.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv2
     class Credentials

--- a/gems/aws-sigv2/lib/aws-sigv2/signer.rb
+++ b/gems/aws-sigv2/lib/aws-sigv2/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'base64'
 require 'uri'

--- a/gems/aws-sigv4/aws-sigv4.gemspec
+++ b/gems/aws-sigv4/aws-sigv4.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'aws-sigv4'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip

--- a/gems/aws-sigv4/lib/aws-sigv4.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'aws-sigv4/credentials'
 require_relative 'aws-sigv4/errors'
 require_relative 'aws-sigv4/signature'

--- a/gems/aws-sigv4/lib/aws-sigv4/credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     # Users that wish to configure static credentials can use the

--- a/gems/aws-sigv4/lib/aws-sigv4/errors.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     module Errors

--- a/gems/aws-sigv4/lib/aws-sigv4/request.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Aws

--- a/gems/aws-sigv4/lib/aws-sigv4/signature.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Aws
   module Sigv4
     class Signature

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'tempfile'
 require 'time'

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 require 'tempfile'

--- a/gems/aws-sigv4/spec/spec_helper.rb
+++ b/gems/aws-sigv4/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 $:.unshift(File.expand_path('../../lib', __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-eventstream/lib',  __FILE__))
 

--- a/gems/aws-sigv4/spec/suite_spec.rb
+++ b/gems/aws-sigv4/spec/suite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module Aws

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 desc 'Generates the code for every service'

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 task 'changelog:add' do
   Dir.glob('gems/*').each do |gem_dir|
     path = "#{gem_dir}/CHANGELOG.md"

--- a/tasks/gems.rake
+++ b/tasks/gems.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 desc 'Builds service gems'

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/core/rake_task'
 
 ##

--- a/tasks/update-aws-sdk-dependencies.rake
+++ b/tasks/update-aws-sdk-dependencies.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates list of service gems dependend on by the aws-sdk gem
 task 'update-aws-sdk-dependencies' do
 

--- a/tasks/update-partition-service-list.rake
+++ b/tasks/update-partition-service-list.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates the services in the aws-partitions gem
 task 'update-partition-service-list' do
   lines = []

--- a/tasks/update-readme.rake
+++ b/tasks/update-readme.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # updates the table of supported services in the repo README
 task 'update-readme' do
 

--- a/tasks/update-sensitive-params.rake
+++ b/tasks/update-sensitive-params.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rebuilds the list of parameters that should be filtered when logging
 task 'update-sensitive-params' do
   sensitive = []


### PR DESCRIPTION
Followup: #2328

Since there isn't any big gem left, but many groups of a few files in many different gems, I opted for submitted all the last changes as a single PR.

I simply ran:

```bash
rubocop -a --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment
```

I also adjusted the line numbers in `region_spec.rb`.