### PR TITLE
Prevent double callback: Add the readpartial method to IO wrapper

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
@@ -21,11 +21,23 @@ module Seahorse
         attr_reader :io
 
         def read(*args)
-          ret = @io.read(*args)
-          @bytes_read += ret.bytesize if ret && ret.respond_to?(:bytesize)
+          @io.read(*args).tap do |chunk|
+            handle_chunk(chunk)
+          end
+        end
+
+        def readpartial(*args)
+          @io.readpartial(*args).tap do |chunk|
+            handle_chunk(chunk)
+          end
+        end
+
+        private
+
+        def handle_chunk(chunk)
+          @bytes_read += chunk.bytesize if chunk && chunk.respond_to?(:bytesize)
           total_size = @io.respond_to?(:size) ? @io.size : nil
-          @on_read.call(ret, @bytes_read, total_size) if @on_read
-          ret
+          @on_read.call(chunk, @bytes_read, total_size) if @on_read
         end
       end
 


### PR DESCRIPTION
According to documentation from `IO#copy_stream` the "IO like" object provided for source should have the `readpartial` and/or the `read` method.  If it has the `readpartial` that will be preferred.   Adding an implementation of `readpartial` prevents the on_chunk_sent from being called twice on small bodies.  

*Before*:
```
res = s3.put_object(body: "some_text", on_chunk_sent: Proc.new { |_chunk, read_bytes, total| puts "Progress: #{100.0 * read_bytes / total}%"} )

Progress: 100.0%
Progress: 100.0%
```

*After:*
```
res = s3.put_object(body: "some_text", on_chunk_sent: Proc.new { |_chunk, read_bytes, total| puts "Progress: #{100.0 * read_bytes / total}%"} )

Progress: 100.0%
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
