### PR TITLE
Deduplicate partitions.json

### DIFF
--- a/gems/aws-partitions/lib/aws-partitions.rb
+++ b/gems/aws-partitions/lib/aws-partitions.rb
@@ -212,7 +212,12 @@ module Aws
       def defaults
         @defaults ||= begin
           path = File.expand_path('../../partitions.json', __FILE__)
-          JSON.load(File.read(path))
+          defaults = if JSON::VERSION >= '2.4.0'
+            JSON.load(File.read(path), freeze: true)
+          else
+            JSON.parse(File.read(path))
+          end
+          defaults.merge('partitions' => defaults['partitions'].dup)
         end
       end
 


### PR DESCRIPTION
`partitions.json` contains a lot of duplicated data, but recent `json` gem have a `freeze: true` option to deduplicate data in documents.

Test script:

```ruby
# typed: false
# frozen_string_literal: true

require 'json'
require 'set'
require 'objspace'

module DeepMemsize
  class << self
    def memsize_of(object, seen = Set.new.compare_by_identity)
      return 0 unless seen.add?(object)

      size = ObjectSpace.memsize_of(object)
      object.instance_variables.each { |v| size += memsize_of(object.instance_variable_get(v), seen) }

      case object
      when Hash
        object.each { |k, v| size += memsize_of(k, seen) + memsize_of(v, seen) }
      when Array
        object.each { |i| size += memsize_of(i, seen) }
      end
      size
    end

    UNIT_PREFIXES = {
      0 => 'B',
      3 => 'kB',
      6 => 'MB',
      9 => 'GB',
      12 => 'TB',
      15 => 'PB',
      18 => 'EB',
      21 => 'ZB',
      24 => 'YB',
    }.freeze

    def scale_bytes(bytes)
      return "0 B" if bytes.zero?

      scale = Math.log10(bytes).div(3) * 3
      scale = 24 if scale > 24
      format("%.2f #{UNIT_PREFIXES[scale]}", (bytes / 10.0**scale))
    end
  end
end

json_path = ARGV.first
puts "base: #{DeepMemsize.scale_bytes(DeepMemsize.memsize_of(JSON.load(File.read(json_path))))}"
puts "freeze: #{DeepMemsize.scale_bytes(DeepMemsize.memsize_of(JSON.parse(File.read(json_path), freeze: true)))}"
``` 

```bash
$ ruby /tmp/size_of.rb gems/aws-partitions/partitions.json 
base: 1.63 MB
freeze: 776.20 kB
```

So it reduces the memory footprint by a bit more than 50%.