### PR TITLE
Filter sensitive params per service/type rather than a global list

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -269,11 +269,6 @@ module AwsSdkCodeGenerator
         def empty?
           @empty
         end
-
-        # @return [Boolean]
-        def sensitive_params?
-          @sensitive_params.any?
-        end
       end
 
       class StructMember

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -48,9 +48,14 @@ module AwsSdkCodeGenerator
           if shape['eventstream']
             list
           elsif struct_type?(shape)
+            struct_members = struct_members(shape)
+            sensitive_params = struct_members.select(&:sensitive).map do |m|
+              m.member_name.to_sym
+            end
             list << StructClass.new(
               class_name: shape_name,
-              members: struct_members(shape),
+              members: struct_members,
+              sensitive_params: sensitive_params,
               documentation: struct_class_docs(shape_name)
             )
           else
@@ -78,10 +83,22 @@ module AwsSdkCodeGenerator
 
       def struct_members(shape)
         return if shape['members'].nil?
-        members = shape['members'].map do |member_name, _|
-          StructMember.new(member_name: underscore(member_name))
+        sensitive = false
+        members = shape['members'].map do |member_name, member_ref|
+          if member_ref['sensitive'] || @api['shapes'][member_ref['shape']]['sensitive']
+            sensitive = true
+          end
+          StructMember.new(
+            member_name: underscore(member_name),
+            sensitive: sensitive
+          )
         end
-        members << StructMember.new(member_name: "event_type") if shape['event']
+        if shape['event']
+          members << StructMember.new(
+            member_name: 'event_type',
+            sensitive: sensitive
+          )
+        end
         members
       end
 
@@ -236,6 +253,7 @@ module AwsSdkCodeGenerator
           @class_name = options.fetch(:class_name)
           @members = options.fetch(:members)
           @documentation = options.fetch(:documentation)
+          @sensitive_params = options.fetch(:sensitive_params)
           if @members.nil? || @members.empty?
             @empty = true
           else
@@ -253,22 +271,33 @@ module AwsSdkCodeGenerator
         # @return [String, nil]
         attr_accessor :documentation
 
+        # @return [Array<Symbol>]
+        attr_accessor :sensitive_params
+
         # @return [Boolean]
         def empty?
           @empty
         end
 
+        # @return [Boolean]
+        def sensitive_params?
+          @sensitive_params.any?
+        end
       end
 
       class StructMember
 
         def initialize(options)
           @member_name = options.fetch(:member_name)
+          @sensitive = options.fetch(:sensitive)
           @last = false
         end
 
         # @return [String]
         attr_accessor :member_name
+
+        # @return [Boolean]
+        attr_accessor :sensitive
 
         # @return [Boolean]
         attr_accessor :last

