### PR TITLE
Check for flattened on ref for lists when serializing.

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Check for flattened on ref for lists when serializing.
+
 3.109.1 (2020-10-05)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
@@ -48,7 +48,7 @@ module Aws
       end
 
       def list(name, ref, values)
-        if ref.shape.flattened
+        if ref[:flattened] || ref.shape.flattened
           values.each do |value|
             member(ref.shape.member.location_name || name, ref.shape.member, value)
           end


### PR DESCRIPTION
*Summary*
We currently have some [customizations](https://github.com/aws/aws-sdk-ruby/blob/master/build_tools/customizations.rb#L173) that pull the "flattened" trait from a shape definition down to the list definition.  We currently do not handle serialization of TagSet in a few S3 operations (eg `put_bucket_metrics_configuration`).  This PR fixes that, and should remove the need for such customizations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
