### PR TITLE
Fix incorrect documentation for list_buckets

### DIFF
--- a/apis/s3/2006-03-01/examples-1.json
+++ b/apis/s3/2006-03-01/examples-1.json
@@ -981,9 +981,9 @@
           "output": {
           }
         },
-        "description": "The following example return versions of an object with specific key name prefix. The request limits the number of items returned to two. If there are are more than two object version, S3 returns NextToken in the response. You can specify this token value in your next request to fetch next set of object versions.",
+        "description": "The following example returns a list of all buckets owned by the authenticated sender of the request.",
         "id": "to-list-object-versions-1481910996058",
-        "title": "To list object versions"
+        "title": "To list buckets"
       }
     ],
     "ListMultipartUploads": [


### PR DESCRIPTION
Hi, I wasn't sure if this was more fit to be a PR or an issue. I've been using the s3 API recently and noticed that the example docs for [list_buckets](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/S3/Client.html#list_buckets-instance_method) are not correct, and looks like it was erroneously copy-pasted from [list_object_versions](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/S3/Client.html#list_object_versions-instance_method).

In this PR I've modified `description` and `title` (stealing the description from the [boto docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_buckets)). `id` should also be changed, but I have not done so yet because I don't know where that numerical id comes from. Additionally, [gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb](https://github.com/aws/aws-sdk-ruby/blob/13394b6ec2ab35baf0ba574b6a0b3c5ae82a03a6/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb#L6694-L6698) needs to be updated, but since that is autogenerated, I wasn't sure what the best way to do that was.

I hope this is helpful!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