--- a/build_tools/aws-sdk-code-generator/templates/types_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/types_module.mustache
@@ -17,7 +17,7 @@ module {{module_name}}
       :{{member_name}}{{^last}},{{/last}}{{#last}}){{/last}}
       {{/members}}
       {{#sensitive_params?}}
-      SENSITIVE_PARAMS = {{sensitive_params}}
+      SENSITIVE = {{sensitive_params}}
       {{/sensitive_params?}}
       include Aws::Structure
     end

--- a/build_tools/aws-sdk-code-generator/templates/types_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/types_module.mustache
@@ -16,6 +16,9 @@ module {{module_name}}
       {{#members}}
       :{{member_name}}{{^last}},{{/last}}{{#last}}){{/last}}
       {{/members}}
+      {{#sensitive_params?}}
+      SENSITIVE_PARAMS = {{sensitive_params}}
+      {{/sensitive_params?}}
       include Aws::Structure
     end
     {{/empty?}}

--- a/build_tools/aws-sdk-code-generator/templates/types_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/types_module.mustache
@@ -16,9 +16,7 @@ module {{module_name}}
       {{#members}}
       :{{member_name}}{{^last}},{{/last}}{{#last}}){{/last}}
       {{/members}}
-      {{#sensitive_params?}}
       SENSITIVE = {{sensitive_params}}
-      {{/sensitive_params?}}
       include Aws::Structure
     end
     {{/empty?}}

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Feature - Moved sensitive param filters to request and response Types instead of on a large list.
+* Feature - Provide an option `:filter_sensitive_params` for `Aws::Log::Formatter` to allow disabling of the sensitive param filter (#2312, #2105, #2082).
+
 3.100.0 (2020-06-15)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Moved sensitive param filters to request and response Types instead of on a large list.
+* Feature - Added sensitive params to request and response Types instead of just on a large list.
 * Feature - Provide an option `:filter_sensitive_params` for `Aws::Log::Formatter` to allow disabling of the sensitive param filter (#2312, #2105, #2082).
 
 3.100.0 (2020-06-15)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
@@ -85,6 +85,9 @@ module Aws
       #   The default list of filtered parameters is documented on the
       #   {ParamFilter} class.
       #
+      # @option options [Boolean] :filter_sensitive_params (true) Set to false
+      #   to disable the sensitive parameter filtering when logging
+      #   `:request_params`.
       def initialize(pattern, options = {})
         @pattern = pattern
         @param_formatter = ParamFormatter.new(options)
@@ -99,7 +102,7 @@ module Aws
       # @param [Seahorse::Client::Response] response
       # @return [String]
       def format(response)
-        pattern.gsub(/:(\w+)/) {|sym| send("_#{sym[1..-1]}", response) }
+        pattern.gsub(/:(\w+)/) { |sym| send("_#{sym[1..-1]}", response) }
       end
 
       # @api private
@@ -123,7 +126,8 @@ module Aws
 
       def _request_params(response)
         params = response.context.params
-        @param_formatter.summarize(@param_filter.filter(params))
+        type = response.context.operation.input.shape.struct_class
+        @param_formatter.summarize(@param_filter.filter(params, type))
       end
 
       def _time(response)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -11,7 +11,7 @@ module Aws
         @additional_filters = options[:filter] || []
       end
 
-      def filter(values, type = nil)
+      def filter(values, type)
         case values
         when Struct, Hash then filter_hash(values, type)
         when Array then filter_array(values, type)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -7,7 +7,9 @@ module Aws
   module Log
     class ParamFilter
       # DEPRECATED - this must exist for backwards compatibility. Sensitive
-      # members are now computed for each request/response type.
+      # members are now computed for each request/response type. This can be
+      # removed in a new major version.
+      #
       # A managed list of sensitive parameters that should be filtered from
       # logs. This is updated automatically as part of each release. See the
       # `tasks/update-sensitive-params.rake` for more information.
@@ -36,6 +38,7 @@ module Aws
         if type.const_defined?('SENSITIVE')
           filters = type::SENSITIVE + @additional_filters
         else
+          # Support backwards compatibility (new core + old service)
           filters = SENSITIVE + @additional_filters
         end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -6,40 +6,40 @@ require 'set'
 module Aws
   module Log
     class ParamFilter
-
-      # A managed list of sensitive parameters that should be filtered from
-      # logs. This is updated automatically as part of each release. See the
-      # `tasks/update-sensitive-params.rake` for more information.
-      #
-      # @api private
-      # begin
-      SENSITIVE = [:access_token, :account_name, :account_password, :address, :admin_contact, :admin_password, :alexa_for_business_room_arn, :artifact_credentials, :auth_code, :auth_parameters, :authentication_token, :authorization_result, :backup_plan_tags, :backup_vault_tags, :base_32_string_seed, :block, :block_address, :block_data, :blocks, :body, :bot_configuration, :bot_email, :calling_name, :cause, :client_id, :client_request_token, :client_secret, :comment, :configuration, :content, :copy_source_sse_customer_key, :credentials, :current_password, :custom_attributes, :custom_private_key, :db_password, :default_phone_number, :definition, :description, :destination_access_token, :digest_tip_address, :display_name, :domain_signing_private_key, :e164_phone_number, :email, :email_address, :email_message, :embed_url, :error, :external_meeting_id, :external_model_endpoint_data_blobs, :external_user_id, :fall_back_phone_number, :feedback_token, :file, :filter_expression, :first_name, :full_name, :host_key, :id, :id_token, :input, :input_text, :ion_text, :join_token, :key, :key_id, :key_material, :key_store_password, :kms_key_id, :kms_master_key_id, :lambda_function_arn, :last_name, :local_console_password, :master_account_email, :master_user_name, :master_user_password, :meeting_host_id, :message, :metadata, :name, :new_password, :next_password, :notes, :number, :old_password, :outbound_events_https_endpoint, :output, :owner_information, :parameters, :passphrase, :password, :payload, :phone_number, :plaintext, :previous_password, :primary_email, :primary_provisioned_number, :private_key, :private_key_plaintext, :proof, :proposed_password, :proxy_phone_number, :public_key, :qr_code_png, :query, :random_password, :recovery_point_tags, :refresh_token, :registrant_contact, :request_attributes, :resource_arn, :restore_metadata, :revision, :saml_assertion, :search_query, :secret_access_key, :secret_binary, :secret_code, :secret_hash, :secret_string, :secret_to_authenticate_initiator, :secret_to_authenticate_target, :security_token, :service_password, :session_attributes, :session_token, :share_notes, :shared_secret, :slots, :sns_topic_arn, :source_access_token, :sqs_queue_arn, :sse_customer_key, :ssekms_encryption_context, :ssekms_key_id, :status_message, :tag_key_list, :tags, :target_address, :task_parameters, :tech_contact, :temporary_password, :text, :token, :trust_password, :type, :upload_credentials, :upload_url, :uri, :user_data, :user_email, :user_name, :user_password, :username, :value, :values, :variables, :vpn_psk, :web_identity_token, :zip_file]
-      # end
-
       def initialize(options = {})
-        @filters = Set.new(SENSITIVE + Array(options[:filter]))
+        @enabled = options[:filter_sensitive_params] != false
+        @additional_filters = options[:filter] || []
       end
 
-      def filter(value)
-        case value
-        when Struct, Hash then filter_hash(value)
-        when Array then filter_array(value)
-        else value
+      def filter(values, type = nil)
+        case values
+        when Struct, Hash then filter_hash(values, type)
+        when Array then filter_array(values, type)
+        else values
         end
       end
 
       private
 
-      def filter_hash(values)
+      def filter_hash(values, type)
+        filters = @additional_filters
+        if type.const_defined?('SENSITIVE_PARAMS')
+          filters = type::SENSITIVE_PARAMS + @additional_filters
+        end
+
         filtered = {}
         values.each_pair do |key, value|
-          filtered[key] = @filters.any? { |f| f.to_s.casecmp(key.to_s).zero? } ? '[FILTERED]' : filter(value)
+          filtered[key] = if @enabled && filters.include?(key)
+            '[FILTERED]'
+          else
+            filter(value, type)
+          end
         end
         filtered
       end
 
-      def filter_array(values)
-        values.map { |value| filter(value) }
+      def filter_array(values, type)
+        values.map { |value| filter(value, type) }
       end
 
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -23,8 +23,8 @@ module Aws
 
       def filter_hash(values, type)
         filters = @additional_filters
-        if type.const_defined?('SENSITIVE_PARAMS')
-          filters = type::SENSITIVE_PARAMS + @additional_filters
+        if type.const_defined?('SENSITIVE')
+          filters = type::SENSITIVE + @additional_filters
         end
 
         filtered = {}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -6,6 +6,17 @@ require 'set'
 module Aws
   module Log
     class ParamFilter
+      # DEPRECATED - this must exist for backwards compatibility. Sensitive
+      # members are now computed for each request/response type.
+      # A managed list of sensitive parameters that should be filtered from
+      # logs. This is updated automatically as part of each release. See the
+      # `tasks/update-sensitive-params.rake` for more information.
+      #
+      # @api private
+      # begin
+      SENSITIVE = [:access_token, :account_name, :account_password, :address, :admin_contact, :admin_password, :alexa_for_business_room_arn, :artifact_credentials, :auth_code, :auth_parameters, :authentication_token, :authorization_result, :backup_plan_tags, :backup_vault_tags, :base_32_string_seed, :block, :block_address, :block_data, :blocks, :body, :bot_configuration, :bot_email, :calling_name, :cause, :client_id, :client_request_token, :client_secret, :comment, :configuration, :content, :copy_source_sse_customer_key, :credentials, :current_password, :custom_attributes, :custom_private_key, :db_password, :default_phone_number, :definition, :description, :destination_access_token, :digest_tip_address, :display_name, :domain_signing_private_key, :e164_phone_number, :email, :email_address, :email_message, :embed_url, :error, :external_meeting_id, :external_model_endpoint_data_blobs, :external_user_id, :fall_back_phone_number, :feedback_token, :file, :filter_expression, :first_name, :full_name, :host_key, :id, :id_token, :input, :input_text, :ion_text, :join_token, :key, :key_id, :key_material, :key_store_password, :kms_key_id, :kms_master_key_id, :lambda_function_arn, :last_name, :local_console_password, :master_account_email, :master_user_name, :master_user_password, :meeting_host_id, :message, :metadata, :name, :new_password, :next_password, :notes, :number, :old_password, :outbound_events_https_endpoint, :output, :owner_information, :parameters, :passphrase, :password, :payload, :phone_number, :plaintext, :previous_password, :primary_email, :primary_provisioned_number, :private_key, :private_key_plaintext, :proof, :proposed_password, :proxy_phone_number, :public_key, :qr_code_png, :query, :random_password, :recovery_point_tags, :refresh_token, :registrant_contact, :request_attributes, :resource_arn, :restore_metadata, :revision, :saml_assertion, :search_query, :secret_access_key, :secret_binary, :secret_code, :secret_hash, :secret_string, :secret_to_authenticate_initiator, :secret_to_authenticate_target, :security_token, :service_password, :session_attributes, :session_token, :share_notes, :shared_secret, :slots, :sns_topic_arn, :source_access_token, :sqs_queue_arn, :sse_customer_key, :ssekms_encryption_context, :ssekms_key_id, :status_message, :tag_key_list, :tags, :target_address, :task_parameters, :tech_contact, :temporary_password, :text, :token, :trust_password, :type, :upload_credentials, :upload_url, :uri, :user_data, :user_email, :user_name, :user_password, :username, :value, :values, :variables, :vpn_psk, :web_identity_token, :zip_file]
+      # end
+
       def initialize(options = {})
         @enabled = options[:filter_sensitive_params] != false
         @additional_filters = options[:filter] || []
@@ -22,9 +33,10 @@ module Aws
       private
 
       def filter_hash(values, type)
-        filters = @additional_filters
         if type.const_defined?('SENSITIVE')
           filters = type::SENSITIVE + @additional_filters
+        else
+          filters = SENSITIVE + @additional_filters
         end
 
         filtered = {}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -48,7 +48,7 @@ module Aws
 
     # Wraps the default #to_s logic with filtering of sensitive parameters.
     def to_s(obj = self)
-      Aws::Log::ParamFilter.new.filter(obj).to_s
+      Aws::Log::ParamFilter.new.filter(obj, obj.class).to_s
     end
 
     class << self

--- a/gems/aws-sdk-core/spec/api_helper.rb
+++ b/gems/aws-sdk-core/spec/api_helper.rb
@@ -56,6 +56,7 @@ module ApiHelper
             'NestedMap' => { 'shape' => 'StructureMap' },
             'NumberList' => { 'shape' => 'IntegerList' },
             'StringMap' => { 'shape' => 'StringMap' },
+            'SensitiveString' => { 'shape' => 'SensitiveStringShape' },
             # scalar members
             'Blob' => { 'shape' => 'BlobShape' },
             'Byte' => { 'shape' => 'ByteShape' },
@@ -120,6 +121,7 @@ module ApiHelper
         'IntegerShape' => { 'type' => 'integer' },
         'LongShape' => { 'type' => 'long' },
         'StringShape' => { 'type' => 'string' },
+        'SensitiveStringShape' => { 'type' => 'string', 'sensitive' => true },
         'TimestampShape' => { 'type' => 'timestamp' },
       }
     end

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -7,21 +7,34 @@ module Aws
   module Log
     describe Formatter do
 
-      let(:response) { Seahorse::Client::Response.new }
+      let(:operation_request_type) do
+        class OperationRequestType < Struct
+          include Aws::Structure
+        end
+      end
+
+      let(:operation_request) do
+        shape = Seahorse::Model::Shapes::StructureShape.new(name: 'OperationRequest')
+        shape.struct_class = operation_request_type
+        shape
+      end
+
+      let(:response) do
+        resp = Seahorse::Client::Response.new
+        resp.context.operation = Seahorse::Model::Operation.new.tap do |o|
+          o.input = Seahorse::Model::Shapes::ShapeRef.new(
+            shape: operation_request
+          )
+        end
+        resp
+      end
 
       def format(pattern, options = {})
         Formatter.new(pattern, options).format(response)
       end
 
       before do
-        class OperationRequestType < Struct
-          include Aws::Structure
-        end
-        OperationRequest = Seahorse::Model::Shapes::StructureShape.new(name: 'OperationRequest')
-        response.context.operation = Seahorse::Model::Operation.new.tap do |o|
-          o.input = Seahorse::Model::Shapes::ShapeRef.new(shape: OperationRequest)
-        end
-        OperationRequest.struct_class = OperationRequestType
+
       end
 
       describe '#format' do

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -6,7 +6,6 @@ require 'pathname'
 module Aws
   module Log
     describe Formatter do
-
       let(:operation_request_type) do
         class OperationRequestType < Struct
           include Aws::Structure
@@ -31,10 +30,6 @@ module Aws
 
       def format(pattern, options = {})
         Formatter.new(pattern, options).format(response)
-      end
-
-      before do
-
       end
 
       describe '#format' do

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -13,6 +13,17 @@ module Aws
         Formatter.new(pattern, options).format(response)
       end
 
+      before do
+        class OperationRequestType < Struct
+          include Aws::Structure
+        end
+        OperationRequest = Seahorse::Model::Shapes::StructureShape.new(name: 'OperationRequest')
+        response.context.operation = Seahorse::Model::Operation.new.tap do |o|
+          o.input = Seahorse::Model::Shapes::ShapeRef.new(shape: OperationRequest)
+        end
+        OperationRequest.struct_class = OperationRequestType
+      end
+
       describe '#format' do
 
         it 'provides a :client_class replacement' do

--- a/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
@@ -8,7 +8,7 @@ module Aws
       class SensitiveType < Struct.new(
         :peccy_id,
         :password)
-        SENSITIVE_PARAMS = [:password]
+        SENSITIVE = [:password]
         include Aws::Structure
       end
 

--- a/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
@@ -12,62 +12,51 @@ module Aws
         include Aws::Structure
       end
 
-      class InsensitiveType < Struct.new(
-        :peccy_id)
+      class OldServiceType < Struct.new(
+        :peccy_id,
+        :password)
         include Aws::Structure
       end
 
       describe '#filter' do
         it 'filters sensitive hash params' do
-          filtered = subject.filter({ password: 'peccy' }, SensitiveType)
-          expect(filtered).to eq(password: '[FILTERED]')
+          filtered = subject.filter(
+            { password: 'peccy', peccy_id: 'peccy-id' }, SensitiveType
+          )
+          expect(filtered).to eq(password: '[FILTERED]', peccy_id: 'peccy-id')
         end
 
         it 'filters sensitive array params' do
-          filtered = subject.filter([{ password: 'peccy' }], SensitiveType)
-          expect(filtered).to eq([{ password: '[FILTERED]' }])
+          filtered = subject.filter(
+            [{ password: 'peccy', peccy_id: 'peccy-id' }], SensitiveType
+          )
+          expect(filtered).to eq(
+            [{ password: '[FILTERED]', peccy_id: 'peccy-id' }]
+          )
         end
 
         it 'filters sensitive Struct params' do
-          instance = Struct.new(:password).new('peccy')
+          instance = Struct.new(:peccy_id, :password).new('peccy-id', 'peccy')
           filtered = subject.filter(instance, SensitiveType)
-          expect(filtered).to eq(password: '[FILTERED]')
-        end
-
-        context 'no sensitive params' do
-          it 'does not filter sensitive hash params' do
-            unfiltered = subject.filter({ peccy_id: 'peccy-id' }, InsensitiveType)
-            expect(unfiltered).to eq(peccy_id: 'peccy-id')
-          end
-
-          it 'does not filter sensitive array params' do
-            unfiltered = subject.filter([{ peccy_id: 'peccy-id' }], InsensitiveType)
-            expect(unfiltered).to eq([{ peccy_id: 'peccy-id' }])
-          end
-
-          it 'does not filter sensitive Struct params' do
-            instance = Struct.new(:peccy_id).new('peccy-id')
-            unfiltered = subject.filter(instance, InsensitiveType)
-            expect(unfiltered).to eq(peccy_id: 'peccy-id')
-          end
+          expect(filtered).to eq(password: '[FILTERED]', peccy_id: 'peccy-id')
         end
 
         context 'with additional filters' do
           subject { Aws::Log::ParamFilter.new(filter: [:peccy_id]) }
 
           it 'filters sensitive hash params' do
-            filtered = subject.filter({ peccy_id: 'peccy-id' }, InsensitiveType)
+            filtered = subject.filter({ peccy_id: 'peccy-id' }, SensitiveType)
             expect(filtered).to eq(peccy_id: '[FILTERED]')
           end
 
           it 'filters sensitive array params' do
-            filtered = subject.filter([{ peccy_id: 'peccy-id' }], InsensitiveType)
+            filtered = subject.filter([{ peccy_id: 'peccy-id' }], SensitiveType)
             expect(filtered).to eq([{ peccy_id: '[FILTERED]' }])
           end
 
           it 'filters sensitive Struct params' do
             instance = Struct.new(:peccy_id).new('peccy-id')
-            filtered = subject.filter(instance, InsensitiveType)
+            filtered = subject.filter(instance, SensitiveType)
             expect(filtered).to eq(peccy_id: '[FILTERED]')
           end
         end
@@ -89,6 +78,31 @@ module Aws
             instance = Struct.new(:password).new('peccy')
             unfiltered = subject.filter(instance, SensitiveType)
             expect(unfiltered).to eq(password: 'peccy')
+          end
+        end
+
+        # hinges on :password being sensitive and :peccy_id never existing
+        context 'backwards compatible with old service gems' do
+          it 'filters sensitive hash params' do
+            filtered = subject.filter(
+              { password: 'peccy', peccy_id: 'peccy-id' }, OldServiceType
+            )
+            expect(filtered).to eq(password: '[FILTERED]', peccy_id: 'peccy-id')
+          end
+
+          it 'filters sensitive array params' do
+            filtered = subject.filter(
+              [{ password: 'peccy', peccy_id: 'peccy-id' }], OldServiceType
+            )
+            expect(filtered).to eq(
+              [{ password: '[FILTERED]', peccy_id: 'peccy-id' }]
+            )
+          end
+
+          it 'filters sensitive Struct params' do
+            instance = Struct.new(:peccy_id, :password).new('peccy-id', 'peccy')
+            filtered = subject.filter(instance, OldServiceType)
+            expect(filtered).to eq(password: '[FILTERED]', peccy_id: 'peccy-id')
           end
         end
       end

--- a/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
@@ -7,7 +7,7 @@ module Aws
   module Plugins
     describe HttpChecksum do
       HttpChecksumClient = ApiHelper.sample_service(
-        metadata: {'protocol' => 'rest-xml'},
+        metadata: { 'protocol' => 'rest-xml' },
         operations: {
           'Operation' => {
             'http' => { 'method' => 'POST', 'requestUri' => '/' },

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -79,10 +79,13 @@ module Aws
 
     describe "#to_s" do
       it 'filters sensitive parameters' do
-        struct = Structure.new(:trait, :access_token).new
-        struct.trait = "Trait"
-        struct.access_token = "asdf1234"
-        expect(struct.to_s).to eq("{:trait=>\"Trait\", :access_token=>\"[FILTERED]\"}")
+        class Type < Structure.new(
+          :trait, :access_token)
+          SENSITIVE_PARAMS = [:access_token]
+          include Aws::Structure
+        end
+        struct = Type.new(trait: 'trait', access_token: 'secret')
+        expect(struct.to_s).to eq("{:trait=>\"trait\", :access_token=>\"[FILTERED]\"}")
       end
     end
 

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -81,7 +81,7 @@ module Aws
       it 'filters sensitive parameters' do
         class Type < Structure.new(
           :trait, :access_token)
-          SENSITIVE_PARAMS = [:access_token]
+          SENSITIVE = [:access_token]
           include Aws::Structure
         end
         struct = Type.new(trait: 'trait', access_token: 'secret')

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -25,6 +25,7 @@ module Aws
           integer: 0,
           long: 0,
           string: "StringShape",
+          sensitive_string: 'SensitiveStringShape',
           timestamp: now,
         })
       end

--- a/tasks/update-sensitive-params.rake
+++ b/tasks/update-sensitive-params.rake
@@ -2,28 +2,5 @@
 
 # rebuilds the list of parameters that should be filtered when logging
 task 'update-sensitive-params' do
-  sensitive = []
-  BuildTools::Services.each do |svc|
-    svc.api['shapes'].each_pair do |shape_name, shape|
-      if shape['type'] == 'structure' && shape['members']
-        shape['members'].each_pair do |member_name, member_ref|
-          if 
-            member_ref['sensitive'] || 
-            svc.api['shapes'][member_ref['shape']]['sensitive']
-          then
-            name = AwsSdkCodeGenerator::Underscore.underscore(member_name).to_sym
-            sensitive << name
-          end
-        end
-      end
-    end
-  end
-  sensitive = sensitive.uniq.map(&:inspect).sort.join(', ')
-
-  BuildTools.replace_lines(
-    filename: "#{$GEMS_DIR}/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb", 
-    start: /# begin/,
-    stop: /# end/,
-    new_lines: "      SENSITIVE = [#{sensitive}]\n"
-  )
+  # no-op
 end

--- a/tasks/update-sensitive-params.rake
+++ b/tasks/update-sensitive-params.rake
@@ -2,5 +2,28 @@
 
 # rebuilds the list of parameters that should be filtered when logging
 task 'update-sensitive-params' do
-  # no-op
+  sensitive = []
+  BuildTools::Services.each do |svc|
+    svc.api['shapes'].each_pair do |shape_name, shape|
+      if shape['type'] == 'structure' && shape['members']
+        shape['members'].each_pair do |member_name, member_ref|
+          if 
+            member_ref['sensitive'] || 
+            svc.api['shapes'][member_ref['shape']]['sensitive']
+          then
+            name = AwsSdkCodeGenerator::Underscore.underscore(member_name).to_sym
+            sensitive << name
+          end
+        end
+      end
+    end
+  end
+  sensitive = sensitive.uniq.map(&:inspect).sort.join(', ')
+
+  BuildTools.replace_lines(
+    filename: "#{$GEMS_DIR}/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb", 
+    start: /# begin/,
+    stop: /# end/,
+    new_lines: "      SENSITIVE = [#{sensitive}]\n"
+  )
 end


### PR DESCRIPTION
Filters sensitive params only if they are marked in the type (via codegen)
Provide an option to disable sensitive param filtering if needed.

Fixes #2312, #2105, #2082

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
