### PR TITLE
Fix nil pagination tokens not merging into next params

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fixed an issue with `Aws::PageableResponse` where intentionally nil tokens were not merged into the params for the next call.
+
 3.114.1 (2021-06-02)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -115,6 +115,11 @@ module Aws
     # @return [Hash] Returns the hash of request parameters for the
     #   next page, merging any given params.
     def next_page_params(params)
+      # Remove all previous tokens from original params
+      # Sometimes a token can be nil and merge would not include it.
+      @pager.tokens.each do |_k, v|
+        context[:original_params].delete(v.to_sym)
+      end
       context[:original_params].merge(@pager.next_tokens(self).merge(params))
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pager.rb
@@ -18,6 +18,9 @@ module Aws
     # @return [Symbol, nil]
     attr_reader :limit_key
 
+    # @return [Hash, nil]
+    attr_reader :tokens
+
     # @param [Seahorse::Client::Response] response
     # @return [Hash]
     def next_tokens(response)

--- a/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -79,8 +79,8 @@ module Aws
 
       it 'removes previous tokens on subsequent #next_page calls' do
         client = double('client')
-        new_request = double('new-request')
-        new_new_request = double('new-new-request')
+        request_1 = double('new-request')
+        request_2 = double('new-new-request')
 
         resp.data = { 'next_token' => 'OFFSET', 'other_token' => 'TOKEN' }
         resp.context.client = client
@@ -88,26 +88,28 @@ module Aws
 
         expect(client).to receive(:build_request).
           with('operation-name', { :offset => 'OFFSET', :token => 'TOKEN' }).
-          and_return(new_request)
+          and_return(request_1)
 
-        context = Seahorse::Client::RequestContext.new(params: { :offset => 'OFFSET', :token => 'TOKEN' })
+        context = Seahorse::Client::RequestContext.new(
+          params: { :offset => 'OFFSET', :token => 'TOKEN' }
+        )
         new_resp = pageable(Seahorse::Client::Response.new(context: context), pager)
         new_resp.data = { 'next_token' => 'OFFSET' }
         new_resp.context.client = client
         new_resp.context.operation_name = 'operation-name'
 
-        expect(new_request).to receive(:send_request).and_return(new_resp)
+        expect(request_1).to receive(:send_request).and_return(new_resp)
 
-        next_page = resp.next_page
+        second_page = resp.next_page
 
         expect(client).to receive(:build_request).
           with('operation-name', { :offset => 'OFFSET' }).
-          and_return(new_new_request)
+          and_return(request_2)
 
-        expect(new_new_request).to receive(:send_request).
+        expect(request_2).to receive(:send_request).
           and_return(Seahorse::Client::Response.new)
 
-        next_page.next_page
+        second_page.next_page
       end
     end
 

--- a/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -20,7 +20,8 @@ module Aws
 
       let(:options) {{
         tokens: {
-          'next_token' => 'offset'
+          'next_token' => 'offset',
+          'other_token' => 'token'
         }
       }}
 
@@ -76,6 +77,38 @@ module Aws
         resp.next_page
       end
 
+      it 'removes previous tokens on subsequent #next_page calls' do
+        client = double('client')
+        new_request = double('new-request')
+        new_new_request = double('new-new-request')
+
+        resp.data = { 'next_token' => 'OFFSET', 'other_token' => 'TOKEN' }
+        resp.context.client = client
+        resp.context.operation_name = 'operation-name'
+
+        expect(client).to receive(:build_request).
+          with('operation-name', { :offset => 'OFFSET', :token => 'TOKEN' }).
+          and_return(new_request)
+
+        context = Seahorse::Client::RequestContext.new(params: { :offset => 'OFFSET', :token => 'TOKEN' })
+        new_resp = pageable(Seahorse::Client::Response.new(context: context), pager)
+        new_resp.data = { 'next_token' => 'OFFSET' }
+        new_resp.context.client = client
+        new_resp.context.operation_name = 'operation-name'
+
+        expect(new_request).to receive(:send_request).and_return(new_resp)
+
+        next_page = resp.next_page
+
+        expect(client).to receive(:build_request).
+          with('operation-name', { :offset => 'OFFSET' }).
+          and_return(new_new_request)
+
+        expect(new_new_request).to receive(:send_request).
+          and_return(Seahorse::Client::Response.new)
+
+        next_page.next_page
+      end
     end
 
     describe 'paging with multiple tokens' do


### PR DESCRIPTION
Sometimes an API returns an intentionally nil token. Merging this nil token over a previous token will not work. This approach deletes all previous tokens from the original param context.

Needs unit tests. Manual testing works on `route53.list_resource_record_sets`.