### PR TITLE
Add spec to exercise API Gateway modeled errors

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/interfaces/client/api_gateway_spec.rb
@@ -49,6 +49,18 @@ describe 'Client Interface:' do
       }.to raise_error("cannot locate shape ShapeFoo")
     end
 
+    it 'handles modeled errors correctly' do
+      error_data = JSON.dump({ code: 'InternalServerErrorException', hostId: 'test' } )
+      client.stub_responses(:get_noauth_errors, {status_code: 500, headers: {}, body: error_data})
+      expect do
+        client.get_noauth_errors(error_type: "internal_error")
+      end.to raise_error { |error|
+        expect(error).to be_a(WhiteLabel::Errors::InternalServerErrorException)
+        expect(error.data).to be_a(WhiteLabel::Types::InternalServerErrorException)
+        expect(error.data.host_id).to eq('test')
+      }
+    end
+
     it 'populates x-api-key header correctly' do
       resp = client.put_apikey({
         scalar_types: {


### PR DESCRIPTION
Adding a spec to exercise API Gateway modeled errors.   See [whitelabel/service.json](https://github.com/aws/aws-sdk-ruby/blob/version-3/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/white_label/service.json#L25) for the API and modeled error used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
