### PR TITLE
Require the correct files when using specific gems (aws-sdk-sts & aws-sdk-sso)

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -89,10 +89,10 @@ require_relative 'aws-sdk-core/arn_parser'
 require_relative 'aws-sdk-core/ec2_metadata'
 
 # aws-sdk-sts is included to support Aws::AssumeRoleCredentials
-require 'aws-sdk-sts'
+require_relative 'aws-sdk-sts'
 
 # aws-sdk-sso is included to support Aws::SSOCredentials
-require 'aws-sdk-sso'
+require_relative 'aws-sdk-sso'
 
 module Aws
 


### PR DESCRIPTION
#### Context

We recently updated the dependency manifest on one of our projects to be specific about using the `aws-sdk-sts` gem, and found that `aws-sdk-core` fails to load the appropriate `aws-sdk-sts` file.

```
require 'aws-sdk-sts'
=> true

Aws::CORE_GEM_VERSION
 => "3.111.0"

Aws::STS::GEM_VERSION
<..> NameError (uninitialized constant Aws::STS)
```

#### Changes

Require the correct file for `aws-sdk-sts`, and pre-emptively do the same for `aws-sdk-sso`.