### PR TITLE
Allow non HTTP verbs actions into S3 Presigner

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Allow S3 Presigner to sign non http verbs like (upload_part, multipart_upload_abort, etc.) #2511
+
 1.93.1 (2021-04-12)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -153,21 +153,35 @@ module Aws
       #     obj.presigned_url(:put, acl: 'public-read')
       #     #=> "https://bucket-name.s3.amazonaws.com/object-key?..."
       #
-      # @param [Symbol] http_method
-      #   The HTTP method to generate a presigned URL for. Valid values
-      #   are `:get`, `:put`, `:head`, and `:delete`.
+      # @example Pre-signed UploadPart PUT
+      #
+      #     # the object uploaded using this URL will be publicly accessible
+      #     obj.presigned_url(:upload_part, part_number: 1, upload_id: 'uploadIdToken')
+      #     #=> "https://bucket-name.s3.amazonaws.com/object-key?..."
+      #
+      # @param [Symbol] method
+      #   The S3 operation to generate a presigned URL for. Valid values
+      #   are `:get`, `:put`, `:head`, `:delete`, `:create_multipart_upload`, 
+      #   `:list_multipart_uploads`, `:complete_multipart_upload`,
+      #   `:abort_multipart_upload`, `:list_parts`, and `:upload_part`.
       #
       # @param [Hash] params
       #   Additional request parameters to use when generating the pre-signed
       #   URL. See the related documentation in {Client} for accepted
       #   params.
       #
-      #   | HTTP Method   | Client Method          |
-      #   |---------------|------------------------|
-      #   | `:get`        | {Client#get_object}    |
-      #   | `:put`        | {Client#put_object}    |
-      #   | `:head`       | {Client#head_object}   |
-      #   | `:delete`     | {Client#delete_object} |
+      #   | Method                       | Client Method                      |
+      #   |------------------------------|------------------------------------|
+      #   | `:get`                       | {Client#get_object}                |
+      #   | `:put`                       | {Client#put_object}                |
+      #   | `:head`                      | {Client#head_object}               |
+      #   | `:delete`                    | {Client#delete_object}             |
+      #   | `:create_multipart_upload`   | {Client#create_multipart_upload}   |
+      #   | `:list_multipart_uploads`    | {Client#list_multipart_uploads}    |
+      #   | `:complete_multipart_upload` | {Client#complete_multipart_upload} |
+      #   | `:abort_multipart_upload`    | {Client#abort_multipart_upload}    |
+      #   | `:list_parts`                | {Client#list_parts}                |
+      #   | `:upload_part`               | {Client#upload_part}               |
       #
       # @option params [Boolean] :virtual_host (false) When `true` the
       #   presigned URL will use the bucket name as a virtual host.
@@ -188,10 +202,15 @@ module Aws
       #
       # @return [String]
       #
-      def presigned_url(http_method, params = {})
+      def presigned_url(method, params = {})
         presigner = Presigner.new(client: client)
+
+        if %w(delete head get put).include?(method.to_s)
+          method = "#{method}_object".to_sym
+        end
+
         presigner.presigned_url(
-          "#{http_method.downcase}_object",
+          method.downcase,
           params.merge(bucket: bucket_name, key: key)
         )
       end


### PR DESCRIPTION
By applying the `_object` suffix only if the operation is an HTTP Verb is
possible to use the rest of the S3 like:

- upload_part
- abort_multipart_upload
- complete_multipart_upload

See aws/aws-sdk-ruby#2511

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
