### PR TITLE
Fix multipart_threshold documentation

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `multipart_threshold` documentation.
+
 1.83.0 (2020-10-02)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -282,8 +282,8 @@ module Aws
       #     # small files are uploaded in a single API call
       #     obj.upload_file('/path/to/file')
       #
-      # Files larger than `:multipart_threshold` are uploaded using the
-      # Amazon S3 multipart upload APIs.
+      # Files larger than or equal to `:multipart_threshold` are uploaded
+      # using the Amazon S3 multipart upload APIs.
       #
       #     # large files are automatically split into parts
       #     # and the parts are uploaded in parallel
@@ -313,7 +313,8 @@ module Aws
       #   will be empty.
       #
       # @option options [Integer] :multipart_threshold (15728640) Files larger
-      #   than `:multipart_threshold` are uploaded using the S3 multipart APIs.
+      #   than or equal to `:multipart_threshold` are uploaded using the S3
+      #   multipart APIs.
       #   Default threshold is 15MB.
       #
       # @option options [Integer] :thread_count (10) The number of parallel

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb
@@ -22,7 +22,7 @@ module Aws
       # @return [Client]
       attr_reader :client
 
-      # @return [Integer] Files larger than this in bytes are uploaded
+      # @return [Integer] Files larger than or equal to this in bytes are uploaded
       #   using a {MultipartFileUploader}.
       attr_reader :multipart_threshold
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

The `multipart_threshold` size comparaison is done with the superior or equal operator (`>=`) as seen on https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb#L37

```ruby
if File.size(source) >= multipart_threshold
  MultipartFileUploader.new(@options).upload(source, options)
```

The documentation is incorrectly stating: 

> Files larger than `:multipart_threshold` are uploaded using the Amazon S3 multipart upload APIs.