### PR TITLE
Automatically use SSO provider when profile is SSO

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -28,6 +28,7 @@ module Aws
         [:env_credentials, {}],
         [:assume_role_web_identity_credentials, {}],
         [:assume_role_credentials, {}],
+        [:sso_credentials, {}],
         [:shared_credentials, {}],
         [:process_credentials, {}],
         [:instance_profile_credentials, {
@@ -113,6 +114,13 @@ module Aws
       end
     rescue Errors::NoSuchProfileError
       nil
+    end
+
+    def sso_credentials(options)
+      profile_name = determine_profile_name(options)
+      if Aws.shared_config.config_enabled? && !profile_name.nil?
+        Aws.shared_config.assume_sso_credentials(options.merge(profile: profile_name))
+      end
     end
 
     def assume_role_credentials(options)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@alextwoods Not sure if this is quite the right approach, but adding this to your SSO Creds code means that the credentials will automatically be set from the profile when creating clients. The benefit that this brings is that the same code will work in an environment where the credentials are pulled in from SSO, environment variables, instance profile etc. without having to add "special" logic.

Feel free to rewrite/take only the idea/ignore

Fixes #2396 