### PR TITLE
Retry when waiting for stopped task state if starting or running

### DIFF
--- a/apis/dms/2016-01-01/waiters-2.json
+++ b/apis/dms/2016-01-01/waiters-2.json
@@ -189,13 +189,13 @@
                     "argument":"ReplicationTasks[].Status",
                     "expected":"starting",
                     "matcher":"pathAny",
-                    "state":"failure"
+                    "state":"retry"
                 },
                 {
                     "argument":"ReplicationTasks[].Status",
                     "expected":"running",
                     "matcher":"pathAny",
-                    "state":"failure"
+                    "state":"retry"
                 },
                 {
                     "argument":"ReplicationTasks[].Status",

--- a/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
+++ b/gems/aws-sdk-databasemigrationservice/lib/aws-sdk-databasemigrationservice/waiters.rb
@@ -518,13 +518,13 @@ module Aws::DatabaseMigrationService
                 "argument" => "replication_tasks[].status",
                 "expected" => "starting",
                 "matcher" => "pathAny",
-                "state" => "failure"
+                "state" => "retry"
               },
               {
                 "argument" => "replication_tasks[].status",
                 "expected" => "running",
                 "matcher" => "pathAny",
-                "state" => "failure"
+                "state" => "retry"
               },
               {
                 "argument" => "replication_tasks[].status",


### PR DESCRIPTION
Currently, the waiter raises an immediate failure unless it is already in the stopped state. It does not wait for the task to finish, making this waiter virtually useless.

There may be other wait states in this config that might be worth considering, these are the two states I am concerned about retrying. I  made this change in the gem and the API, unsure of where it belongs. The contrib guidelines state waiters are API-backed changes but I'm not sure what that means in terms of proposing changes. 

Please advise (first time contrib to this project). Let me know if there is anything I can do to resolve.

