### PR TITLE
Correct override for null LocationConstraint in us-east-1.

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Replace null LocationConstraint with us-east-1 instead of an empty string.
+
 1.96.1 (2021-06-10)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/get_bucket_location_fix.rb
@@ -12,7 +12,11 @@ module Aws
               response.data = S3::Types::GetBucketLocationOutput.new
               xml = context.http_response.body_contents
               matches = xml.match(/<LocationConstraint.*?>(.+?)<\/LocationConstraint>/)
-              response.data[:location_constraint] = matches ? matches[1] : ''
+
+              # According to the service API docs, a bucket is us-east-1 has a LocationConstraint
+              # value `null`.
+              # https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
+              response.data[:location_constraint] = matches ? matches[1] : 'us-east-1'
             end
           end
         end

--- a/gems/aws-sdk-s3/spec/client_spec.rb
+++ b/gems/aws-sdk-s3/spec/client_spec.rb
@@ -410,7 +410,7 @@ module Aws
             Seahorse::Client::Response.new(context: context)
           end
           resp = client.get_bucket_location(bucket: 'name')
-          expect(resp.location_constraint).to eq('')
+          expect(resp.location_constraint).to eq('us-east-1')
         end
       end
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Related to issue #1725, this changes the synthetic value returns by the SDK for a bucket's location constraint to match the API docs.