### PR TITLE
Fix uninitialized constant Aws::S3::Plugins::RetryableBlockIO::Forwar…

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/streaming_retry.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/streaming_retry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module Aws
   module S3
     module Plugins


### PR DESCRIPTION
…dable
```
(/home/runner/.rubies/ruby-2.5.5/bin/cab)
NameError: uninitialized constant Aws::S3::Plugins::RetryableBlockIO::Forwardable
  /home/runner/.rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/aws-sdk-s3-1.71.0/lib/aws-sdk-s3/plugins/streaming_retry.rb:10:in `<class:RetryableBlockIO>'
  /home/runner/.rubies/ruby-2.5.5
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
