### PR TITLE
Fix an issue with max_attempts and validation

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix an issue with `max_attempts` validation raising incorrectly.
+
 3.111.0 (2021-01-11)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
@@ -176,11 +176,12 @@ a clock skew correction and retry requests with skewed client clocks.
       end
 
       def self.resolve_max_attempts(cfg)
-        value = (ENV['AWS_MAX_ATTEMPTS'] && ENV['AWS_MAX_ATTEMPTS'].to_i) ||
+        value = (ENV['AWS_MAX_ATTEMPTS']) ||
                 Aws.shared_config.max_attempts(profile: cfg.profile) ||
-                3
+                '3'
+        value = value.to_i
         # Raise if provided value is not a positive integer
-        if !value.is_a?(Integer) || value <= 0
+        if value <= 0
           raise ArgumentError,
             'Must provide a positive integer for max_attempts profile '\
             'option or for ENV[\'AWS_MAX_ATTEMPTS\']'

--- a/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retry_errors_spec.rb
@@ -48,13 +48,13 @@ module Aws
 
       it 'can configure max_attempts with shared config' do
         allow_any_instance_of(Aws::SharedConfig)
-          .to receive(:max_attempts).and_return(5)
+          .to receive(:max_attempts).and_return('5')
         expect(client.config.max_attempts).to eq(5)
       end
 
       it 'can configure max_attempts using ENV with precedence over config' do
         allow_any_instance_of(Aws::SharedConfig)
-          .to receive(:max_attempts).and_return(3)
+          .to receive(:max_attempts).and_return('3')
         ENV['AWS_MAX_ATTEMPTS'] = '1'
         expect(client.config.max_attempts).to eq(1)
       end


### PR DESCRIPTION
Closes #2464

We only converted `AWS_MAX_ATTEMPTS` in #2319 . This change just allows value to be a string and converts (and returns) as part of validation. Our tests mistakenly mocked integers from shared config instead of strings.