### PR TITLE
Fix a Ruby warning about mismatched indentation

### DIFF
--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/encryptionV2/default_cipher_provider.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/encryptionV2/default_cipher_provider.rb
@@ -87,9 +87,9 @@ module Aws
                     ' kms+context.  Please configure the client with the' \
                     ' required kms_key_id'
               else
-              raise ArgumentError, 'Unsupported wrap-alg: ' \
-                "#{envelope['x-amz-wrap-alg']}"
-            end
+                raise ArgumentError, 'Unsupported wrap-alg: ' \
+                      "#{envelope['x-amz-wrap-alg']}"
+              end
             iv = decode64(envelope['x-amz-iv'])
             Utils.aes_decryption_cipher(:GCM, key, iv)
           end


### PR DESCRIPTION
When running with warnings on Ruby complains about the `end` statement being indented differently than its opening `case` statement. I'm not sure if this warrants a mention in the changelog so let me know if you'd like me to add it. I think it's pretty trivial.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
