### PR TITLE
Delete reference to deleted file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ appreciate help on:
    and via a pair of [YARD](https://github.com/lsegal/yard) plugins.
 3. **Tests** – We maintain high code coverage, but if there are any tests you feel are missing, please add them.
 4. **Convenience features** – Are there any features you feel would add value to the SDK? Contributions in this
-   area would be greatly appreciated. See the [feature requests document][feature-requests] for a list of ideas.
+   area would be greatly appreciated. 
 5. If you have some other ideas, please let us know!
 
 ## Running the unit tests
@@ -59,7 +59,6 @@ contain a `"region"` and credentials. Running rake test when this file is presen
 
 [issues]: https://github.com/aws/aws-sdk-ruby/issues
 [pull-requests]: https://github.com/aws/aws-sdk-ruby/pulls
-[feature-requests]: https://github.com/aws/aws-sdk-ruby/blob/master/FEATURE_REQUESTS.md
 [license]: http://aws.amazon.com/apache2.0/
 [cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
 [docs-readme]: https://github.com/aws/aws-sdk-php/blob/master/docs/README.md


### PR DESCRIPTION
`FEATURE_REQUESTS.md` was deleted in a0d4497c44359d74942a46114ccc28a29205ed6c so it shouldn't be referenced here

Omitting CHANGELOG.md entry as this is a typo fix in a non-code file.