### PR TITLE
DynamoDBStreams simple attributes

### DIFF
--- a/gems/aws-sdk-dynamodbstreams/CHANGELOG.md
+++ b/gems/aws-sdk-dynamodbstreams/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Feature - Adds a utility class `Aws::DynamoDBStreams::AttributeTranslator` to translate records from DynamoDBStream events given to a lambda function into a native Ruby hash.
+
+* Feature - Adds a `:simple_attributes` client option for returning native Ruby hashes on records returned by the `get_records` operation.
+
 1.26.0 (2020-10-05)
 ------------------
 

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_translator.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_translator.rb
@@ -5,7 +5,7 @@ module Aws
     class AttributeTranslator
       # Parse a DynamoDBStream event hash from Lambda that contains 1 or more
       # records. When using the SDK to retrieve DynamoDB stream records, use the
-      # `simple_attributes: true` option instead.
+      # `simple_attributes: true` client option instead.
       #
       # @param [Hash] event A DynamoDBStream event.
       #
@@ -32,7 +32,7 @@ module Aws
           shape_ref, :unmarshal
         )
         parser = Aws::Json::Parser.new(shape_ref)
-        input = parser.parse(JSON.dump(event))
+        input = parser.parse(Aws::Json.dump(event))
         translator.apply(input).records
       end
     end

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_translator.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_translator.rb
@@ -1,0 +1,40 @@
+module Aws
+  module DynamoDBStreams
+    # A utility class that translates DynamoDBStream events from Lambda
+    # functions into their simple attribute equivalents.
+    class AttributeTranslator
+      # Parse a DynamoDBStream event hash from Lambda that contains 1 or more
+      # records. When using the SDK to retrieve DynamoDB stream records, use the
+      # `simple_attributes: true` option instead.
+      #
+      # @param [Hash] event A DynamoDBStream event.
+      #
+      # @example Parse a DynamoDB stream event from Lambda
+      #   def lambda_handler(event:, context:)
+      #     records = Aws::DynamoDBStreams::AttributeTranslator.from_event(event)
+      #     records.each do |record|
+      #       puts record.dynamodb.new_image
+      #       # => { "size" => 123, "enabled" => true, ... }
+      #     end
+      #   end
+      def self.from_event(event)
+        return unless event.is_a?(Hash)
+
+        # TODO: This implementation is slow and inefficient. It would be
+        # better to write a switch-case that has similar logic to AttributeValue
+        # used in the ValueTranslator. This implementation however provides
+        # consistency between both DynamoDB and DynamoDBStreams. The translator
+        # only works with shapes and structs and not a regular Ruby hash.
+        shape_ref = ClientApi::Shapes::ShapeRef.new(
+          shape: ClientApi::GetRecordsOutput
+        )
+        translator = Plugins::SimpleAttributes::ValueTranslator.new(
+          shape_ref, :unmarshal
+        )
+        parser = Aws::Json::Parser.new(shape_ref)
+        input = parser.parse(JSON.dump(event))
+        translator.apply(input).records
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_value.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_value.rb
@@ -10,67 +10,11 @@ module Aws
     class AttributeValue
 
       def initialize
-        @marshaler = Marshaler.new
         @unmarshaler = Unmarshaler.new
-      end
-
-      def marshal(value)
-        @marshaler.format(value)
       end
 
       def unmarshal(value)
         @unmarshaler.format(value)
