### PR TITLE
Expose presigned request status to the request handler stack

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Expose presigned request status to the request handler stack #2513
+* Issue - Expose presigned request status to the request handler stack #2513
 
 1.94.0 (2021-04-27)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Expose presigned request status to the request handler stack #2513
+
 1.94.0 (2021-04-27)
 ------------------
 

--- a/gems/aws-sdk-s3/spec/presigner_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigner_spec.rb
@@ -47,6 +47,14 @@ module Aws
           expect(client.api_requests.size).to eq(1)
         end
 
+        it 'labels context as a presigned request before handlers are invoked' do
+          expect do |block|
+            client.handle_request(&block)
+
+            subject.presigned_url(:get_object, bucket: 'bkt', key: 'k')
+          end.to yield_with_args { |c| c[:presigned_url] == true }
+        end
+
         it 'can be excluded from being tracked as an api request' do
           subject.presigned_url(:get_object, bucket: 'bkt', key: 'k')
           expect(client.api_requests(exclude_presign: true)).to be_empty
@@ -160,6 +168,14 @@ module Aws
         it 'will be tracked as an api request' do
           subject.presigned_request(:get_object, bucket: 'bkt', key: 'k')
           expect(client.api_requests.size).to eq(1)
+        end
+
+        it 'labels context as a presigned request before handlers are invoked' do
+          expect do |block|
+            client.handle_request(&block)
+
+            subject.presigned_request(:get_object, bucket: 'bkt', key: 'k')
+          end.to yield_with_args { |c| c[:presigned_url] == true }
         end
 
         it 'can be excluded from being tracked as an api request' do


### PR DESCRIPTION
While implementing a custom request handler for the S3 client, I noticed that requests to generate a presigned URL and real `get_object` requests looked identical to my handler.
Because my handler generates telemetry side-effects that should only account for real S3 remote requests, the these presign requests were generating miscounted telemetry data for my case.

I noticed that there is a signal that this request was a presign request (`context[:presigned_url] = true`), but it was only set _after_ the request stack was executed.

This PR moves that context marking (`context[:presigned_url] = true`) to before the request stack is executed, to allow it to make an informed decision on how to process a presigned url request.

I also noticed that the manual removal of these three handlers is likely due to a similar need as in my case: https://github.com/aws/aws-sdk-ruby/blob/656691b470bb970627286cf1df2bd84049b6787d/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb#L194-L196
