### PR TITLE
Allow configuration of credential refresh behavior

### DIFF
--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
@@ -80,6 +80,9 @@ module Aws
       #
       # @option options [STS::CognitoIdentity] :client Optional CognitoIdentity
       #   client. If not provided, a client will be constructed.
+      #
+      # @option options [Integer] (300) :credential_expiration_buffer Credentials
+      #   will refresh if they are within this many seconds of expiring.
       def initialize(options = {})
         @identity_pool_id = options.delete(:identity_pool_id)
         @identity_id = options.delete(:identity_id)

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Provide an option `:credential_expiration_buffer` for `Aws::AssumeRoleCredentials`, `Aws::AssumeRoleWebIdentityCredentials`, `Aws::ECSCredentials`,  and `Aws::InstanceProfileCredentials` to ensure credentials are refreshed if they are a certain number of seconds before expiring.
+
 3.114.0 (2021-04-13)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
@@ -28,6 +28,8 @@ module Aws
     # @option options [Integer] :duration_seconds
     # @option options [String] :external_id
     # @option options [STS::Client] :client
+    # @option options [Integer] (300) :credential_expiration_buffer Credentials
+    #   will refresh if they are within this many seconds of expiring.
     def initialize(options = {})
       client_opts = {}
       @assume_role_params = {}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
@@ -17,7 +17,7 @@ module Aws
   #       ...
   #     )
   #     For full list of parameters accepted
-  #     @see Aws::STS::Client#assume_role_with_web_identity 
+  #     @see Aws::STS::Client#assume_role_with_web_identity
   #
   #
   # If you omit `:client` option, a new {STS::Client} object will be
@@ -39,6 +39,9 @@ module Aws
     #   encoded UUID is generated as the session name
     #
     # @option options [STS::Client] :client
+    #
+    # @option options [Integer] (300) :credential_expiration_buffer Credentials
+    #   will refresh if they are within this many seconds of expiring.
     def initialize(options = {})
       client_opts = {}
       @assume_role_web_identity_params = {}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -43,6 +43,8 @@ module Aws
     # @option options [IO] :http_debug_output (nil) HTTP wire
     #   traces are sent to this object.  You can specify something
     #   like $stdout.
+    # @option options [Integer] (300) :credential_expiration_buffer Credentials
+    #   will refresh if they are within this many seconds of expiring.
     def initialize options = {}
       @retries = options[:retries] || 5
       @ip_address = options[:ip_address] || '169.254.170.2'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -58,6 +58,8 @@ module Aws
     # @option options [Integer] :token_ttl Time-to-Live in seconds for EC2
     #   Metadata Token used for fetching Metadata Profile Credentials, defaults
     #   to 21600 seconds
+    # @option options [Integer] (300) :credential_expiration_buffer Credentials
+    #   will refresh if they are within this many seconds of expiring.
     def initialize(options = {})
       @retries = options[:retries] || 1
       @ip_address = options[:ip_address] || '169.254.169.254'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
@@ -64,6 +64,9 @@ module Aws
     #
     # @option options [SSO::Client] :client Optional `SSO::Client`.  If not
     #   provided, a client will be constructed.
+    #
+    # @option options [Integer] (300) :credential_expiration_buffer Credentials
+    #   will refresh if they are within this many seconds of expiring.
     def initialize(options = {})
 
       missing_keys = SSO_REQUIRED_OPTS.select { |k| options[k].nil? }

--- a/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ecs_credentials_spec.rb
@@ -140,7 +140,29 @@ module Aws
 
       end
 
-      describe 'failure cases' do
+      describe 'auto refreshing configuration' do
+
+        let(:expiration) { Time.now.utc + 599 }
+
+        it 'refreshes if within the buffer' do
+          c = ECSCredentials.new({ credential_expiration_buffer: 600 })
+          expect(c.credentials.access_key_id).to eq('akid-2')
+          expect(c.credentials.secret_access_key).to eq('secret-2')
+          expect(c.credentials.session_token).to eq('session-token-2')
+          expect(c.expiration.to_s).to eq(expiration2.to_s)
+        end
+
+        it 'does not refresh before entering the buffer' do
+          c = ECSCredentials.new({ credential_expiration_buffer: 599 })
+          expect(c.credentials.access_key_id).to eq('akid')
+          expect(c.credentials.secret_access_key).to eq('secret')
+          expect(c.credentials.session_token).to eq('session-token')
+          expect(c.expiration.to_s).to eq(expiration.to_s)
+        end
+
+      end
+
+    describe 'failure cases' do
 
         let(:resp) { '{}' }
 

--- a/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/instance_profile_credentials_spec.rb
@@ -309,6 +309,26 @@ module Aws
         end
       end
 
+      describe 'auto refreshing configuration' do
+        let(:expiration) { Time.now.utc + 599 }
+
+        it 'refreshes if within the buffer' do
+          c = InstanceProfileCredentials.new({ credential_expiration_buffer: 600 })
+          expect(c.credentials.access_key_id).to eq('akid-2')
+          expect(c.credentials.secret_access_key).to eq('secret-2')
+          expect(c.credentials.session_token).to eq('session-token-2')
+          expect(c.expiration.to_s).to eq(expiration2.to_s)
+        end
+
+        it 'does not refresh before entering the buffer' do
+          c = InstanceProfileCredentials.new({ credential_expiration_buffer: 599 })
+          expect(c.credentials.access_key_id).to eq('akid')
+          expect(c.credentials.secret_access_key).to eq('secret')
+          expect(c.credentials.session_token).to eq('session-token')
+          expect(c.expiration.to_s).to eq(expiration.to_s)
+        end
+      end
+
       describe 'failure cases' do
         let(:resp) { '{}' }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Hey all! We came across this when using presigned URLs in S3. We often need our presigned URLs a little bit longer than 5 minutes. This change would allow us to ensure we refreshed our credentials within a larger buffer before expiration thus giving us the window we need to use the presigned URLs before they are revoked for an expired token. We were going to work around this in our project, but figured we might as well try to add the option. Maybe if it is useful for us it will be for others as well.

I added tests only where the 5 minute behavior was already tested but added docs everywhere the option is available. I am happy to add tests, or limit which classes can configure the behavior (I personally only care about `Aws::InstanceProfileCredentials` right now), but wanted to see what you all thought about this change before going any further.

Please let me know if this makes sense and if there is anything you would like me to clean up. Thank you!