-      end
-
-      class Marshaler
-        HASHY_TEST = lambda { |val| val.nil? ? false : val.respond_to?(:to_h) }
-        STRINGY_TEST = lambda { |val| val.respond_to?(:to_str) }
-
-        def format(obj)
-          case obj
-          when Hash
-            obj.each.with_object(m:{}) do |(key, value), map|
-              map[:m][key.to_s] = format(value)
-            end
-          when Array
-            obj.each.with_object(l:[]) do |value, list|
-              list[:l] << format(value)
-            end
-          when String then { s: obj }
-          when Symbol then { s: obj.to_s }
-          when STRINGY_TEST then { s: obj.to_str }
-          when Numeric then { n: obj.to_s }
-          when StringIO, IO then { b: obj }
-          when Set then format_set(obj)
-          when HASHY_TEST
-            hash = obj.to_h
-            hash.each.with_object(m:{}) do |(key, value), map|
-              map[:m][key.to_s] = format(value)
-            end
-          when true, false then { bool: obj }
-          when nil then { null: true }
-          else
-            msg = 'unsupported type, expected Hash, Array, Set, String, Numeric, '\
-                  "IO, true, false, or nil, got #{obj.class.name}"
-            raise ArgumentError, msg
-          end
-        end
-
-        private
-
-        def format_set(set)
-          return { ss: [] } if set.empty?
-          case set.first
-          when String, Symbol then { ss: set.map(&:to_s) }
-          when STRINGY_TEST then { ss: set.map(&:to_str) }
-          when Numeric then { ns: set.map(&:to_s) }
-          when StringIO, IO then { bs: set.to_a }
-          else
-            msg = 'set types only support String, Numeric, or IO objects'
-            raise ArgumentError, msg
-          end
-        end
-
       end
 
       class Unmarshaler

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_value.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/attribute_value.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'stringio'
+require 'set'
+
+module Aws
+  module DynamoDBStreams
+    # @api private
+    class AttributeValue
+
+      def initialize
+        @marshaler = Marshaler.new
+        @unmarshaler = Unmarshaler.new
+      end
+
+      def marshal(value)
+        @marshaler.format(value)
+      end
+
+      def unmarshal(value)
+        @unmarshaler.format(value)
+      end
+
+      class Marshaler
+        HASHY_TEST = lambda { |val| val.nil? ? false : val.respond_to?(:to_h) }
+        STRINGY_TEST = lambda { |val| val.respond_to?(:to_str) }
+
+        def format(obj)
+          case obj
+          when Hash
+            obj.each.with_object(m:{}) do |(key, value), map|
+              map[:m][key.to_s] = format(value)
+            end
+          when Array
+            obj.each.with_object(l:[]) do |value, list|
+              list[:l] << format(value)
+            end
+          when String then { s: obj }
+          when Symbol then { s: obj.to_s }
+          when STRINGY_TEST then { s: obj.to_str }
+          when Numeric then { n: obj.to_s }
+          when StringIO, IO then { b: obj }
+          when Set then format_set(obj)
+          when HASHY_TEST
+            hash = obj.to_h
+            hash.each.with_object(m:{}) do |(key, value), map|
+              map[:m][key.to_s] = format(value)
+            end
+          when true, false then { bool: obj }
+          when nil then { null: true }
+          else
+            msg = 'unsupported type, expected Hash, Array, Set, String, Numeric, '\
+                  "IO, true, false, or nil, got #{obj.class.name}"
+            raise ArgumentError, msg
+          end
+        end
+
+        private
+
+        def format_set(set)
+          return { ss: [] } if set.empty?
+          case set.first
+          when String, Symbol then { ss: set.map(&:to_s) }
+          when STRINGY_TEST then { ss: set.map(&:to_str) }
+          when Numeric then { ns: set.map(&:to_s) }
+          when StringIO, IO then { bs: set.to_a }
+          else
+            msg = 'set types only support String, Numeric, or IO objects'
+            raise ArgumentError, msg
+          end
+        end
+
+      end
+
+      class Unmarshaler
+
+        def format(obj)
+          type, value = extract_type_and_value(obj)
+          case type
+          when :m
+            value.each.with_object({}) do |(k, v), map|
+              map[k] = format(v)
+            end
+          when :l then value.map { |v| format(v) }
+          when :s then value
+          when :n then BigDecimal(value)
+          when :b then StringIO.new(value)
+          when :null then nil
+          when :bool then value
+          when :ss then Set.new(value)
+          when :ns then Set.new(value.map { |n| BigDecimal(n) })
+          when :bs then Set.new(value.map { |b| StringIO.new(b) })
+          else
+            raise ArgumentError, "unhandled type #{type.inspect}"
+          end
+        end
+
+        private
+
+        def extract_type_and_value(obj)
+          case obj
+          when Hash then obj.to_a.first
+          when Struct
+            obj.members.each do |key|
+              value = obj[key]
+              return [key, value] unless value.nil?
+            end
+          else
+            raise ArgumentError, "unhandled type #{obj.inspect}"
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
@@ -29,6 +29,7 @@ require 'aws-sdk-core/plugins/transfer_encoding.rb'
 require 'aws-sdk-core/plugins/http_checksum.rb'
 require 'aws-sdk-core/plugins/signature_v4.rb'
 require 'aws-sdk-core/plugins/protocols/json_rpc.rb'
+require 'aws-sdk-dynamodbstreams/plugins/simple_attributes.rb'
 
 Aws::Plugins::GlobalConfiguration.add_identifier(:dynamodbstreams)
 
