### PR TITLE
Avoid Ruby 2.7 warning for numbered parameters

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_json.rb
@@ -5,7 +5,7 @@ module Aws
     module Protocols
       class RestJson < Rest
 
-        def body_for(_1, _2, rules, data)
+        def body_for(_a, _b, rules, data)
           if eventstream?(rules)
             encode_eventstream_response(rules, data, Aws::Json::Builder)
           else


### PR DESCRIPTION
Apologies, my [previous change](https://github.com/aws/aws-sdk-ruby/pull/2426) causes a warning in Ruby 2.7. I've made a PR to sorbet to address the documentation issue: https://github.com/sorbet/sorbet/pull/3579

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
