### PR TITLE
No need to send a public method "Object#extend"

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -49,8 +49,8 @@ module Aws
   module PageableResponse
 
     def self.extended(base)
-      base.send(:extend, Enumerable)
-      base.send(:extend, UnsafeEnumerableMethods)
+      base.extend Enumerable
+      base.extend UnsafeEnumerableMethods
       base.instance_variable_set("@last_page", nil)
       base.instance_variable_set("@more_results", nil)
     end

--- a/gems/aws-sdk-core/spec/aws/errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/errors_spec.rb
@@ -8,7 +8,7 @@ module Aws
 
       let(:mod) {
         mod = Module.new
-        mod.send(:extend, DynamicErrors)
+        mod.extend DynamicErrors
         mod
       }
 

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations.rb
@@ -4,7 +4,7 @@
 require 'aws-sdk-ec2/customizations/resource'
 require 'aws-sdk-ec2/customizations/instance'
 
-Aws::EC2::Instance::Collection.send(:extend, Aws::Deprecations)
+Aws::EC2::Instance::Collection.extend Aws::Deprecations
 {
   create_tags: :batch_create_tags,
   monitor: :batch_create_tags,
@@ -19,5 +19,5 @@ Aws::EC2::Instance::Collection.send(:extend, Aws::Deprecations)
 end
 
 Aws::EC2::Tag::Collection.send(:alias_method, :delete, :batch_delete!)
-Aws::EC2::Tag::Collection.send(:extend, Aws::Deprecations)
+Aws::EC2::Tag::Collection.extend Aws::Deprecations
 Aws::EC2::Tag::Collection.send(:deprecated, :delete, use: :batch_delete!)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
@@ -29,6 +29,6 @@ require 'aws-sdk-s3/customizations/types/list_object_versions_output'
   Aws::S3::ObjectVersion::Collection,
 ].each do |klass|
   klass.send(:alias_method, :delete, :batch_delete!)
-  klass.send(:extend, Aws::Deprecations)
+  klass.extend Aws::Deprecations
   klass.send(:deprecated, :delete, use: :batch_delete!)
 end


### PR DESCRIPTION
`Object#extend` has been defined as a public method since the last century (I don't exactly know when, but it already was a public method even on version 1.0.0).
So we don't need to call it via `send`.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. Can I just submit this without editing the changelog? I don't want to claim for a credit for a trivial change like this...