@@ -75,6 +76,7 @@ module Aws::DynamoDBStreams
     add_plugin(Aws::Plugins::HttpChecksum)
     add_plugin(Aws::Plugins::SignatureV4)
     add_plugin(Aws::Plugins::Protocols::JsonRpc)
+    add_plugin(Aws::DynamoDBStreams::Plugins::SimpleAttributes)
 
     # @overload initialize(options)
     #   @param [Hash] options
@@ -265,6 +267,14 @@ module Aws::DynamoDBStreams
     #   @option options [String] :secret_access_key
     #
     #   @option options [String] :session_token
+    #
+    #   @option options [Boolean] :simple_attributes (false)
+    #     Enables working with DynamoDB attribute values using
+    #     hashes, arrays, sets, integers, floats, booleans, and nil.
+    #
+    #     Disabling this option requires that all attribute values have
+    #     their types specified, e.g. `{ s: 'abc' }` instead of simply
+    #     `'abc'`.
     #
     #   @option options [Boolean] :simple_json (false)
     #     Disables request parameter conversion, validation, and formatting.

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/client.rb
@@ -269,12 +269,8 @@ module Aws::DynamoDBStreams
     #   @option options [String] :session_token
     #
     #   @option options [Boolean] :simple_attributes (false)
-    #     Enables working with DynamoDB attribute values using
+    #     When enabled, returns DynamoDBStream attribute values using
     #     hashes, arrays, sets, integers, floats, booleans, and nil.
-    #
-    #     Disabling this option requires that all attribute values have
-    #     their types specified, e.g. `{ s: 'abc' }` instead of simply
-    #     `'abc'`.
     #
     #   @option options [Boolean] :simple_json (false)
     #     Disables request parameter conversion, validation, and formatting.

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/customizations.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# utility classes
+require 'aws-sdk-dynamodbstreams/attribute_translator'
+require 'aws-sdk-dynamodbstreams/attribute_value'

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module Aws
+  module DynamoDBStreams
+    module Plugins
+      # Simplifies working with Amazon DynamoDBStream attribute values.
+      # Translates attribute values for requests and responses to sensible
+      # Ruby natives.
+      #
+      # This plugin is disabled by default for all {DynamoDBStreams::Client}
+      # objects. You can enable this plugin by passing
+      # `simple_attributes: false` to the client constructor:
+      #
+      #     ddb = Aws::DynamoDB::Client.new(simple_attributes: true)
+      #
+      # ## Output Examples
+      #
+      # With this plugin **enabled**, `simple_attributes: true`:
+      #
+      #     resp = dynamodbstreams.get_records(shard_iterator: iterator)
+      #     resp.records.first.dynamodb.new_image
+      #     {
+      #       id: 'uuid',
+      #       enabled: true,
+      #       tags: #<Set: {"attributes", "simple"}>,
+      #       data: #<StringIO:0x00007fe4061e6bc0>,
+      #       scores: [0.1e1, 0.2e1, 0.3e1, nil],
+      #       name: {
+      #         first: 'John',
+      #         last: 'Doe',
+      #       }
+      #     }
+      #
+      # With this plugin **disabled**, `simple_attributes: false`:
+      #
+      #     resp = dynamodbstreams.get_records(shard_iterator: iterator)
+      #     resp.records.first.dynamodb.new_image
+      #     {
+      #       "id"=> <struct s='uuid', n=nil, b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=nil>
+      #       "enabled"=> <struct s=nil, n=nil, b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=true>
+      #       ...
+      #     }
+      #
+      class SimpleAttributes < Seahorse::Client::Plugin
+
+        option(:simple_attributes,
+          default: false,
+          doc_type: 'Boolean',
+          docstring: <<-DOCS
+When enabled, returns DynamoDBStream attribute values using
+hashes, arrays, sets, integers, floats, booleans, and nil.
+        DOCS
+        )
+
+        def add_handlers(handlers, config)
+          if config.simple_attributes
+            handlers.add(Handler, step: :initialize, operations: [:get_records])
+          end
+        end
+
+        class Handler < Seahorse::Client::Handler
+
+          def call(context)
+            @handler.call(context).on(200) do |response|
+              response.data = translate_output(response)
+            end
+          end
+
+          private
+
+          def translate_output(response)
+            if shape = response.context.operation.output
+              ValueTranslator.new(shape, :unmarshal).apply(response.data)
+            else
+              response.data
+            end
+          end
+
+        end
+
+        # @api private
+        class ValueTranslator
+
+          include Seahorse::Model::Shapes
+
+          def self.apply(rules, mode, data)
+            new(rules, mode).apply(data)
+          end
+
+          def initialize(rules, mode)
+            @rules = rules
+            @mode = mode
+          end
+
+          def apply(values)
+            structure(@rules, values) if @rules
+          end
+
+          private
+
+          def structure(ref, values)
+            shape = ref.shape
+            if values.is_a?(Struct)
+              values.members.each.with_object(values.class.new) do |key, st|
+                st[key] = translate(shape.member(key), values[key])
+              end
+            elsif values.is_a?(Hash)
+              values.each.with_object({}) do |(key, value), hash|
+                hash[key] = translate(shape.member(key), value)
+              end
+            else
+              values
+            end
+          end
+
+          def list(ref, values)
+            return values unless values.is_a?(Array)
+            member_ref = ref.shape.member
+            values.inject([]) do |list, value|
+              list << translate(member_ref, value)
+            end
+          end
+
+          def map(ref, values)
+            return values unless values.is_a?(Hash)
+            value_ref = ref.shape.value
+            values.each.with_object({}) do |(key, value), hash|
+              hash[key] = translate(value_ref, value)
+            end
+          end
+
+          def translate(ref, value)
+            if ClientApi::AttributeValue === ref.shape
+              AttributeValue.new.send(@mode, value)
+            else
+              translate_complex(ref, value)
+            end
+          end
+
+          def translate_complex(ref, value)
+            case ref.shape
+            when StructureShape then structure(ref, value)
+            when ListShape then list(ref, value)
+            when MapShape then map(ref, value)
+            else value
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
@@ -3,7 +3,7 @@
 module Aws
   module DynamoDBStreams
     module Plugins
