### PR TITLE
Retry on proxy connection failures

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Retry when `Net:HTTPFatalError` is thrown by the `Net::HTTP` library. This can occur when proxy connections are configured. (#2439)
+
 3.109.3 (2020-11-17)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb
@@ -25,7 +25,8 @@ module Seahorse
           SocketError, EOFError, IOError, Timeout::Error,
           Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
           Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError,
-          Errno::EHOSTUNREACH, Errno::ECONNREFUSED
+          Errno::EHOSTUNREACH, Errno::ECONNREFUSED,
+          Net::HTTPFatalError # for proxy connection failures
         ]
 
         # does not exist in Ruby 1.9.3

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/handler_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'ostruct'
-require 'stringio'
-require 'uri'
-require 'openssl'
+require_relative '../../../spec_helper'
 
 module Seahorse
   module Client
@@ -277,6 +273,13 @@ module Seahorse
 
             it 'wraps errors with a NetworkingError' do
               stub_request(:any, endpoint).to_raise(EOFError)
+              resp = make_request
+              expect(resp.error).to be_a(Seahorse::Client::NetworkingError)
+            end
+
+            it 'wraps errors for proxys with a NetworkingError' do
+              error = Net::HTTPFatalError.new("Gateway Time-out", nil)
+              stub_request(:any, endpoint).to_raise(error)
               resp = make_request
               expect(resp.error).to be_a(Seahorse::Client::NetworkingError)
             end


### PR DESCRIPTION
When a connection to a proxy fails, a `Net::HTTPFatalError` is thrown. This will now be retryable.

Fixes #2439