### PR TITLE
Use an array of stubs to ensure each request gets a new response object

### DIFF
--- a/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/multipart_copy_spec.rb
@@ -364,7 +364,7 @@ module Aws
           end
 
           it 'aborts the upload on errors', thread_report_on_exception: false do
-            client.stub_responses(:upload_part_copy, 'NoSuchKey')
+            client.stub_responses(:upload_part_copy, Array.new(10, 'NoSuchKey'))
             allow(client).to receive(:create_multipart_upload)
               .with(bucket: 'bucket', key: 'unescaped/key path')
               .and_return(


### PR DESCRIPTION
This change fixes random failures in the `Aws::S3::Object#copy_from with multipart_copy: true aborts the upload on errors` spec in JRuby.

When we create a stubbed response for a string (which means raise a service error with that code), we create 1 http request.  We set the body of that request to the given error code.  That body is a StringIO object. So that single http response object gets used by many threads.  To work around that, this change passes an array of stubs to ensure each thread gets a seperate response object to read from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