-      # Simplifies working with Amazon DynamoDBStream attribute values.
+      # Simplifies working with Amazon DynamoDBStreams attribute values.
       # Translates attribute values for requests and responses to sensible
       # Ruby natives.
       #
@@ -11,7 +11,7 @@ module Aws
       # objects. You can enable this plugin by passing
       # `simple_attributes: false` to the client constructor:
       #
-      #     ddb = Aws::DynamoDB::Client.new(simple_attributes: true)
+      #     ddb = Aws::DynamoDBStreams::Client.new(simple_attributes: true)
       #
       # ## Output Examples
       #

--- a/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
+++ b/gems/aws-sdk-dynamodbstreams/lib/aws-sdk-dynamodbstreams/plugins/simple_attributes.rb
@@ -4,8 +4,7 @@ module Aws
   module DynamoDBStreams
     module Plugins
       # Simplifies working with Amazon DynamoDBStreams attribute values.
-      # Translates attribute values for requests and responses to sensible
-      # Ruby natives.
+      # Translates attribute values from responses to sensible Ruby natives.
       #
       # This plugin is disabled by default for all {DynamoDBStreams::Client}
       # objects. You can enable this plugin by passing

--- a/gems/aws-sdk-dynamodbstreams/spec/attribute_translator_spec.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/attribute_translator_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module Aws
+  module DynamoDBStreams
+    describe AttributeTranslator do
+      let(:event) do
+        {
+          'Records' => [
+            {
+              'eventID' => '123',
+              'eventName' => 'INSERT',
+              'eventVersion' => '1.1',
+              'eventSource' => 'aws:dynamodb',
+              'awsRegion' => 'us-west-2',
+              'dynamodb' => {
+                'ApproximateCreationDateTime' => 123,
+                'Keys' => {
+                  'id' => { 'S' => 'key' }
+                },
+                'NewImage' => {
+                  'size' => { 'N' => '69' },
+                  'name' => { 'S' => 'new-name' },
+                  'enabled' => { 'BOOL' => true },
+                  'id' => { 'S' => 'key' }
+                },
+                'SequenceNumber' => '12345',
+                'SizeBytes' => 420,
+                'StreamViewType' => 'NEW_AND_OLD_IMAGES'
+              },
+              'eventSourceARN' => 'arn:aws:dynamodb:us-west-2:foo'
+            }
+          ]
+        }
+      end
+
+      let(:simple_attributes) do
+        {
+          'enabled' => true,
+          'id' => 'key',
+          'name' => 'new-name',
+          'size' => 0.69e2
+        }
+      end
+
+      describe '.from_event' do
+        it 'parses an event from Lambda' do
+          records = AttributeTranslator.from_event(event)
+          image = records.first.dynamodb.new_image
+          expect(image).to eq simple_attributes
+        end
+      end
+
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/spec/attribute_value_spec.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/attribute_value_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require 'bigdecimal'
+require 'set'
+
+module Aws
+  module DynamoDBStreams
+    describe AttributeValue do
+
+      let(:value) { AttributeValue.new }
+
+      describe '#unmarshal' do
+
+        it 'converts :m to a hash with string keys (not symbols)' do
+          expect(value.unmarshal(m: {
+            "foo" => { s: 'bar' },
+            "abc" => { s: 'mno' },
+          })).to eq('foo' => 'bar', 'abc' => 'mno')
+        end
+
+        it 'converts :l to an array' do
+          expect(value.unmarshal(l: [
+            { s: 'abc' },
+            { s: 'mno' },
+          ])).to eq(%w(abc mno))
+        end
+
+        it 'converts :ss to a set of strings' do
+          expect(value.unmarshal(ss: %w(abc mno))).to eq(Set.new(%w(abc mno)))
+        end
+
+        it 'converts :ns to a set of big decimals (to preserve precision)' do
+          expect(value.unmarshal(ns: %w(123 456))).to eq(
+            Set.new([BigDecimal('123'), BigDecimal('456')]))
+        end
+
+        it 'converts :bs to a set of binary values' do
+          simple = value.unmarshal(bs: ['data'])
+          expect(simple.count).to eq(1)
+          expect(simple.first).to be_kind_of(StringIO)
+          expect(simple.first.string).to eq('data')
+        end
+
+        it 'converts :n to big decimals' do
+          # supports integers, floats, and big decimals
+          expect(value.unmarshal(n: '123')).to eq(BigDecimal('123'))
+          expect(value.unmarshal(n: '12.34')).to eq(BigDecimal('12.34'))
+          expect(value.unmarshal(n: '0.1E125')).to eq(BigDecimal('0.1E125'))
+        end
+
+        it 'converts :s to a string' do
+          expect(value.unmarshal(s: 'abc')).to eq('abc')
+        end
+
+        it 'converts :bool to booleans true or false' do
+          # supports both true and false
+          expect(value.unmarshal(bool: true)).to be(true)
+          expect(value.unmarshal(bool: false)).to be(false)
+        end
+
+        it 'converts :null to nil' do
+          expect(value.unmarshal(null: true)).to be(nil)
+        end
+
+        it 'recursively converted mixed types' do
+
+          expect(value.unmarshal({
+            m: {
+              "name" => {
+                m: {
+                  "first" => { s: 'John' },
+                  "last" => { s: 'Doe' },
+                }
+              },
+              "age" => { n: "40" },
+              "married" => { bool: false },
+              "hobbies" => { ss: ['scuba', 'hiking'] },
+              "parents" => { l:
+                [
+                  {
+                    m: {
+                      "name" => { m: {
+                        "first" => { s: 'John Sr.' },
+                        "last" => { s: 'Doe' },
+                      }},
+                      "age" => { n: "70" },
+                    }
+                  },
+                  {
+                    m: {
+                      "name" => { m: {
+                        "first" => { s: 'Jane' },
+                        "last" => { s: 'Doe' },
+                      }},
+                      "age" => { null: true },
+                    },
+                  }
+                ],
+              },
+              "scores" => {
+                l: [
+                  { n: '4.5' },
+                  { n: '5' },
+                  { n: '3.9' },
+                  { null: true },
+                  { s: 'perfect' },
+                ]
+              }
+            }
+          })).to eq(
+            'name' =>  { 'first' => 'John', 'last' => 'Doe' },
+            'age' => 40,
+            'married' => false,
+            'hobbies' => Set.new(%w(scuba hiking)),
+            'parents' => [
+              {
+                'name' => { 'first' => 'John Sr.', 'last' => 'Doe' },
+                'age' => 70,
+              },
+              {
+                'name' => { 'first' => 'Jane', 'last' => 'Doe' },
+                'age' => nil,
+              },
+            ],
+            'scores' => [
+              BigDecimal('4.5'),
+              BigDecimal('5'),
+              BigDecimal('3.9'),
+              nil,
+              'perfect'
+            ]
+          )
+        end
+
+        it 'raises an argument error for unhandled types' do
+          expect {
+            value.unmarshal(year: '2006')
+          }.to raise_error(ArgumentError, /unhandled type/)
+        end
+
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
@@ -25,9 +25,7 @@ module Aws
             context.http_response.signal_done(
               status_code: 200,
               headers: {},
-              body: <<-body
-{"Records":[{"eventID":"fa16df60c5de0eed42b0999b156d52c2","eventName":"INSERT","eventVersion":"1.1","eventSource":"aws:dynamodb","awsRegion":"us-west-2","dynamodb":{"ApproximateCreationDateTime":1610128821.0,"Keys":{"id":{"S":"guid"}},"NewImage":{"value":{"N":"123"},"id":{"S":"guid"}},"SequenceNumber":"8231000000000005323959474","SizeBytes":93,"StreamViewType":"NEW_AND_OLD_IMAGES"},"eventSourceARN":"arn:aws:dynamodb:test-arn"}]}
-              body
+              body: '{"Records":[{"dynamodb":{"Keys":{"id":{"S":"guid"}}}}]}'
             )
             Seahorse::Client::Response.new(context: context)
           end

