### PR TITLE
Tagged Unions

### DIFF
--- a/apis/dynamodb/2012-08-10/api-2.json
+++ b/apis/dynamodb/2012-08-10/api-2.json
@@ -736,6 +736,7 @@
       "type":"structure",
       "members":{
         "S":{"shape":"StringAttributeValue"},
+        "N":{"shape":"NumberAttributeValue"},
         "B":{"shape":"BinaryAttributeValue"},
         "SS":{"shape":"StringSetAttributeValue"},
         "NS":{"shape":"NumberSetAttributeValue"},

--- a/apis/dynamodb/2012-08-10/api-2.json
+++ b/apis/dynamodb/2012-08-10/api-2.json
@@ -736,7 +736,6 @@
       "type":"structure",
       "members":{
         "S":{"shape":"StringAttributeValue"},
-        "N":{"shape":"NumberAttributeValue"},
         "B":{"shape":"BinaryAttributeValue"},
         "SS":{"shape":"StringSetAttributeValue"},
         "NS":{"shape":"NumberSetAttributeValue"},
@@ -745,7 +744,8 @@
         "L":{"shape":"ListAttributeValue"},
         "NULL":{"shape":"NullAttributeValue"},
         "BOOL":{"shape":"BooleanAttributeValue"}
-      }
+      },
+      "union": true
     },
     "AttributeValueList":{
       "type":"list",

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -100,6 +100,9 @@ module AwsSdkCodeGenerator
           if member_ref['jsonvalue']
             docstring = docstring.to_s + "<p><b>SDK automatically handles json encoding and base64 encoding for you when the required value (Hash, Array, etc.) is provided according to the description.</b></p>"
           end
+          if member_ref['union']
+            docstring = docstring.to_s + "<p>UNION DOCUMENTATION</p>"
+          end
           YardOptionTag.new(
             name: Underscore.underscore(member_name),
             ruby_type: Api.ruby_input_type(member_ref, api, operation),

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -101,7 +101,7 @@ module AwsSdkCodeGenerator
             docstring = docstring.to_s + "<p><b>SDK automatically handles json encoding and base64 encoding for you when the required value (Hash, Array, etc.) is provided according to the description.</b></p>"
           end
           if member_ref['union']
-            docstring = docstring.to_s + "<p>UNION DOCUMENTATION</p>"
+            docstring = docstring.to_s + "<p>This is a union type and you must set exactly one of the members.</p>"
           end
           YardOptionTag.new(
             name: Underscore.underscore(member_name),

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -31,7 +31,8 @@ module AwsSdkCodeGenerator
         'xmlNamespace' => true,
         'streaming' => true, # transfer-encoding
         'requiresLength' => true, # transder-encoding
-        # event stream modeling
+        'union' => true,
+      # event stream modeling
         'event' => false,
         'eventstream' => false,
         'eventheader' => false,
@@ -61,7 +62,6 @@ module AwsSdkCodeGenerator
         'wrapper' => false,
         'xmlOrder' => false,
         'retryable' => false,
-        'union' => false
       }
 
       METADATA_KEYS = {

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -124,7 +124,6 @@ module AwsSdkCodeGenerator
       end
 
       def output_example_docs(shape_name, shape)
-        # TODO: Special docs
         if @output_shapes.include?(shape_name)
           if shape['union']
             "@note #{shape_name} is a union - when returned from an API call"\
@@ -189,7 +188,7 @@ module AwsSdkCodeGenerator
       def compute_input_shapes(api)
         inputs = Set.new
         (api['operations'] || {}).each do |_, operation|
-          visit_inputs(operation['input'], inputs) if operation['input']
+          visit_shapes(operation['input'], inputs) if operation['input']
         end
         inputs
       end
@@ -197,7 +196,7 @@ module AwsSdkCodeGenerator
       def compute_output_shapes(api)
         outputs = Set.new
         (api['operations'] || {}).each do |_, operation|
-          visit_inputs(operation['output'], outputs) if operation['output']
+          visit_shapes(operation['output'], outputs) if operation['output']
         end
         outputs
       end
@@ -210,22 +209,22 @@ module AwsSdkCodeGenerator
         "<p><b>A suitable default value is auto-generated.</b> You should normally not need to pass this option.</p>"
       end
 
-      def visit_inputs(shape_ref, inputs)
-        return if inputs.include?(shape_ref['shape']) # recursion
-        inputs << shape_ref['shape']
+      def visit_shapes(shape_ref, shapes)
+        return if shapes.include?(shape_ref['shape']) # recursion
+        shapes << shape_ref['shape']
         s = shape(shape_ref)
         raise "cannot locate shape #{shape_ref['shape']}" if s.nil?
         case s['type']
         when 'structure'
           return if s['members'].nil?
           s['members'].each_pair do |_, member_ref|
-            visit_inputs(member_ref, inputs)
+            visit_shapes(member_ref, shapes)
           end
         when 'list'
-          visit_inputs(s['member'], inputs)
+          visit_shapes(s['member'], shapes)
         when 'map'
-          visit_inputs(s['key'], inputs)
-          visit_inputs(s['value'], inputs)
+          visit_shapes(s['key'], shapes)
+          visit_shapes(s['value'], shapes)
         end
       end
 

--- a/build_tools/aws-sdk-code-generator/templates/types_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/types_module.mustache
@@ -18,6 +18,9 @@ module {{module_name}}
       {{/members}}
       SENSITIVE = {{sensitive_params}}
       include Aws::Structure
+      {{#union?}}
+      include Aws::Structure::Union
+      {{/union?}}
     end
     {{/empty?}}
     {{/structures}}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -28,6 +28,8 @@ module Aws
           member_name, member_ref = shape.member_by_location_name(key)
           if member_ref
             target[member_name] = parse_ref(member_ref, value)
+          elsif shape.union
+            target[:unknown] = { name: key, value: value }
           end
         end
         target

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_filter.rb
@@ -26,13 +26,21 @@ module Aws
 
       def filter(values, type)
         case values
-        when Struct, Hash then filter_hash(values, type)
+        when Struct then filter_struct(values, type)
+        when Hash then filter_hash(values, type)
         when Array then filter_array(values, type)
         else values
         end
       end
 
       private
+
+      def filter_struct(values, type)
+        if values.class.include? Aws::Structure::Union
+          values = { values.member => values.value }
+        end
+        filter_hash(values, type)
+      end
 
       def filter_hash(values, type)
         if type.const_defined?('SENSITIVE')

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -70,6 +70,14 @@ module Aws
           end
         end
 
+        if @validate_required && shape.union
+          if values.length > 1
+            errors << "multiple values provided to union at #{context} - must contain exactly one of the supported types: #{shape.member_names.join(', ')}"
+          elsif values.length == 0
+            errors << "No values provided to union at #{context} - must contain exactly one of the supported types: #{shape.member_names.join(', ')}"
+          end
+        end
+
         # validate non-nil members
         values.each_pair do |name, value|
           unless value.nil?

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -70,11 +70,24 @@ module Aws
       end
 
     end
+
+    module Union
+      def member
+        self.members.select { |k| self[k] }.first
+      end
+
+      def value
+        self[member] if member
+      end
+
+      def set_unknown_member(name, value)
+        self[:unknown] = {name: name, value: value}
+      end
+    end
   end
 
   # @api private
   class EmptyStructure < Struct.new('AwsEmptyStructure')
     include(Aws::Structure)
   end
-
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -79,10 +79,6 @@ module Aws
       def value
         self[member] if member
       end
-
-      def set_unknown_member(name, value)
-        self[:unknown] = {name: name, value: value}
-      end
     end
   end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/frame.rb
@@ -95,6 +95,8 @@ module Aws
         def child_frame(xml_name)
           if @member = @members[xml_name]
             Frame.new(xml_name, self, @member[:ref])
+          elsif @ref.shape.union
+            UnknownMemberFrame.new(xml_name, self, nil, @result)
           else
             NullFrame.new(xml_name, self)
           end
@@ -106,6 +108,8 @@ module Aws
             @result[@member[:name]][child.key.result] = child.value.result
           when FlatListFrame
             @result[@member[:name]] << child.result
+          when UnknownMemberFrame
+            @result[:unknown] = { name: child.path.last, value: child.result }
           when NullFrame
           else
             @result[@member[:name]] = child.result
@@ -239,6 +243,12 @@ module Aws
         def set_text(value)
           yield_unhandled_value(path, value)
           super
+        end
+      end
+
+      class UnknownMemberFrame < Frame
+        def result
+          @text.join
         end
       end
 

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -114,6 +114,9 @@ module Seahorse
         # @return [String, nil]
         attr_accessor :documentation
 
+        # @return [Boolean]
+        attr_accessor :union
+
         # Gets metadata for the given `key`.
         def [](key)
           @metadata[key.to_s]
@@ -261,6 +264,10 @@ module Seahorse
         def member_by_location_name(location_name)
           @members_by_location_name[location_name]
         end
+
+      end
+
+      class UnionShape < StructureShape
 
       end
 

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -267,10 +267,6 @@ module Seahorse
 
       end
 
-      class UnionShape < StructureShape
-
-      end
-
       class TimestampShape < Shape; end
 
     end

--- a/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/param_filter_spec.rb
@@ -12,6 +12,14 @@ module Aws
         include Aws::Structure
       end
 
+      class UnionType < Struct.new(
+        :member_1,
+        :sensitive_member)
+        SENSITIVE = [:sensitive_member]
+        include Aws::Structure
+        include Aws::Structure::Union
+      end
+
       class OldServiceType < Struct.new(
         :peccy_id,
         :password)
@@ -39,6 +47,12 @@ module Aws
           instance = Struct.new(:peccy_id, :password).new('peccy-id', 'peccy')
           filtered = subject.filter(instance, SensitiveType)
           expect(filtered).to eq(password: '[FILTERED]', peccy_id: 'peccy-id')
+        end
+
+        it 'filters sensitive Union params' do
+          instance = UnionType.new(sensitive_member: 'sensitive')
+          filtered = subject.filter(instance, UnionType)
+          expect(filtered).to eq(sensitive_member: '[FILTERED]')
         end
 
         context 'with additional filters' do

--- a/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/param_validator_spec.rb
@@ -55,7 +55,7 @@ module Aws
         validate({})
       end
 
-      it 'raises an error when a required paramter is missing' do
+      it 'raises an error when a required parameter is missing' do
         shapes['StructureShape']['required'] = %w(String)
         validate({}, 'missing required parameter params[:string]')
       end
@@ -87,6 +87,23 @@ module Aws
         validate({})
       end
 
+    end
+
+    describe 'unions' do
+      it 'raises an error when no values are set' do
+        shapes['StructureShape']['union'] = true
+        validate({}, 'No values provided to union')
+      end
+
+      it 'raises an error when multiple values are set' do
+        shapes['StructureShape']['union'] = true
+        validate({string: 's', boolean: true}, 'multiple values provided to union')
+      end
+
+      it 'access a struct with exactly one value set' do
+        shapes['StructureShape']['union'] = true
+        validate({string: 's'})
+      end
     end
 
     describe 'lists' do

--- a/gems/aws-sdk-core/spec/aws/structure_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/structure_spec.rb
@@ -89,5 +89,36 @@ module Aws
       end
     end
 
+    describe 'Union' do
+      class UnionType < Struct.new(
+        :member_1,
+        :member_2)
+        include Aws::Structure
+        include Aws::Structure::Union
+      end
+
+      let(:union) { UnionType.new(member_1: 'member_1') }
+
+      describe '#member' do
+        it 'returns the set member' do
+          expect(union.member).to eq :member_1
+        end
+
+        it 'returns nil when no member is set' do
+          expect(UnionType.new.member).to be_nil
+        end
+      end
+
+      describe '#value' do
+        it 'returns the set value' do
+          expect(union.value).to eq 'member_1'
+        end
+
+        it 'returns nil when no member is set' do
+          expect(UnionType.new.value).to be_nil
+        end
+      end
+    end
+
   end
 end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -542,16 +542,28 @@ module Aws::DynamoDB
     #       "Music" => {
     #         keys: [
     #           {
-    #             "Artist" => "No One You Know", 
-    #             "SongTitle" => "Call Me Today", 
+    #             "Artist" => {
+    #               s: "No One You Know", 
+    #             }, 
+    #             "SongTitle" => {
+    #               s: "Call Me Today", 
+    #             }, 
     #           }, 
     #           {
-    #             "Artist" => "Acme Band", 
-    #             "SongTitle" => "Happy Day", 
+    #             "Artist" => {
+    #               s: "Acme Band", 
+    #             }, 
+    #             "SongTitle" => {
+    #               s: "Happy Day", 
+    #             }, 
     #           }, 
     #           {
-    #             "Artist" => "No One You Know", 
-    #             "SongTitle" => "Scared of My Shadow", 
+    #             "Artist" => {
+    #               s: "No One You Know", 
+    #             }, 
+    #             "SongTitle" => {
+    #               s: "Scared of My Shadow", 
+    #             }, 
     #           }, 
     #         ], 
     #         projection_expression: "AlbumTitle", 
@@ -564,13 +576,19 @@ module Aws::DynamoDB
     #     responses: {
     #       "Music" => [
     #         {
-    #           "AlbumTitle" => "Somewhat Famous", 
+    #           "AlbumTitle" => {
+    #             s: "Somewhat Famous", 
+    #           }, 
     #         }, 
     #         {
-    #           "AlbumTitle" => "Blue Sky Blues", 
+    #           "AlbumTitle" => {
+    #             s: "Blue Sky Blues", 
+    #           }, 
     #         }, 
     #         {
-    #           "AlbumTitle" => "Louder Than Ever", 
+    #           "AlbumTitle" => {
+    #             s: "Louder Than Ever", 
+    #           }, 
     #         }, 
     #       ], 
     #     }, 
@@ -795,27 +813,45 @@ module Aws::DynamoDB
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => "Somewhat Famous", 
-    #               "Artist" => "No One You Know", 
-    #               "SongTitle" => "Call Me Today", 
+    #               "AlbumTitle" => {
+    #                 s: "Somewhat Famous", 
+    #               }, 
+    #               "Artist" => {
+    #                 s: "No One You Know", 
+    #               }, 
+    #               "SongTitle" => {
+    #                 s: "Call Me Today", 
+    #               }, 
     #             }, 
     #           }, 
     #         }, 
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => "Songs About Life", 
-    #               "Artist" => "Acme Band", 
-    #               "SongTitle" => "Happy Day", 
+    #               "AlbumTitle" => {
+    #                 s: "Songs About Life", 
+    #               }, 
+    #               "Artist" => {
+    #                 s: "Acme Band", 
+    #               }, 
+    #               "SongTitle" => {
+    #                 s: "Happy Day", 
+    #               }, 
     #             }, 
     #           }, 
     #         }, 
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => "Blue Sky Blues", 
-    #               "Artist" => "No One You Know", 
-    #               "SongTitle" => "Scared of My Shadow", 
+    #               "AlbumTitle" => {
+    #                 s: "Blue Sky Blues", 
+    #               }, 
+    #               "Artist" => {
+    #                 s: "No One You Know", 
+    #               }, 
+    #               "SongTitle" => {
+    #                 s: "Scared of My Shadow", 
+    #               }, 
     #             }, 
     #           }, 
     #         }, 
@@ -1783,8 +1819,12 @@ module Aws::DynamoDB
     #
     #   resp = client.delete_item({
     #     key: {
-    #       "Artist" => "No One You Know", 
-    #       "SongTitle" => "Scared of My Shadow", 
+    #       "Artist" => {
+    #         s: "No One You Know", 
+    #       }, 
+    #       "SongTitle" => {
+    #         s: "Scared of My Shadow", 
+    #       }, 
     #     }, 
     #     table_name: "Music", 
     #   })
@@ -2861,8 +2901,12 @@ module Aws::DynamoDB
     #
     #   resp = client.get_item({
     #     key: {
-    #       "Artist" => "Acme Band", 
-    #       "SongTitle" => "Happy Day", 
+    #       "Artist" => {
+    #         s: "Acme Band", 
+    #       }, 
+    #       "SongTitle" => {
+    #         s: "Happy Day", 
+    #       }, 
     #     }, 
     #     table_name: "Music", 
     #   })
@@ -2870,9 +2914,15 @@ module Aws::DynamoDB
     #   resp.to_h outputs the following:
     #   {
     #     item: {
-    #       "AlbumTitle" => "Songs About Life", 
-    #       "Artist" => "Acme Band", 
-    #       "SongTitle" => "Happy Day", 
+    #       "AlbumTitle" => {
+    #         s: "Songs About Life", 
+    #       }, 
+    #       "Artist" => {
+    #         s: "Acme Band", 
+    #       }, 
+    #       "SongTitle" => {
+    #         s: "Happy Day", 
+    #       }, 
     #     }, 
     #   }
     #
@@ -3481,9 +3531,15 @@ module Aws::DynamoDB
     #
     #   resp = client.put_item({
     #     item: {
-    #       "AlbumTitle" => "Somewhat Famous", 
-    #       "Artist" => "No One You Know", 
-    #       "SongTitle" => "Call Me Today", 
+    #       "AlbumTitle" => {
+    #         s: "Somewhat Famous", 
+    #       }, 
+    #       "Artist" => {
+    #         s: "No One You Know", 
+    #       }, 
+    #       "SongTitle" => {
+    #         s: "Call Me Today", 
+    #       }, 
     #     }, 
     #     return_consumed_capacity: "TOTAL", 
     #     table_name: "Music", 
@@ -4000,7 +4056,9 @@ module Aws::DynamoDB
     #
     #   resp = client.query({
     #     expression_attribute_values: {
-    #       ":v1" => "No One You Know", 
+    #       ":v1" => {
+    #         s: "No One You Know", 
+    #       }, 
     #     }, 
     #     key_condition_expression: "Artist = :v1", 
     #     projection_expression: "SongTitle", 
@@ -4014,7 +4072,9 @@ module Aws::DynamoDB
     #     count: 2, 
     #     items: [
     #       {
-    #         "SongTitle" => "Call Me Today", 
+    #         "SongTitle" => {
+    #           s: "Call Me Today", 
+    #         }, 
     #       }, 
     #     ], 
     #     scanned_count: 2, 
@@ -4855,7 +4915,9 @@ module Aws::DynamoDB
     #       "#ST" => "SongTitle", 
     #     }, 
     #     expression_attribute_values: {
-    #       ":a" => "No One You Know", 
+    #       ":a" => {
+    #         s: "No One You Know", 
+    #       }, 
     #     }, 
     #     filter_expression: "Artist = :a", 
     #     projection_expression: "#ST, #AT", 
@@ -4869,12 +4931,20 @@ module Aws::DynamoDB
     #     count: 2, 
     #     items: [
     #       {
-    #         "AlbumTitle" => "Somewhat Famous", 
-    #         "SongTitle" => "Call Me Today", 
+    #         "AlbumTitle" => {
+    #           s: "Somewhat Famous", 
+    #         }, 
+    #         "SongTitle" => {
+    #           s: "Call Me Today", 
+    #         }, 
     #       }, 
     #       {
-    #         "AlbumTitle" => "Blue Sky Blues", 
-    #         "SongTitle" => "Scared of My Shadow", 
+    #         "AlbumTitle" => {
+    #           s: "Blue Sky Blues", 
+    #         }, 
+    #         "SongTitle" => {
+    #           s: "Scared of My Shadow", 
+    #         }, 
     #       }, 
     #     ], 
     #     scanned_count: 3, 
@@ -5988,40 +6058,6 @@ module Aws::DynamoDB
     #   * {Types::UpdateItemOutput#attributes #attributes} => Hash&lt;String,Types::AttributeValue&gt;
     #   * {Types::UpdateItemOutput#consumed_capacity #consumed_capacity} => Types::ConsumedCapacity
     #   * {Types::UpdateItemOutput#item_collection_metrics #item_collection_metrics} => Types::ItemCollectionMetrics
-    #
-    #
-    # @example Example: To update an item in a table
-    #
-    #   # This example updates an item in the Music table. It adds a new attribute (Year) and modifies the AlbumTitle attribute. 
-    #   # All of the attributes in the item, as they appear after the update, are returned in the response.
-    #
-    #   resp = client.update_item({
-    #     expression_attribute_names: {
-    #       "#AT" => "AlbumTitle", 
-    #       "#Y" => "Year", 
-    #     }, 
-    #     expression_attribute_values: {
-    #       ":t" => "Louder Than Ever", 
-    #       ":y" => "2015", 
-    #     }, 
-    #     key: {
-    #       "Artist" => "Acme Band", 
-    #       "SongTitle" => "Happy Day", 
-    #     }, 
-    #     return_values: "ALL_NEW", 
-    #     table_name: "Music", 
-    #     update_expression: "SET #Y = :y, #AT = :t", 
-    #   })
-    #
-    #   resp.to_h outputs the following:
-    #   {
-    #     attributes: {
-    #       "AlbumTitle" => "Louder Than Ever", 
-    #       "Artist" => "Acme Band", 
-    #       "SongTitle" => "Happy Day", 
-    #       "Year" => "2015", 
-    #     }, 
-    #   }
     #
     # @example Request syntax with placeholder values
     #

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -542,28 +542,16 @@ module Aws::DynamoDB
     #       "Music" => {
     #         keys: [
     #           {
-    #             "Artist" => {
-    #               s: "No One You Know", 
-    #             }, 
-    #             "SongTitle" => {
-    #               s: "Call Me Today", 
-    #             }, 
+    #             "Artist" => "No One You Know", 
+    #             "SongTitle" => "Call Me Today", 
     #           }, 
     #           {
-    #             "Artist" => {
-    #               s: "Acme Band", 
-    #             }, 
-    #             "SongTitle" => {
-    #               s: "Happy Day", 
-    #             }, 
+    #             "Artist" => "Acme Band", 
+    #             "SongTitle" => "Happy Day", 
     #           }, 
     #           {
-    #             "Artist" => {
-    #               s: "No One You Know", 
-    #             }, 
-    #             "SongTitle" => {
-    #               s: "Scared of My Shadow", 
-    #             }, 
+    #             "Artist" => "No One You Know", 
+    #             "SongTitle" => "Scared of My Shadow", 
     #           }, 
     #         ], 
     #         projection_expression: "AlbumTitle", 
@@ -576,19 +564,13 @@ module Aws::DynamoDB
     #     responses: {
     #       "Music" => [
     #         {
-    #           "AlbumTitle" => {
-    #             s: "Somewhat Famous", 
-    #           }, 
+    #           "AlbumTitle" => "Somewhat Famous", 
     #         }, 
     #         {
-    #           "AlbumTitle" => {
-    #             s: "Blue Sky Blues", 
-    #           }, 
+    #           "AlbumTitle" => "Blue Sky Blues", 
     #         }, 
     #         {
-    #           "AlbumTitle" => {
-    #             s: "Louder Than Ever", 
-    #           }, 
+    #           "AlbumTitle" => "Louder Than Ever", 
     #         }, 
     #       ], 
     #     }, 
@@ -813,45 +795,27 @@ module Aws::DynamoDB
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => {
-    #                 s: "Somewhat Famous", 
-    #               }, 
-    #               "Artist" => {
-    #                 s: "No One You Know", 
-    #               }, 
-    #               "SongTitle" => {
-    #                 s: "Call Me Today", 
-    #               }, 
+    #               "AlbumTitle" => "Somewhat Famous", 
+    #               "Artist" => "No One You Know", 
+    #               "SongTitle" => "Call Me Today", 
     #             }, 
     #           }, 
     #         }, 
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => {
-    #                 s: "Songs About Life", 
-    #               }, 
-    #               "Artist" => {
-    #                 s: "Acme Band", 
-    #               }, 
-    #               "SongTitle" => {
-    #                 s: "Happy Day", 
-    #               }, 
+    #               "AlbumTitle" => "Songs About Life", 
+    #               "Artist" => "Acme Band", 
+    #               "SongTitle" => "Happy Day", 
     #             }, 
     #           }, 
     #         }, 
     #         {
     #           put_request: {
     #             item: {
-    #               "AlbumTitle" => {
-    #                 s: "Blue Sky Blues", 
-    #               }, 
-    #               "Artist" => {
-    #                 s: "No One You Know", 
-    #               }, 
-    #               "SongTitle" => {
-    #                 s: "Scared of My Shadow", 
-    #               }, 
+    #               "AlbumTitle" => "Blue Sky Blues", 
+    #               "Artist" => "No One You Know", 
+    #               "SongTitle" => "Scared of My Shadow", 
     #             }, 
     #           }, 
     #         }, 
@@ -1819,12 +1783,8 @@ module Aws::DynamoDB
     #
     #   resp = client.delete_item({
     #     key: {
-    #       "Artist" => {
-    #         s: "No One You Know", 
-    #       }, 
-    #       "SongTitle" => {
-    #         s: "Scared of My Shadow", 
-    #       }, 
+    #       "Artist" => "No One You Know", 
+    #       "SongTitle" => "Scared of My Shadow", 
     #     }, 
     #     table_name: "Music", 
     #   })
@@ -2901,12 +2861,8 @@ module Aws::DynamoDB
     #
     #   resp = client.get_item({
     #     key: {
-    #       "Artist" => {
-    #         s: "Acme Band", 
-    #       }, 
-    #       "SongTitle" => {
-    #         s: "Happy Day", 
-    #       }, 
+    #       "Artist" => "Acme Band", 
+    #       "SongTitle" => "Happy Day", 
     #     }, 
     #     table_name: "Music", 
     #   })
@@ -2914,15 +2870,9 @@ module Aws::DynamoDB
     #   resp.to_h outputs the following:
     #   {
     #     item: {
-    #       "AlbumTitle" => {
-    #         s: "Songs About Life", 
-    #       }, 
-    #       "Artist" => {
-    #         s: "Acme Band", 
-    #       }, 
-    #       "SongTitle" => {
-    #         s: "Happy Day", 
-    #       }, 
+    #       "AlbumTitle" => "Songs About Life", 
+    #       "Artist" => "Acme Band", 
+    #       "SongTitle" => "Happy Day", 
     #     }, 
     #   }
     #
@@ -3531,15 +3481,9 @@ module Aws::DynamoDB
     #
     #   resp = client.put_item({
     #     item: {
-    #       "AlbumTitle" => {
-    #         s: "Somewhat Famous", 
-    #       }, 
-    #       "Artist" => {
-    #         s: "No One You Know", 
-    #       }, 
-    #       "SongTitle" => {
-    #         s: "Call Me Today", 
-    #       }, 
+    #       "AlbumTitle" => "Somewhat Famous", 
+    #       "Artist" => "No One You Know", 
+    #       "SongTitle" => "Call Me Today", 
     #     }, 
     #     return_consumed_capacity: "TOTAL", 
     #     table_name: "Music", 
@@ -4056,9 +4000,7 @@ module Aws::DynamoDB
     #
     #   resp = client.query({
     #     expression_attribute_values: {
-    #       ":v1" => {
-    #         s: "No One You Know", 
-    #       }, 
+    #       ":v1" => "No One You Know", 
     #     }, 
     #     key_condition_expression: "Artist = :v1", 
     #     projection_expression: "SongTitle", 
@@ -4072,9 +4014,7 @@ module Aws::DynamoDB
     #     count: 2, 
     #     items: [
     #       {
-    #         "SongTitle" => {
-    #           s: "Call Me Today", 
-    #         }, 
+    #         "SongTitle" => "Call Me Today", 
     #       }, 
     #     ], 
     #     scanned_count: 2, 
@@ -4915,9 +4855,7 @@ module Aws::DynamoDB
     #       "#ST" => "SongTitle", 
     #     }, 
     #     expression_attribute_values: {
-    #       ":a" => {
-    #         s: "No One You Know", 
-    #       }, 
+    #       ":a" => "No One You Know", 
     #     }, 
     #     filter_expression: "Artist = :a", 
     #     projection_expression: "#ST, #AT", 
@@ -4931,20 +4869,12 @@ module Aws::DynamoDB
     #     count: 2, 
     #     items: [
     #       {
-    #         "AlbumTitle" => {
-    #           s: "Somewhat Famous", 
-    #         }, 
-    #         "SongTitle" => {
-    #           s: "Call Me Today", 
-    #         }, 
+    #         "AlbumTitle" => "Somewhat Famous", 
+    #         "SongTitle" => "Call Me Today", 
     #       }, 
     #       {
-    #         "AlbumTitle" => {
-    #           s: "Blue Sky Blues", 
-    #         }, 
-    #         "SongTitle" => {
-    #           s: "Scared of My Shadow", 
-    #         }, 
+    #         "AlbumTitle" => "Blue Sky Blues", 
+    #         "SongTitle" => "Scared of My Shadow", 
     #       }, 
     #     ], 
     #     scanned_count: 3, 
@@ -6058,6 +5988,40 @@ module Aws::DynamoDB
     #   * {Types::UpdateItemOutput#attributes #attributes} => Hash&lt;String,Types::AttributeValue&gt;
     #   * {Types::UpdateItemOutput#consumed_capacity #consumed_capacity} => Types::ConsumedCapacity
     #   * {Types::UpdateItemOutput#item_collection_metrics #item_collection_metrics} => Types::ItemCollectionMetrics
+    #
+    #
+    # @example Example: To update an item in a table
+    #
+    #   # This example updates an item in the Music table. It adds a new attribute (Year) and modifies the AlbumTitle attribute. 
+    #   # All of the attributes in the item, as they appear after the update, are returned in the response.
+    #
+    #   resp = client.update_item({
+    #     expression_attribute_names: {
+    #       "#AT" => "AlbumTitle", 
+    #       "#Y" => "Year", 
+    #     }, 
+    #     expression_attribute_values: {
+    #       ":t" => "Louder Than Ever", 
+    #       ":y" => "2015", 
+    #     }, 
+    #     key: {
+    #       "Artist" => "Acme Band", 
+    #       "SongTitle" => "Happy Day", 
+    #     }, 
+    #     return_values: "ALL_NEW", 
+    #     table_name: "Music", 
+    #     update_expression: "SET #Y = :y, #AT = :t", 
+    #   })
+    #
+    #   resp.to_h outputs the following:
+    #   {
+    #     attributes: {
+    #       "AlbumTitle" => "Louder Than Ever", 
+    #       "Artist" => "Acme Band", 
+    #       "SongTitle" => "Happy Day", 
+    #       "Year" => "2015", 
+    #     }, 
+    #   }
     #
     # @example Request syntax with placeholder values
     #

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
@@ -391,6 +391,7 @@ module Aws::DynamoDB
     AttributeUpdates.value = Shapes::ShapeRef.new(shape: AttributeValueUpdate)
 
     AttributeValue.add_member(:s, Shapes::ShapeRef.new(shape: StringAttributeValue, location_name: "S"))
+    AttributeValue.add_member(:n, Shapes::ShapeRef.new(shape: NumberAttributeValue, location_name: "N"))
     AttributeValue.add_member(:b, Shapes::ShapeRef.new(shape: BinaryAttributeValue, location_name: "B"))
     AttributeValue.add_member(:ss, Shapes::ShapeRef.new(shape: StringSetAttributeValue, location_name: "SS"))
     AttributeValue.add_member(:ns, Shapes::ShapeRef.new(shape: NumberSetAttributeValue, location_name: "NS"))

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client_api.rb
@@ -22,7 +22,7 @@ module Aws::DynamoDB
     AttributeName = Shapes::StringShape.new(name: 'AttributeName')
     AttributeNameList = Shapes::ListShape.new(name: 'AttributeNameList')
     AttributeUpdates = Shapes::MapShape.new(name: 'AttributeUpdates')
-    AttributeValue = Shapes::StructureShape.new(name: 'AttributeValue')
+    AttributeValue = Shapes::StructureShape.new(name: 'AttributeValue', union: true)
     AttributeValueList = Shapes::ListShape.new(name: 'AttributeValueList')
     AttributeValueUpdate = Shapes::StructureShape.new(name: 'AttributeValueUpdate')
     AutoScalingPolicyDescription = Shapes::StructureShape.new(name: 'AutoScalingPolicyDescription')
@@ -391,7 +391,6 @@ module Aws::DynamoDB
     AttributeUpdates.value = Shapes::ShapeRef.new(shape: AttributeValueUpdate)
 
     AttributeValue.add_member(:s, Shapes::ShapeRef.new(shape: StringAttributeValue, location_name: "S"))
-    AttributeValue.add_member(:n, Shapes::ShapeRef.new(shape: NumberAttributeValue, location_name: "N"))
     AttributeValue.add_member(:b, Shapes::ShapeRef.new(shape: BinaryAttributeValue, location_name: "B"))
     AttributeValue.add_member(:ss, Shapes::ShapeRef.new(shape: StringSetAttributeValue, location_name: "SS"))
     AttributeValue.add_member(:ns, Shapes::ShapeRef.new(shape: NumberSetAttributeValue, location_name: "NS"))

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
@@ -91,39 +91,14 @@ module Aws::DynamoDB
     #
     # [1]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes
     #
-    # @note When making an API call, you may pass AttributeValue
-    #   data as a hash:
+    # @note AttributeValue is a union - when making an API calls you must set exactly one of the members.
     #
-    #       {
-    #         s: "StringAttributeValue",
-    #         n: "NumberAttributeValue",
-    #         b: "data",
-    #         ss: ["StringAttributeValue"],
-    #         ns: ["NumberAttributeValue"],
-    #         bs: ["data"],
-    #         m: {
-    #           "AttributeName" => "value", # value <Hash,Array,String,Numeric,Boolean,IO,Set,nil>
-    #         },
-    #         l: ["value"], # value <Hash,Array,String,Numeric,Boolean,IO,Set,nil>
-    #         null: false,
-    #         bool: false,
-    #       }
+    # @note AttributeValue is a union - when returned from an API call exactly one value will be set.  You may call `#member` to determine which value is set.
     #
     # @!attribute [rw] s
     #   An attribute of type String. For example:
     #
     #   `"S": "Hello"`
-    #   @return [String]
-    #
-    # @!attribute [rw] n
-    #   An attribute of type Number. For example:
-    #
-    #   `"N": "123.45"`
-    #
-    #   Numbers are sent across the network to DynamoDB as strings, to
-    #   maximize compatibility across languages and libraries. However,
-    #   DynamoDB treats them as number type attributes for mathematical
-    #   operations.
     #   @return [String]
     #
     # @!attribute [rw] b
@@ -183,7 +158,6 @@ module Aws::DynamoDB
     #
     class AttributeValue < Struct.new(
       :s,
-      :n,
       :b,
       :ss,
       :ns,
@@ -191,9 +165,11 @@ module Aws::DynamoDB
       :m,
       :l,
       :null,
-      :bool)
+      :bool,
+      :unknown)
       SENSITIVE = []
       include Aws::Structure
+      include Aws::Structure::Union
     end
 
     # For the `UpdateItem` operation, represents the attributes to be

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/types.rb
@@ -101,6 +101,17 @@ module Aws::DynamoDB
     #   `"S": "Hello"`
     #   @return [String]
     #
+    # @!attribute [rw] n
+    #   An attribute of type Number. For example:
+    #
+    #   `"N": "123.45"`
+    #
+    #   Numbers are sent across the network to DynamoDB as strings, to
+    #   maximize compatibility across languages and libraries. However,
+    #   DynamoDB treats them as number type attributes for mathematical
+    #   operations.
+    #   @return [String]
+    #
     # @!attribute [rw] b
     #   An attribute of type Binary. For example:
     #
@@ -158,6 +169,7 @@ module Aws::DynamoDB
     #
     class AttributeValue < Struct.new(
       :s,
+      :n,
       :b,
       :ss,
       :ns,


### PR DESCRIPTION
**Summary**: Add support for the union trait - adds additional behavior to existing Structure member types.

There are two types of behavior modified:
1. Unions as inputs - when used as an input, unions validate that exactly one member is set.
2. Unions as outputs - there are two additional methods added: `#member` which returns the name of the union's member that is set and `#value` which returns the set value.  Additionally, `:unknown` is added as a member on unions.

These methods make it easy to use union output types in case statements:
```ruby
item_value = `ddb.get_item(params).item['value']
case item_value.member
when :s then handle_string_member(item_value.value)
when :ss then handle_ss_member(item_value.value)
when :unknown then handle_unknown_value(item_value)
end
```

**NOTE**:  (do not merge as is) This PR contains a modification to dynamodb api to add `union` to the dynamodb `AttributeValue` type to demonstrate the changes from code gen.

**TODO**: 
* Documentation cleanups


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
