### PR TITLE
Fix LexModelsV2 to use a content type

### DIFF
--- a/gems/aws-sdk-lexmodelsv2/CHANGELOG.md
+++ b/gems/aws-sdk-lexmodelsv2/CHANGELOG.md
@@ -1,8 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add a `Content-Type` header to mitigate a service side issue.
+
 1.0.0 (2021-01-22)
 ------------------
 
 * Feature - Initial release of `aws-sdk-lexmodelsv2`.
-

--- a/gems/aws-sdk-lexmodelsv2/lib/aws-sdk-lexmodelsv2/client.rb
+++ b/gems/aws-sdk-lexmodelsv2/lib/aws-sdk-lexmodelsv2/client.rb
@@ -29,6 +29,7 @@ require 'aws-sdk-core/plugins/transfer_encoding.rb'
 require 'aws-sdk-core/plugins/http_checksum.rb'
 require 'aws-sdk-core/plugins/signature_v4.rb'
 require 'aws-sdk-core/plugins/protocols/rest_json.rb'
+require 'aws-sdk-lexmodelsv2/plugins/content_type.rb'
 
 Aws::Plugins::GlobalConfiguration.add_identifier(:lexmodelsv2)
 
@@ -75,6 +76,7 @@ module Aws::LexModelsV2
     add_plugin(Aws::Plugins::HttpChecksum)
     add_plugin(Aws::Plugins::SignatureV4)
     add_plugin(Aws::Plugins::Protocols::RestJson)
+    add_plugin(Aws::LexModelsV2::Plugins::ContentType)
 
     # @overload initialize(options)
     #   @param [Hash] options

--- a/gems/aws-sdk-lexmodelsv2/lib/aws-sdk-lexmodelsv2/plugins/content_type.rb
+++ b/gems/aws-sdk-lexmodelsv2/lib/aws-sdk-lexmodelsv2/plugins/content_type.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Aws
-  module SSO
+  module LexModelsV2
     module Plugins
       class ContentType < Seahorse::Client::Plugin
 
-        def add_handlers(handlers, config)
+        def add_handlers(handlers, _config)
           handlers.add(Handler)
         end
 
@@ -15,7 +15,7 @@ module Aws
             # The SDK adds this blank content-type header
             # since Net::HTTP provides a default that can break services.
             # We're setting one here even though it's not used or necessary.
-            context.http_request.headers['content-type'] = 'application/json'
+            context.http_request.headers['content-type'] = 'application/x-amz-json-1.1'
             @handler.call(context)
           end
         end

--- a/services.json
+++ b/services.json
@@ -485,7 +485,10 @@
     "models": "lex-models/2017-04-19"
   },
   "LexModelsV2": {
-    "models": "models.lex.v2/2020-08-07"
+    "models": "models.lex.v2/2020-08-07",
+    "addPlugins": [
+      "Aws::LexModelsV2::Plugins::ContentType"
+    ]
   },
   "LexRuntimeV2": {
     "models": "runtime.lex.v2/2020-08-07"


### PR DESCRIPTION
Tested with `lexmodelsv2.list_bots` with and without a payload