### PR TITLE
Fix Aws::Sigv4::Signer

### DIFF
--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -127,7 +127,7 @@ module Aws
         @unsigned_headers << 'x-amzn-trace-id'
         @unsigned_headers << 'expect'
         [:uri_escape_path, :apply_checksum_header].each do |opt|
-          instance_variable_set("@#{opt}", options.key?(opt) ? !!options[:opt] : true)
+          instance_variable_set("@#{opt}", options.key?(opt) ? !!options[opt] : true)
         end
       end
 

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -269,6 +269,16 @@ module Aws
           expect(signature.headers['x-amz-content-sha256']).to eq(Digest::SHA256.hexdigest('abc'))
         end
 
+        it 'adds the X-Amz-Content-Sha256 header if :apply_checksum_header option with true is passed' do
+          options[:apply_checksum_header] = true
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'https://domain.com',
+            body: 'abc'
+          )
+          expect(signature.headers['x-amz-content-sha256']).to eq(Digest::SHA256.hexdigest('abc'))
+        end
+
         it 'can omit the X-Amz-Content-Sha256 header' do
           options[:apply_checksum_header] = false
           signature = Signer.new(options).sign_request(

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -356,6 +356,32 @@ module Aws
           expect(signature.headers['authorization']).to eq('AWS4-HMAC-SHA256 Credential=akid/20120101/REGION/SERVICE/aws4_request, SignedHeaders=bar;bar2;foo;host;x-amz-content-sha256;x-amz-date, Signature=4a7d3e06d1950eb64a3daa1becaa8ba030d9099858516cb2fa4533fab4e8937d')
         end
 
+        it 'escapes path for the canonical request by default' do
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'https://domain.com/foo%bar'
+          )
+          expect(signature.canonical_request.lines[1]).to eq "/foo%25bar\n"
+        end
+
+        it 'escapes path for the canonical request if :uri_escape_path option with true is passed' do
+          options[:uri_escape_path] = true
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'https://domain.com/foo%bar'
+          )
+          expect(signature.canonical_request.lines[1]).to eq "/foo%25bar\n"
+        end
+
+        it 'does not escape path for the canonical request if :uri_escape_path option with false is passed' do
+          options[:uri_escape_path] = false
+          signature = Signer.new(options).sign_request(
+            http_method: 'GET',
+            url: 'https://domain.com/foo%bar'
+          )
+          expect(signature.canonical_request.lines[1]).to eq "/foo%bar\n"
+        end
+
       end
 
       context '#sign_event' do


### PR DESCRIPTION
The constructor incorrectly handles `uri_escape_path`, `apply_checksum_header` options because of a typo. The change fixes the typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
