### PR TITLE
Assume role chaining

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature = Add support for Assume Role Chaining in profiles. (#2531)
+
 3.114.3 (2021-06-15)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature = Add support for Assume Role Chaining in profiles. (#2531)
+* Feature - Add support for Assume Role Chaining in profiles. (#2531)
 
 3.114.3 (2021-06-15)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -210,6 +210,10 @@ module Aws
     # Raised when SSO Credentials are invalid
     class InvalidSSOCredentials < RuntimeError; end
 
+    # Raised when there is a circular reference in chained
+    # source_profiles
+    class SourceProfileCircularReferenceError < RuntimeError; end
+
     # Raised when a client is constructed and region is not specified.
     class MissingRegionError < ArgumentError
       def initialize(*args)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -289,9 +289,9 @@ module Aws
 
     def assume_role_process_credentials_from_config(profile)
       validate_profile_exists(profile)
-      credential_process = @parsed_credentials.fetch(:profile, {})['credential_process']
+      credential_process = @parsed_credentials.fetch(profile, {})['credential_process']
       if @parsed_config
-        credential_process = @parsed_config.fetch(:profile, {})['credential_process']
+        credential_process ||= @parsed_config.fetch(profile, {})['credential_process']
       end
       ProcessCredentials.new(credential_process) if credential_process
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -289,7 +289,6 @@ module Aws
 
     def assume_role_process_credentials_from_config(profile)
       validate_profile_exists(profile)
-      puts "Checking role_process from config...., profile: #{profile}"
       credential_process = @parsed_credentials.fetch(:profile, {})['credential_process']
       if @parsed_config
         credential_process = @parsed_config.fetch(:profile, {})['credential_process']

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -249,7 +249,7 @@ module Aws
 
     def resolve_source_profile(profile, opts = {})
       if opts[:visited_profiles] && opts[:visited_profiles].include?(profile)
-        raise Errors::CredentialSourceConflictError  # TODO: Better error for this
+        raise Errors::SourceProfileCircularReferenceError
       end
       opts[:visited_profiles].add(profile) if opts[:visited_profiles]
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -205,6 +205,7 @@ module Aws
             'a credential_source. For assume role credentials, must '\
             'provide only source_profile or credential_source, not both.'
         elsif opts[:source_profile]
+          opts[:visited_profiles] ||= Set.new
           opts[:credentials] = resolve_source_profile(opts[:source_profile], opts)
           if opts[:credentials]
             opts[:role_session_name] ||= prof_cfg['role_session_name']
@@ -214,6 +215,7 @@ module Aws
             opts[:external_id] ||= prof_cfg['external_id']
             opts[:serial_number] ||= prof_cfg['mfa_serial']
             opts[:profile] = opts.delete(:source_profile)
+            opts.delete(:visited_profiles)
             AssumeRoleCredentials.new(opts)
           else
             raise Errors::NoSourceProfileError,
@@ -246,8 +248,21 @@ module Aws
     end
 
     def resolve_source_profile(profile, opts = {})
+      if opts[:visited_profiles] && opts[:visited_profiles].include?(profile)
+        raise Errors::CredentialSourceConflictError  # TODO: Better error for this
+      end
+      opts[:visited_profiles].add(profile) if opts[:visited_profiles]
+
+      profile_config = @parsed_credentials[profile]
+      if @config_enabled
+        profile_config ||= @parsed_config[profile]
+      end
+
       if (creds = credentials(profile: profile))
         creds # static credentials
+      elsif profile_config && profile_config['source_profile']
+        opts.delete(:source_profile)
+        assume_role_credentials_from_config(opts.merge(profile: profile))
       elsif (provider = assume_role_web_identity_credentials_from_config(opts.merge(profile: profile)))
         provider.credentials if provider.credentials.set?
       elsif (provider = assume_role_process_credentials_from_config(profile))
@@ -274,7 +289,11 @@ module Aws
 
     def assume_role_process_credentials_from_config(profile)
       validate_profile_exists(profile)
-      credential_process = @parsed_config[profile]['credential_process']
+      puts "Checking role_process from config...., profile: #{profile}"
+      credential_process = @parsed_credentials.fetch(:profile, {})['credential_process']
+      if @parsed_config
+        credential_process = @parsed_config.fetch(:profile, {})['credential_process']
+      end
       ProcessCredentials.new(credential_process) if credential_process
     end
 

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -331,7 +331,7 @@ module Aws
         it 'supports assume role chaining' do
           assume_role_stub(
             'arn:aws:iam:123456789012:role/role_b',
-            'ACCESS_KEY_0',
+            'ACCESS_KEY_BASE',
             'AK_1',
             'SECRET_AK_1',
             'TOKEN_1'
@@ -352,6 +352,49 @@ module Aws
             client.config.credentials.credentials.access_key_id
           ).to eq('AK_2')
         end
+
+        it 'uses source credentials when source and static are both set' do
+          assume_role_stub(
+            'arn:aws:iam:123456789012:role/role_a',
+            'ACCESS_KEY_BASE',
+            'AK_2',
+            'SECRET_AK_2',
+            'TOKEN_2'
+          )
+
+          client = ApiHelper.sample_rest_xml::Client.new(
+            profile: 'assume_role_source_and_credentials', region: 'us-east-1'
+          )
+          expect(
+            client.config.credentials.credentials.access_key_id
+          ).to eq('AK_2')
+        end
+
+        it 'uses static credentials when the profile self references' do
+          assume_role_stub(
+            'arn:aws:iam:123456789012:role/role_a',
+            'ACCESS_KEY_SELF',
+            'AK_2',
+            'SECRET_AK_2',
+            'TOKEN_2'
+          )
+
+          client = ApiHelper.sample_rest_xml::Client.new(
+            profile: 'assume_role_self_reference', region: 'us-east-1'
+          )
+          expect(
+            client.config.credentials.credentials.access_key_id
+          ).to eq('AK_2')
+        end
+
+        it 'raises if there is a loop in chained profiles' do
+          expect do
+            ApiHelper.sample_rest_xml::Client.new(
+              profile: 'assume_role_chain_loop_a', region: 'us-east-1'
+            )
+          end.to raise_error(Errors::SourceProfileCircularReferenceError)
+        end
+
 
         it 'raises if credential_source is present but invalid' do
           expect do

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -328,6 +328,31 @@ module Aws
           ).to eq('AR_AKID')
         end
 
+        it 'supports assume role chaining' do
+          assume_role_stub(
+            'arn:aws:iam:123456789012:role/role_b',
+            'ACCESS_KEY_0',
+            'AK_1',
+            'SECRET_AK_1',
+            'TOKEN_1'
+          )
+
+          assume_role_stub(
+            'arn:aws:iam:123456789012:role/role_a',
+            'AK_1',
+            'AK_2',
+            'SECRET_AK_2',
+            'TOKEN_2'
+          )
+
+          client = ApiHelper.sample_rest_xml::Client.new(
+            profile: 'assume_role_chain_b', region: 'us-east-1'
+          )
+          expect(
+            client.config.credentials.credentials.access_key_id
+          ).to eq('AK_2')
+        end
+
         it 'raises if credential_source is present but invalid' do
           expect do
             ApiHelper.sample_rest_xml::Client.new(

--- a/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
+++ b/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
@@ -189,3 +189,11 @@ adaptive_retry_wait_to_fill = false
 
 [profile correct_clock_skew]
 correct_clock_skew = false
+
+[profile assume_role_chain_a]
+source_profile = default
+role_arn = arn:aws:iam:123456789012:role/role_a
+
+[profile assume_role_chain_b]
+source_profile = assume_role_chain_a
+role_arn = arn:aws:iam:123456789012:role/role_b

--- a/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
+++ b/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
@@ -190,10 +190,38 @@ adaptive_retry_wait_to_fill = false
 [profile correct_clock_skew]
 correct_clock_skew = false
 
+[profile assume_role_base]
+aws_access_key_id = ACCESS_KEY_BASE
+aws_secret_access_key = SECRET_KEY_BASE
+aws_session_token = TOKEN_BASE
+
 [profile assume_role_chain_a]
-source_profile = default
+source_profile = assume_role_base
 role_arn = arn:aws:iam:123456789012:role/role_a
 
 [profile assume_role_chain_b]
 source_profile = assume_role_chain_a
 role_arn = arn:aws:iam:123456789012:role/role_b
+
+[profile assume_role_source_and_credentials]
+source_profile = assume_role_base
+role_arn = arn:aws:iam:123456789012:role/role_a
+aws_access_key_id = ACCESS_KEY_DO_NOT_USE
+aws_secret_access_key = SECRET_KEY_DO_NOT_USE
+aws_session_token = TOKEN_DO_NOT_USE
+
+[profile assume_role_self_reference]
+source_profile = assume_role_self_reference
+role_arn = arn:aws:iam:123456789012:role/role_a
+aws_access_key_id = ACCESS_KEY_SELF
+aws_secret_access_key = SECRET_KEY_SELF
+aws_session_token = TOKEN_SELF
+
+[profile assume_role_chain_loop_a]
+source_profile = assume_role_chain_loop_b
+role_arn = arn:aws:iam:123456789012:role/role_a
+
+[profile assume_role_chain_loop_b]
+source_profile = assume_role_chain_loop_a
+role_arn = arn:aws:iam:123456789012:role/role_b
+


### PR DESCRIPTION
Fixes: #2531 

This is a WIP - it fixes the immediate issue in #2531 (in `assume_role_process_credentials_from_config` it needed to check both config and credentials).  It adds recursive assume role to `resolve_source_profile` and adds a `visisted_profiles` set to check for cycles.  

Still needs tests and may not cover all expected behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
