### PR TITLE
aws-sdk-core/xml/builder: no default indentation

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Change XML Builder to not indent by default
+
 3.114.0 (2021-04-13)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/builder.rb
@@ -11,7 +11,7 @@ module Aws
       def initialize(rules, options = {})
         @rules = rules
         @xml = options[:target] || []
-        indent = options[:indent] || '  '
+        indent = options[:indent] || ''
         pad = options[:pad] || ''
         @builder = DocBuilder.new(target: @xml, indent: indent, pad: pad)
       end

--- a/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/http_checksum_spec.rb
@@ -39,7 +39,7 @@ module Aws
         it 'computes MD5 of the http body and sends as content-md5 header' do
           resp = client.checksum_operation(string: 'md5 me captain')
           expect(resp.context.http_request.headers['content-md5']).to eq(
-            '9ZS+xZNSM+p0Dt901z+WHg=='
+            'rqd/0N8H2GgZWzmo3oY9tA=='
           )
         end
 

--- a/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/builder_spec.rb
@@ -19,7 +19,7 @@ module Aws
       let(:rules) { operation.input }
 
       def xml(params)
-        Builder.new(rules).to_xml(params)
+        Builder.new(rules, indent: '  ').to_xml(params)
       end
 
       it 'serializes empty values as empty elements' do

--- a/gems/aws-sdk-s3/spec/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/client_spec.rb
@@ -321,7 +321,7 @@ module Aws
           end
           resp = s3.create_bucket(bucket: 'aws-sdk')
           expect(resp.context.http_request.body_contents.strip)
-            .to eq(<<-XML.strip)
+            .to eq(<<-XML.gsub(/(^\s+|\n)/, ''))
 <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <LocationConstraint>us-west-2</LocationConstraint>
 </CreateBucketConfiguration>
@@ -341,7 +341,7 @@ module Aws
             }
           )
           expect(resp.context.http_request.body_contents.strip)
-            .to eq(<<-XML.strip)
+            .to eq(<<-XML.gsub(/(^\s+|\n)/, ''))
 <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <LocationConstraint>EU</LocationConstraint>
 </CreateBucketConfiguration>
@@ -583,7 +583,7 @@ module Aws
               ]
             }
           )
-          expect(resp.context.http_request.body_contents).to eq(<<-XML)
+          expect(resp.context.http_request.body_contents).to eq(<<-XML.gsub(/(^\s+|\n)/, ''))
 <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <AccessControlList>
     <Grant>


### PR DESCRIPTION
XML document indentation increases the body size. It can
be useful for debugging purposes, but under normal operations,
it is not helpful.

The result of a larger body size makes operations like
`complete_multipart_upload` fail for certain S3 gateways
(Ceph Object Gateway at least) when having 10k parts,
because of the body being too large.

Compared to boto3, boto3 does not indent, which makes
the body smaller than the fatal limit.

This commit removes the default indentation to have the
same behavior as boto3 and to be able to use multipart
uploads with 10k parts with Ceph Object Gateway.
