### PR TITLE
🐛  fix: Handle IAD regional endpoint plugin correctly for S3 PrivateLink endpoints

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix an issue with the IAD regional endpoint plugin dropping the region portion of the PrivateLink endpoint.
+* Issue - Fix an issue with the IAD regional endpoint plugin dropping the region(us-east-1) portion of the PrivateLink endpoint.
 
 1.88.1 (2021-02-12)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix an issue with the IAD regional endpoint plugin dropping the region(us-east-1) portion of the PrivateLink endpoint.
+* Issue - Fix an issue with the IAD regional endpoint plugin removing `us-east-1` from a PrivateLink endpoint.
 
 1.88.1 (2021-02-12)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix an issue with the IAD regional endpoint plugin removing `us-east-1` from a PrivateLink endpoint.
+* Issue - Fix an issue with the IAD regional endpoint plugin removing `us-east-1` from custom endpoints.
 
 1.88.1 (2021-02-12)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix an issue with the IAD regional endpoint plugin dropping the region portion of the PrivateLink endpoint.
+
 1.88.1 (2021-02-12)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/iad_regional_endpoint.rb
@@ -46,13 +46,13 @@ region. Defaults to `legacy` mode using global endpoint.
         end
 
         def self.private_link_host?(host, force_path_style)
-          s3_private_link_prefixes = %w(bucket control accesspoint).freeze
+          s3_private_link_prefix = 'bucket'.freeze
           if force_path_style
             private_link_prefix_part = host.split(".")[0]
           else
             private_link_prefix_part = host.split(".")[1]
           end
-          s3_private_link_prefixes.include?(private_link_prefix_part)
+          s3_private_link_prefix == private_link_prefix_part
         end
 
         private

--- a/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
@@ -92,6 +92,17 @@ module Aws
             'https://s3.us-west-2.amazonaws.com/')
         end
 
+        it 'does not modify custom endpoints' do
+          client = Aws::S3::Client.new(
+            stub_responses: true,
+            region: 'us-east-1',
+            endpoint: 'https://my-endpoint.us-east-1.amazonaws.com'
+          )
+          bucket = 'bucketname'
+          resp = client.list_objects(bucket: bucket)
+          expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
+        end
+
         it 'does not modify any ARNs' do
           client = Client.new(
             stub_responses: true,
@@ -102,28 +113,6 @@ module Aws
           expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
         end
 
-        it 'does not modify a virtual host private link endpoint' do
-          client = Aws::S3::Client.new(
-            stub_responses: true,
-            region: 'us-east-1',
-            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          )
-          bucket = 'bucketname'
-          resp = client.list_objects(bucket: bucket)
-          expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
-        end
-
-        it 'does not modify a path style private link endpoint' do
-          client = Aws::S3::Client.new(
-            stub_responses: true,
-            region: 'us-east-1',
-            force_path_style: true,
-            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          )
-          bucket = 'bucketname'
-          resp = client.list_objects(bucket: bucket)
-          expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
-        end
       end
 
     end

--- a/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/iad_regional_endpoint_spec.rb
@@ -101,6 +101,29 @@ module Aws
           resp = client.list_objects(bucket: arn)
           expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
         end
+
+        it 'does not modify a virtual host private link endpoint' do
+          client = Aws::S3::Client.new(
+            stub_responses: true,
+            region: 'us-east-1',
+            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          )
+          bucket = 'bucketname'
+          resp = client.list_objects(bucket: bucket)
+          expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
+        end
+
+        it 'does not modify a path style private link endpoint' do
+          client = Aws::S3::Client.new(
+            stub_responses: true,
+            region: 'us-east-1',
+            force_path_style: true,
+            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          )
+          bucket = 'bucketname'
+          resp = client.list_objects(bucket: bucket)
+          expect(resp.context.http_request.endpoint.to_s).to match(/us-east-1/)
+        end
       end
 
     end

--- a/gems/aws-sdk-s3/spec/client/private_link_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/private_link_spec.rb
@@ -85,6 +85,33 @@ module Aws
           expect(resp.context.http_request.endpoint.host).to eq(host)
         end
 
+        it 'works with the private link endpoint as is with path style in us-east-1 region' do
+          client = Aws::S3::Client.new(
+            stub_responses: true,
+            region: 'us-east-1',
+            force_path_style: true,
+            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          )
+          bucket = 'bucketname'
+          expect_sigv4_service('s3')
+          resp = client.list_objects(bucket: bucket)
+          host = 'bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          expect(resp.context.http_request.endpoint.host).to eq(host)
+        end
+
+        it 'works with the private link endpoint as is in us-east-1 region' do
+          client = Aws::S3::Client.new(
+            stub_responses: true,
+            region: 'us-east-1',
+            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          )
+          bucket = 'bucketname'
+          expect_sigv4_service('s3')
+          resp = client.list_objects(bucket: bucket)
+          host = 'bucketname.bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
+          expect(resp.context.http_request.endpoint.host).to eq(host)
+        end
+
         it 'works with the private link endpoint using the ARN region' do
           client = Aws::S3::Client.new(
             stub_responses: true,

--- a/gems/aws-sdk-s3/spec/client/private_link_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/private_link_spec.rb
@@ -85,33 +85,6 @@ module Aws
           expect(resp.context.http_request.endpoint.host).to eq(host)
         end
 
-        it 'works with the private link endpoint as is with path style in us-east-1 region' do
-          client = Aws::S3::Client.new(
-            stub_responses: true,
-            region: 'us-east-1',
-            force_path_style: true,
-            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          )
-          bucket = 'bucketname'
-          expect_sigv4_service('s3')
-          resp = client.list_objects(bucket: bucket)
-          host = 'bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          expect(resp.context.http_request.endpoint.host).to eq(host)
-        end
-
-        it 'works with the private link endpoint as is in us-east-1 region' do
-          client = Aws::S3::Client.new(
-            stub_responses: true,
-            region: 'us-east-1',
-            endpoint: 'https://bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          )
-          bucket = 'bucketname'
-          expect_sigv4_service('s3')
-          resp = client.list_objects(bucket: bucket)
-          host = 'bucketname.bucket.vpce-123-abc.s3.us-east-1.vpce.amazonaws.com'
-          expect(resp.context.http_request.endpoint.host).to eq(host)
-        end
-
         it 'works with the private link endpoint using the ARN region' do
           client = Aws::S3::Client.new(
             stub_responses: true,


### PR DESCRIPTION
Description
------------

Currently there is a bug when the `aws-sdk-s3` client is used with a private link endpoint and the region is set to `us-east-1`. The IAD regional endpoint plugin drops the `us-east-1` portion. 

So, I get the following issue (using `aws-sdk-s3` gem version `1.88.0`) when I use a PrivateLink endpoint in `us-east-1` but not in other regions like `us-west-2`

```
$ client = Aws::S3::Client.new(region: 'us-east-1', endpoint: 'https://bucket.vpce-xxxx-yyyy.s3.us-east-1.vpce.amazonaws.com')
$ client.list_buckets
Seahorse::Client::NetworkingError: Failed to open TCP connection to bucket.vpce-xxxx-yyyy.s3.vpce.amazonaws.com:443 (getaddrinfo: Name or service not known)
```

So in this PR, we modify the IAD regional endpoint plugin to additionally not drop `us-east-1` if the specified endpoint is a PrivateLink endpoint. 

Testing
--------

- Added unit tests to cover the `us-east-1` case with PrivateLink endpoints. 


Agreement (Generated)
-----------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/master/CONTRIBUTING.md

Thank you for your contribution!
