### PR TITLE
XML encoding (revert the revert)

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure end of line characters are correctly encoded in XML.
+
 3.113.0 (2021-03-10)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/doc_builder.rb
@@ -67,7 +67,12 @@ module Aws
       end
 
       def escape(string, text_or_attr)
-        string.to_s.encode(:xml => text_or_attr)
+        string.to_s
+          .encode(:xml => text_or_attr)
+          .gsub("\u{000D}", '&#xD;') # Carriage Return
+          .gsub("\u{000A}", '&#xA;') # Line Feed
+          .gsub("\u{0085}", '&#x85;') # Next Line
+          .gsub("\u{2028}", '&#x2028;') # Line Separator
       end
 
       def attributes(attr)

--- a/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
@@ -245,8 +245,7 @@ module Aws
       it 'correctly serializes newlines' do
         expect(xml(string:"\n")).to eq(<<-XML)
 <xml>
-  <String>
-</String>
+  <String>&#xA;</String>
 </xml>
         XML
       end

--- a/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/doc_builder_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../spec_helper'
 require 'ostruct'
+require 'base64'
 
 module Aws
   module Xml
@@ -81,6 +82,43 @@ module Aws
           xml.node('this & that')
         end
         expect(result).to eq('<xml xmlns="a&quot;b"><this & that/></xml>')
+      end
+
+      it 'escapes carriage return in attributes' do
+        xml.node('xml', key: "my\rkey")
+        expect(result).to include("my&#xD;key")
+      end
+
+      context 'End Of Line Characters' do
+        # human readable input is tricky for these - so use a base64 encoded
+        # string to ensure we get exactly what should be tested
+        it 'encodes line feeds' do
+          # "\n \n"
+          input = Base64.decode64('CiAK').force_encoding('utf-8')
+          xml.node('xml', input)
+          expect(result).to include('&#xA; &#xA;')
+        end
+
+        it 'encodes line feeds and carriage returns' do
+          # "a\r\n b\n c\r"
+          input = Base64.decode64('YQ0KIGIKIGMN').force_encoding('utf-8')
+          xml.node('xml', input)
+          expect(result).to include('a&#xD;&#xA; b&#xA; c&#xD;')
+        end
+
+        it 'encodes next lines' do
+          # "a\r\u0085 b\u0085"
+          input = Base64.decode64('YQ3ChSBiwoU=').force_encoding('utf-8')
+          xml.node('xml', input)
+          expect(result).to include('a&#xD;&#x85; b&#x85;')
+        end
+
+        it 'encodes line separators' do
+          # "a\r\u2028 b\u0085 c\u2028"
+          input = Base64.decode64('YQ3igKggYsKFIGPigKg=').force_encoding('utf-8')
+          xml.node('xml', input)
+          expect(result).to include('a&#xD;&#x2028; b&#x85; c&#x2028;')
+        end
       end
 
       it 'accepts :indent and initial :pad options' do


### PR DESCRIPTION
This reverts commit eff871cc34638e2aed8f5fd85a4b1173720b857f.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
