### PR TITLE
Sort query params with same names by value when signing.

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Issue - Sort query params with same names by value when signing. Fixes #2376
-
 3.104.3 (2020-07-23)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Sort query params with same names by value when signing. Fixes #2376
+
 3.104.3 (2020-07-23)
 ------------------
 

--- a/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
+++ b/gems/aws-sdk-core/spec/support/retry_errors_helper.rb
@@ -71,7 +71,7 @@ def apply_expectations(test_case)
       resp.context.config.client_rate_limiter.instance_variable_get(
         :@calculated_rate
       )
-    ).to be_within(0.1).of(expected[:calculated_rate])
+    ).to be_within(0.2).of(expected[:calculated_rate])
   end
   if expected[:measured_tx_rate]
     expect(

--- a/gems/aws-sdk-polly/spec/presigner_spec.rb
+++ b/gems/aws-sdk-polly/spec/presigner_spec.rb
@@ -50,7 +50,7 @@ module Aws
             'us-west-2%2Fpolly%2Faws4_request&'\
             'X-Amz-Date=20160101T112233Z&X-Amz-Expires=900&'\
             'X-Amz-SignedHeaders=host&'\
-            'X-Amz-Signature=956ef486286b12f43ffc02dd09eae03cfea4cd8dfb30e0fab3f23de4e131195a'
+            'X-Amz-Signature=acb554087d5e340223b3415c79618adeb5c2b6dba19ba91771fbbe1d50a78f3d'
 
           pre = Presigner.new(region: region, credentials: credentials)
           params = {

--- a/gems/aws-sdk-s3/spec/encryption/client_functional_spec.rb
+++ b/gems/aws-sdk-s3/spec/encryption/client_functional_spec.rb
@@ -84,6 +84,7 @@ module Aws
             client.put_object(bucket: test_bucket, key: test_object, body: plaintext)
 
             stub_get(s3_client, data, true)
+            expect_any_instance_of(Aws::S3::Encryption::DecryptHandler).to receive(:warn)
             decrypted = ''
             client.get_object(bucket: test_bucket, key: test_object) do |chunk|
               decrypted += chunk

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Sort query params with same names by value when signing. Fixes #2376
+* Issue - Sort query params with same names by value when signing. (#2376)
 
 1.2.1 (2020-06-24)
 ------------------

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Sort query params with same names by value when signing. Fixes #2376
+
 1.2.1 (2020-06-24)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -514,16 +514,23 @@ module Aws
         # Default sort <=> in JRuby will swap members
         # occasionally when <=> is 0 (considered still sorted), but this
         # causes our normalized query string to not match the sent querystring.
-        # When names match, we then sort by their values
-        params.sort do |a, b|
+        # When names match, we then sort by their values.  When values also
+        # match then we sort by
+        params.each.with_index.sort do |a, b|
+          a, a_offset = a
+          b, b_offset = b
           a_name, a_value = a.split('=')
           b_name, b_value = b.split('=')
           if a_name == b_name
-            a_value <=> b_value
+            if a_value == b_value
+              a_offset <=> b_offset
+            else
+              a_value <=> b_value
+            end
           else
             a_name <=> b_name
           end
-        end.join('&')
+        end.map(&:first).join('&')
       end
 
       def signed_headers(headers)

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -548,7 +548,7 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
           EOF
         end
 
-        it 'sorts by name, params with same name stay in the same order' do
+        it 'sorts by name, params with same name are ordered by value' do
           signature = Signer.new(options).sign_request(
             http_method: 'PUT',
             url: 'http://domain.com?q.options=abc&q=xyz&q=mno',
@@ -556,17 +556,7 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
               'X-Amz-Date' => '20160101T112233Z',
             }
           )
-          expect(signature.canonical_request).to eq(<<-EOF.strip)
-PUT
-/
-q=xyz&q=mno&q.options=abc
-host:domain.com
-x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-x-amz-date:20160101T112233Z
-
-host;x-amz-content-sha256;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-          EOF
+          expect(signature.canonical_request).to include('q=mno&q=xyz&q.options=abc')
         end
 
         it 'uses the X-Amz-Content-Sha256 header when present' do


### PR DESCRIPTION
Fixes #2376 

From: https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
> Sort the parameter names by character code point in ascending order.
> Parameters with duplicate names should be sorted by value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