--- a/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require_relative 'spec_helper'
+require 'zlib'
+module Aws
+  module DynamoDBStreams
+    describe Client do
+      let(:opts) {{
+        credentials: Credentials.new('akid', 'secret'),
+        region: 'us-west-2',
+      }}
+      let(:ddb) { Client.new(opts) }
+      describe ':simple_attributes' do
+        it 'simple attributes mode is disabled by default' do
+          expect(Client.new(opts).config.simple_attributes).to be(false)
+        end
+
+        it 'can be enabled' do
+          ddb = Client.new(opts.merge(simple_attributes: true))
+          expect(ddb.config.simple_attributes).to be(true)
+        end
+
+        it 'unmarshals returned attribute values' do
+          ddb = Client.new(opts.merge(simple_attributes: true))
+          ddb.handle(step: :send) do |context|
+            context.http_response.signal_done(
+              status_code: 200,
+              headers: {},
+              body: <<-body
+{"Records":[{"eventID":"fa16df60c5de0eed42b0999b156d52c2","eventName":"INSERT","eventVersion":"1.1","eventSource":"aws:dynamodb","awsRegion":"us-west-2","dynamodb":{"ApproximateCreationDateTime":1610128821.0,"Keys":{"id":{"S":"guid"}},"NewImage":{"value":{"N":"123"},"id":{"S":"guid"}},"SequenceNumber":"8231000000000005323959474","SizeBytes":93,"StreamViewType":"NEW_AND_OLD_IMAGES"},"eventSourceARN":"arn:aws:dynamodb:test-arn"}]}
+              body
+            )
+            Seahorse::Client::Response.new(context: context)
+          end
+          resp = ddb.get_records(shard_iterator: 'itr')
+          expect(resp.data.records.first.dynamodb.keys).to eq('id' => 'guid')
+        end
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodbstreams/spec/client_spec.rb
@@ -22,13 +22,13 @@ module Aws
         it 'nmarshals returned attribute values' do
           ddb = Client.new(stub_responses: true, simple_attributes: true)
           ddb.stub_responses(:get_records, {
-            :records=>
-              [{:event_id=>"event_1",
-                :dynamodb=>
-                 {
-                  :keys=>{"id"=>{:s=>"guid"}},
-                  :new_image=>{"id"=>{:s=>"guid"}},
-                  }
+            records:
+              [{event_id: "event_1",
+                dynamodb:
+                {
+                  keys: {"id"=>{s: "guid"}},
+                  new_image: {"id"=>{s: "guid"}},
+                }
               }]
             })
 

--- a/services.json
+++ b/services.json
@@ -253,7 +253,10 @@
     ]
   },
   "DynamoDBStreams": {
-    "models": "streams.dynamodb/2012-08-10"
+    "models": "streams.dynamodb/2012-08-10",
+    "addPlugins": [
+      "Aws::DynamoDBStreams::Plugins::SimpleAttributes"
+    ]
   },
   "EBS": {
     "models": "ebs/2019-11-02"


### PR DESCRIPTION
Closes #1212 

Adds a utility that can be used in Lambda functions (`Aws::DynamoDBStreams::AttributeTranslator`) for parsing events.

Adds a plugin `:simple_attributes` similar to the one in DynamoDB to return stream records with simple attributes.

The implementation of the utility is slower than a switch case but not terrible. It provides consistency.