### PR TITLE
Add a ProviderChainCredentials class that uses the CredentialsProviderChain to resolve credentials

### DIFF
--- a/gems/aws-sdk-core/lib/aws-sdk-core.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core.rb
@@ -19,6 +19,7 @@ require_relative 'aws-sdk-core/instance_profile_credentials'
 require_relative 'aws-sdk-core/shared_credentials'
 require_relative 'aws-sdk-core/process_credentials'
 require_relative 'aws-sdk-core/sso_credentials'
+require_relative 'aws-sdk-core/provider_chain_credentials'
 
 # client modules
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/provider_chain_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/provider_chain_credentials.rb
@@ -1,0 +1,43 @@
+module Aws
+  class ProviderChainCredentials
+    include CredentialProvider
+
+    def initialize(options = {})
+      config = build_config(options)
+
+      @credentials = CredentialProviderChain.new(config).resolve
+    end
+
+    def credentials
+      @credentials.credentials
+    end
+
+    private
+
+    # Constructs a {Configuration} object with a default
+    # set of credential related plugins
+    def build_config(options)
+      config = Seahorse::Client::Configuration.new
+      config.add_option(:api)
+      credential_plugins.each do |plugin|
+        plugin.add_options(config) if plugin.respond_to?(:add_options)
+      end
+
+      api = Seahorse::Model::Api.new.tap do |api|
+        api.metadata = { }
+      end
+
+      config.build!(options.merge(api: api))
+    end
+
+    def credential_plugins
+      Seahorse::Client::PluginList.new(
+        [
+          Aws::Plugins::CredentialsConfiguration,
+          Aws::Plugins::RegionalEndpoint
+        ]
+      ).map { |plugin| plugin.is_a?(Class) ? plugin.new : plugin }
+    end
+
+  end
+end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -14,10 +14,15 @@ module Aws
       'aws_session_token' => 'session_token',
     }
 
-    # Constructs a new SharedCredentials object. This will load AWS access
+    # Constructs a new SharedCredentials object. This will load static
+    # (access_key_id, secret_access_key and session_token) AWS access
     # credentials from an ini file, which supports profiles. The default
     # profile name is 'default'. You can specify the profile name with the
     # `ENV['AWS_PROFILE']` or with the `:profile_name` option.
+    #
+    # To use credentials from the default credential resolution chain
+    # either create a client without the credential option specified or
+    # see: {Aws::ProviderChainCredentials}.
     #
     # @option [String] :path Path to the shared file.  Defaults
     #   to "#{Dir.home}/.aws/credentials".

--- a/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/configuration.rb
@@ -223,6 +223,7 @@ module Seahorse
           if @members.include?(method_name)
             value_at(method_name)
           else
+            puts caller
             super
           end
         end


### PR DESCRIPTION
Clarify SharedCredentials docs re: Credential Resolution from profile.

[DRAFT] - Add a ProviderChainCredentials class that uses the CredentialsProviderChain to resolve credentials.
Because the CredentialsProviderChain relies on client config, we need to add the required options and create an instance of a Credentials class - this is not ideal.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
