### PR TITLE
Fix Struct::Tms deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix Struct::Tms deprecation warnings
+
 2.11.595 (2020-09-28)
 ------------------
 

--- a/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/eager_loader.rb
@@ -16,6 +16,7 @@ module Aws
     def load(klass_or_module)
       @loaded << klass_or_module
       klass_or_module.constants.each do |const_name|
+        next if const_name == :Tms
         path = klass_or_module.autoload?(const_name)
         begin
           require(path) if path


### PR DESCRIPTION
Fixes: #2323 by applying the patch from [dpl#1208](https://github.com/travis-ci/dpl/pull/1208).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
