### PR TITLE
Don't overwrite `host` header in sigv4 signer if given.

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Don't overwrite `host` header in sigv4 signer if given.
+
 1.2.0 (2020-06-17)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -219,7 +219,7 @@ module Aws
         content_sha256 ||= sha256_hexdigest(request[:body] || '')
 
         sigv4_headers = {}
-        sigv4_headers['host'] = host(url)
+        sigv4_headers['host'] = headers['host'] || host(url)
         sigv4_headers['x-amz-date'] = datetime
         sigv4_headers['x-amz-security-token'] = creds.session_token if creds.session_token
         sigv4_headers['x-amz-content-sha256'] ||= content_sha256 if @apply_checksum_header
@@ -376,7 +376,7 @@ module Aws
         url = extract_url(options)
 
         headers = downcase_headers(options[:headers])
-        headers['host'] = host(url)
+        headers['host'] ||= host(url)
 
         datetime = headers['x-amz-date']
         datetime ||= (options[:time] || Time.now).utc.strftime("%Y%m%dT%H%M%SZ")

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -146,7 +146,7 @@ module Aws
 
         context 'when a Host header is provided' do
           
-          let(:headers) { 'host' => 'custom-host-value' }
+          let(:headers) { {'host' => 'custom-host-value'} }
 
           it 'uses the original Host header' do
             signature = Signer.new(options.merge(headers: headers)).sign_request(request)

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -146,12 +146,12 @@ module Aws
 
         context 'when a Host header is provided' do
           
-          let(:headers) { {'host' => 'custom-host-value'} }
+          let(:headers) { { headers: { 'host' => 'custom-host-value' } } }
 
           it 'uses the original Host header' do
-            signature = Signer.new(options.merge(headers: headers)).sign_request(request)
+            signature = Signer.new(options).sign_request(request.merge(headers))
 
-            expect(signature.headers['host']).to eql(custom-host-value)
+            expect(signature.headers['host']).to eql('custom-host-value')
           end
         end
 

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -145,13 +145,12 @@ module Aws
         end
 
         context 'when a Host header is provided' do
-          
-          let(:headers) { { headers: { 'host' => 'custom-host-value' } } }
+          it 'uses the provided Host header' do
+            signature = Signer.new(options).sign_request(
+              request.merge(headers: { 'host' => 'otherdomain.com' })
+            )
 
-          it 'uses the original Host header' do
-            signature = Signer.new(options).sign_request(request.merge(headers))
-
-            expect(signature.headers['host']).to eql('custom-host-value')
+            expect(signature.headers['host']).to eql('otherdomain.com')
           end
         end
 

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -144,6 +144,17 @@ module Aws
           expect(signature.headers['host']).to eq('domain.com')
         end
 
+        context 'when a Host header is provided' do
+          
+          let(:options) { options.merge('host' => 'custom-host-value') }
+
+          it 'uses the original Host header' do
+            signature = Signer.new(options).sign_request(request)
+
+            expect(signature.headers['host']).to eql(custom-host-value)
+          end
+        end
+
         context 'when credentials are not set' do
           let(:creds) do
             Credentials.new(access_key_id: '', secret_access_key: '')

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -146,10 +146,10 @@ module Aws
 
         context 'when a Host header is provided' do
           
-          let(:options) { options.merge('host' => 'custom-host-value') }
+          let(:headers) { 'host' => 'custom-host-value' }
 
           it 'uses the original Host header' do
-            signature = Signer.new(options).sign_request(request)
+            signature = Signer.new(options.merge(headers: headers)).sign_request(request)
 
             expect(signature.headers['host']).to eql(custom-host-value)
           end


### PR DESCRIPTION
Closes #2339 

Makes sigv4's `Signer#sign_request` keep the original Host header if that header was given, instead of overwriting it with a host header from the URL. 

This also updates `Signer#presign_url`, which looks like it would have the same issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
