### PR TITLE
Fix xml parsing of S3 bucket location constraint

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - fix GetBucketLocation location_constraint XML parsing (#2536)
+
 1.96.0 (2021-06-03)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
@@ -11,7 +11,7 @@ module Aws
             @handler.call(context).on(200) do |response|
               response.data = S3::Types::GetBucketLocationOutput.new
               xml = context.http_response.body_contents
-              matches = xml.match(/>(.+?)<\/LocationConstraint>/)
+              matches = xml.match(/<LocationConstraint.*?>(.+?)<\/LocationConstraint>/)
               response.data[:location_constraint] = matches ? matches[1] : ''
             end
           end


### PR DESCRIPTION
Just wanted to throw out a possible fix for the issue described in https://github.com/aws/aws-sdk-ruby/issues/2536

The XML that is returned when using stubbed responses is: `<GetBucketLocationResult xmlns=\"\"><LocationConstraint>EU</LocationConstraint></GetBucketLocationResult>` which fails with the regex `/>(.+?)<\/LocationConstraint>/`
Fix an issue with parsing of an S3 bucket location constraint introduced by removal of default xml indentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Thank you for your contribution!

Fixes https://github.com/aws/aws-sdk-ruby/issues/2536