### PR TITLE
Added rspec-retry to fix flaky multipart copy specs in Jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ group :test do
 
   gem 'multipart-post'
   gem 'rspec'
+  gem 'rspec-retry'
 end
 
 group :build do

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift(File.expand_path('../../../aws-eventstream/lib',  __FILE__))
 $LOAD_PATH.unshift(File.expand_path('../../../aws-partitions/lib',  __FILE__))
 
 require 'webmock/rspec'
+require 'rspec/retry'
 
 # Prevent the SDK unit tests from loading actual credentials while under test.
 # By default the SDK attempts to load credentials from:
@@ -32,6 +33,9 @@ RSpec.configure do |config|
 
     Aws.shared_config.fresh
   end
+
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
 
   # Thread.report_on_exception was set to default true in Ruby 2.5
   # When testing code that intentionally has threads that raise exceptions

--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 module Aws
   module S3
-    describe Object do
+    describe Object, retry: 3 do
       let(:object) do
         S3::Object.new('bucket', 'unescaped/key path', stub_responses: true)
       end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
