### PR TITLE
Fix incorrect use of JSON.load breaking Ruby <= 2.2

### DIFF
--- a/gems/aws-partitions/CHANGELOG.md
+++ b/gems/aws-partitions/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix incorrect use of JSON.load breaking Ruby <= 2.2.
+
 1.425.0 (2021-02-08)
 ------------------
 

--- a/gems/aws-partitions/lib/aws-partitions.rb
+++ b/gems/aws-partitions/lib/aws-partitions.rb
@@ -213,7 +213,7 @@ module Aws
         @defaults ||= begin
           path = File.expand_path('../../partitions.json', __FILE__)
           defaults = if JSON::VERSION >= '2.4.0'
-            JSON.load(File.read(path), freeze: true)
+            JSON.load(File.read(path), nil, freeze: true)
           else
             JSON.parse(File.read(path))
           end


### PR DESCRIPTION
In #2471, a change was introduced to use the json gem `freeze` option to reduce memory usage of the partitions object.

Unfortunately, it seems in the midst of all the tweaks during review, at some point `JSON.parse(..., freeze: true)` was replaced with `JSON.load` which has the following signature:

```ruby
def load(source, proc = nil, options = {})
```

(from <https://github.com/flori/json/blob/ce14bf685d6e1c57c92aa1435fe8cd690805f3d9/lib/json/common.rb#L557>

which means that doing `JSON.load(arg, freeze: true)` does not do what's expected -- `{freeze: true}` ends up in the `proc` argument, not in the `options` argument.

```ruby
[1] pry(main)> puts RUBY_DESCRIPTION
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
=> nil
[2] pry(main)> def test(a, b = nil, c = {})
[2] pry(main)*   [a, b, c]
[2] pry(main)* end
=> :test
[3] pry(main)> test(1, foo: true)
=> [1, {:foo=>true}, {}]
```

Now, the json gem does `recurse_proc(result, &proc) if proc` which breaks on older rubies with

```
TypeError:
  wrong argument type Hash (expected Proc)
```

By a very unfortunate chance, `Hash#to_proc` exists on modern rubies, which was masking this error.

Finally, the wrong result can also be observed by the fact that the output of `JSON.load` is not really frozen:

```ruby
[7] pry(main)> JSON.load('{"hello": "world"}', freeze: true).frozen?
=> false
[8] pry(main)> JSON.load('{"hello": "world"}', nil, freeze: true).frozen?
=> true
```

This is breaking our CI (which tests with the latest version of this gem), so if possible, I'd ask that you release the fix ASAP.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your  changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
