### PR TITLE
No need to include Seahorse::Model::Shapes into Aws::Stubbing::Protocols::RestXml

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest_xml.rb
@@ -5,8 +5,6 @@ module Aws
     module Protocols
       class RestXml < Rest
 
-        include Seahorse::Model::Shapes
-
         def body_for(api, operation, rules, data)
           if eventstream?(rules)
             encode_eventstream_response(rules, data, Xml::Builder)


### PR DESCRIPTION
Because `Aws::Stubbing::Protocols::RestXml`'s parent class `Aws::Stubbing::Protocols::Rest` already includes this very module `Seahorse::Model::Shapes`. https://github.com/aws/aws-sdk-ruby/blob/6ca1851/gems/aws-sdk-core/lib/aws-sdk-core/stubbing/protocols/rest.rb#L10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. I don't think I want to add a changelog for this trivial one line deletion that wouldn't cause any behavior change. I mean, I'm happy if the patch just gets merged.