### PR TITLE
feat(lexmodelsv2): Implement Waiters

### DIFF
--- a/apis/models.lex.v2/2020-08-07/waiters-2.json
+++ b/apis/models.lex.v2/2020-08-07/waiters-2.json
@@ -1,0 +1,185 @@
+{
+  "version": 2,
+  "waiters": {
+    "BotAvailable": {
+      "delay": 10,
+      "operation": "DescribeBot",
+      "maxAttempts": 35,
+      "description": "Wait until a bot is available",
+      "acceptors": [
+        {
+          "expected": "Available",
+          "matcher": "path",
+          "state": "success",
+          "argument": "botStatus"
+        },
+        {
+          "expected": "Deleting",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botStatus"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botStatus"
+        },
+        {
+          "expected": "Inactive",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botStatus"
+        }
+      ]
+    },
+    "BotAliasAvailable": {
+      "delay": 10,
+      "operation": "DescribeBotAlias",
+      "maxAttempts": 35,
+      "description": "Wait until a bot alias is available",
+      "acceptors": [
+        {
+          "expected": "Available",
+          "matcher": "path",
+          "state": "success",
+          "argument": "botAliasStatus"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botAliasStatus"
+        },
+        {
+          "expected": "Deleting",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botAliasStatus"
+        }
+      ]
+    },
+    "BotExportCompleted": {
+      "delay": 10,
+      "operation": "DescribeExport",
+      "maxAttempts": 35,
+      "description": "Wait until a bot has been exported",
+      "acceptors": [
+        {
+          "expected": "Completed",
+          "matcher": "path",
+          "state": "success",
+          "argument": "exportStatus"
+        },
+        {
+          "expected": "Deleting",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "exportStatus"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "exportStatus"
+        }
+      ]
+    },
+    "BotImportCompleted": {
+      "delay": 10,
+      "operation": "DescribeImport",
+      "maxAttempts": 35,
+      "description": "Wait until a bot has been imported",
+      "acceptors": [
+        {
+          "expected": "Completed",
+          "matcher": "path",
+          "state": "success",
+          "argument": "importStatus"
+        },
+        {
+          "expected": "Deleting",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "importStatus"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "importStatus"
+        }
+      ]
+    },
+    "BotLocaleBuilt": {
+      "delay": 10,
+      "operation": "DescribeBotLocale",
+      "maxAttempts": 35,
+      "description": "Wait until a bot locale is built",
+      "acceptors": [
+        {
+          "expected": "Built",
+          "matcher": "path",
+          "state": "success",
+          "argument": "botLocaleStatus"
+        },
+        {
+          "expected": "Deleting",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botLocaleStatus"
+        },
+        {
+          "expected": "Failed",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botLocaleStatus"
+        },
+        {
+          "expected": "NotBuilt",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "botLocaleStatus"
+        }
+      ],
+      "BotLocaleExpressTestingAvailable": {
+        "delay": 10,
+        "operation": "DescribeBotLocale",
+        "maxAttempts": 35,
+        "description": "Wait until a bot locale build is ready for express testing",
+        "acceptors": [
+          {
+            "expected": "Built",
+            "matcher": "path",
+            "state": "success",
+            "argument": "botLocaleStatus"
+          },
+          {
+            "expected": "ReadyExpressTesting",
+            "matcher": "path",
+            "state": "success",
+            "argument": "botLocaleStatus"
+          },
+          {
+            "expected": "Deleting",
+            "matcher": "path",
+            "state": "failure",
+            "argument": "botLocaleStatus"
+          },
+          {
+            "expected": "Failed",
+            "matcher": "path",
+            "state": "failure",
+            "argument": "botLocaleStatus"
+          },
+          {
+            "expected": "NotBuilt",
+            "matcher": "path",
+            "state": "failure",
+            "argument": "botLocaleStatus"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Resolves https://github.com/aws/aws-sdk-ruby/issues/2530
* Implements polling-based waiter methods for the LexModelsV2
  client with the following conditions:
  - `bot_available`: Bot is successfully built
  - `bot_alias_available`: Bot alias is successfully built
  - `bot_export_completed`: Bot has been exported successfully
  - `bot_import_completed`: Bot has been imported successfully
  - `bot_locale_built`: A bot language has been built
  - `bot_locale_express_testing_available`: A bot language is ready for express testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
