### PR TITLE
Rename JSON / OJ Engine Files

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb
@@ -2,14 +2,14 @@
 
 module Aws
   module Json
-    class OjEngine
+    class JSONEngine
 
       def self.load(json)
-        Oj.load(json)
+        JSON.load(json)
       end
 
       def self.dump(value)
-        Oj.dump(value)
+        JSON.dump(value)
       end
 
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/oj_engine.rb
@@ -2,14 +2,14 @@
 
 module Aws
   module Json
-    class JSONEngine
+    class OjEngine
 
       def self.load(json)
-        JSON.load(json)
+        Oj.load(json)
       end
 
       def self.dump(value)
-        JSON.dump(value)
+        Oj.dump(value)
       end
 
     end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

These filenames should be swapped as `oj_engine.rb` contains `JSONEngine` and `json_engine.rb` contains `OjEngine`.