### PR TITLE
Support IMDS IPv6 endpoints

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Feature - Support IPv6 endpoints for `Aws::InstanceProfileCredentials`. It supports two shared configuration options (`ec2_metadata_service_endpoint` & `ec2_metadata_service_endpoint_mode`), two ENV variables (`AWS_EC2_METADATA_SERVICE_ENDPOINT` & `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE`), and two constructor options (`:endpoint` & `:endpoint_mode`).
+
+* Feature - Support IPv6 endpoint for `Aws::EC2Metadata` client. It can be configured with `:endpoint` or `:endpoint_mode`.
+
 3.116.0 (2021-07-07)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -160,10 +160,11 @@ module Aws
     end
 
     def instance_profile_credentials(options)
+      profile_name = determine_profile_name(options)
       if ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']
         ECSCredentials.new(options)
       else
-        InstanceProfileCredentials.new(options)
+        InstanceProfileCredentials.new(options.merge(profile: profile_name))
       end
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ec2_metadata.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ec2_metadata.rb
@@ -39,7 +39,11 @@ module Aws
     #   defaulting to 6 hours.
     # @option options [Integer] :retries (3) The number of retries for failed
     #   requests.
-    # @option options [String] :endpoint (169.254.169.254) The IMDS endpoint.
+    # @option options [String] :endpoint ('http://169.254.169.254') The IMDS
+    #   endpoint. This option has precedence over the :endpoint_mode.
+    # @option options [String] :endpoint_mode ('IPv4') The endpoint mode for
+    #   the instance metadata service. This is either 'IPv4'
+    #   ('http://169.254.169.254') or 'IPv6' ('http://[fd00:ec2::254]').
     # @option options [Integer] :port (80) The IMDS endpoint port.
     # @option options [Integer] :http_open_timeout (1) The number of seconds to
     #   wait for the connection to open.
@@ -55,7 +59,8 @@ module Aws
       @retries = options[:retries] || 3
       @backoff = backoff(options[:backoff])
 
-      @endpoint = options[:endpoint] || '169.254.169.254'
+      endpoint_mode = options[:endpoint_mode] || 'IPv4'
+      @endpoint = resolve_endpoint(options[:endpoint], endpoint_mode)
       @port = options[:port] || 80
 
       @http_open_timeout = options[:http_open_timeout] || 1
@@ -76,7 +81,7 @@ module Aws
     #   ec2_metadata.get('/latest/meta-data/instance-id')
     #   => "i-023a25f10a73a0f79"
     #
-    # @Note This implementation always returns a String and will not parse any
+    # @note This implementation always returns a String and will not parse any
     #   responses. Parsable responses may include JSON objects or directory
     #   listings, which are strings separated by line feeds (ASCII 10).
     #
@@ -93,7 +98,7 @@ module Aws
     #   listing.split(10.chr)
     #   => ["ami-id", "ami-launch-index", ...]
     #
-    # @Note Unlike other services, IMDS does not have a service API model. This
+    # @note Unlike other services, IMDS does not have a service API model. This
     #   means that we cannot confidently generate code with methods and
     #   response structures. This implementation ensures that new IMDS features
     #   are always supported by being deployed to the instance and does not
@@ -115,6 +120,19 @@ module Aws
     end
 
     private
+
+    def resolve_endpoint(endpoint, endpoint_mode)
+      return endpoint if endpoint
+
+      case endpoint_mode.downcase
+      when 'ipv4' then 'http://169.254.169.254'
+      when 'ipv6' then 'http://[fd00:ec2::254]'
+      else
+        raise ArgumentError,
+              ':endpoint_mode is not valid, expected IPv4 or IPv6, '\
+              "got: #{endpoint_mode}"
+      end
+    end
 
     def fetch_token
       open_connection do |conn|
@@ -163,7 +181,8 @@ module Aws
     end
 
     def open_connection
-      http = Net::HTTP.new(@endpoint, @port, nil)
+      uri = URI.parse(@endpoint)
+      http = Net::HTTP.new(uri.hostname || @endpoint, @port || uri.port)
       http.open_timeout = @http_open_timeout
       http.read_timeout = @http_read_timeout
       http.set_debug_output(@http_debug_output) if @http_debug_output

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -5,7 +5,6 @@ require 'net/http'
 
 module Aws
   class InstanceProfileCredentials
-
     include CredentialProvider
     include RefreshingCredentials
 
@@ -44,7 +43,13 @@ module Aws
     # @param [Hash] options
     # @option options [Integer] :retries (1) Number of times to retry
     #   when retrieving credentials.
-    # @option options [String] :ip_address ('169.254.169.254')
+    # @option options [String] :endpoint ('http://169.254.169.254') The IMDS
+    #   endpoint. This option has precedence over the :endpoint_mode.
+    # @option options [String] :endpoint_mode ('IPv4') The endpoint mode for
+    #   the instance metadata service. This is either 'IPv4' ('169.254.169.254')
+    #   or 'IPv6' ('[fd00:ec2::254]').
+    # @option options [String] :ip_address ('169.254.169.254') Deprecated. Do
+    #   not use. The IP address for the endpoint.
     # @option options [Integer] :port (80)
     # @option options [Float] :http_open_timeout (1)
     # @option options [Float] :http_read_timeout (1)
@@ -60,7 +65,8 @@ module Aws
     #   to 21600 seconds
     def initialize(options = {})
       @retries = options[:retries] || 1
-      @ip_address = options[:ip_address] || '169.254.169.254'
+      endpoint_mode = resolve_endpoint_mode(options)
+      @endpoint = resolve_endpoint(options, endpoint_mode)
       @port = options[:port] || 80
       @http_open_timeout = options[:http_open_timeout] || 1
       @http_read_timeout = options[:http_read_timeout] || 1
@@ -77,6 +83,34 @@ module Aws
     attr_reader :retries
 
     private
+
+    def resolve_endpoint_mode(options)
+      value = options[:endpoint_mode]
+      value ||= ENV['AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE']
+      value ||= Aws.shared_config.ec2_metadata_service_endpoint_mode(
+        profile: options[:profile]
+      )
+      value || 'IPv4'
+    end
+
+    def resolve_endpoint(options, endpoint_mode)
+      value = options[:endpoint] || options[:ip_address]
+      value ||= ENV['AWS_EC2_METADATA_SERVICE_ENDPOINT']
+      value ||= Aws.shared_config.ec2_metadata_service_endpoint(
+        profile: options[:profile]
+      )
+
+      return value if value
+
+      case endpoint_mode.downcase
+      when 'ipv4' then 'http://169.254.169.254'
+      when 'ipv6' then 'http://[fd00:ec2::254]'
+      else
+        raise ArgumentError,
+              ':endpoint_mode is not valid, expected IPv4 or IPv6, '\
+              "got: #{endpoint_mode}"
+      end
+    end
 
     def backoff(backoff)
       case backoff
@@ -152,7 +186,8 @@ module Aws
     end
 
     def open_connection
-      http = Net::HTTP.new(@ip_address, @port, nil)
+      uri = URI.parse(@endpoint)
+      http = Net::HTTP.new(uri.hostname || @endpoint, @port || uri.port)
       http.open_timeout = @http_open_timeout
       http.read_timeout = @http_read_timeout
       http.set_debug_output(@http_debug_output) if @http_debug_output

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -48,8 +48,8 @@ module Aws
     # @option options [String] :endpoint_mode ('IPv4') The endpoint mode for
     #   the instance metadata service. This is either 'IPv4' ('169.254.169.254')
     #   or 'IPv6' ('[fd00:ec2::254]').
-    # @option options [String] :ip_address ('169.254.169.254') Deprecated. Do
-    #   not use. The IP address for the endpoint.
+    # @option options [String] :ip_address ('169.254.169.254') Deprecated. Use
+    #   :endpoint instead. The IP address for the endpoint.
     # @option options [Integer] :port (80)
     # @option options [Float] :http_open_timeout (1)
     # @option options [Float] :http_read_timeout (1)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -163,6 +163,8 @@ module Aws
       :ca_bundle,
       :credential_process,
       :endpoint_discovery_enabled,
+      :ec2_metadata_service_endpoint,
+      :ec2_metadata_service_endpoint_mode,
       :max_attempts,
       :retry_mode,
       :adaptive_retry_wait_to_fill,

--- a/gems/aws-sdk-core/spec/aws/ec2_metadata_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ec2_metadata_spec.rb
@@ -20,6 +20,48 @@ module Aws
       token_value
     end
 
+    context 'endpoint configuration' do
+      it 'can be configured without a scheme' do
+        client = EC2Metadata.new(endpoint: '123.123.123.123')
+        expect(client.instance_variable_get(:@endpoint))
+          .to eq('123.123.123.123')
+      end
+
+      it 'can be configured with a scheme' do
+        client = EC2Metadata.new(endpoint: 'http://123.123.123.123')
+        expect(client.instance_variable_get(:@endpoint))
+          .to eq('http://123.123.123.123')
+      end
+
+      it 'takes precedence over endpoint mode' do
+        client = EC2Metadata.new(
+          endpoint_mode: 'IPv6',
+          endpoint: '123.123.123.123'
+        )
+        expect(client.instance_variable_get(:@endpoint))
+          .to eq('123.123.123.123')
+      end
+    end
+
+    context 'endpoint mode configuration' do
+      it 'defaults to ipv4' do
+        client = EC2Metadata.new
+        expect(client.instance_variable_get(:@endpoint))
+          .to eq('http://169.254.169.254')
+      end
+
+      it 'can be configured to use ipv6 mode' do
+        client = EC2Metadata.new(endpoint_mode: 'IPv6')
+        expect(client.instance_variable_get(:@endpoint))
+          .to eq('http://[fd00:ec2::254]')
+      end
+
+      it 'raises with an unknown mode' do
+        expect { EC2Metadata.new(endpoint_mode: 'IPv69') }
+          .to raise_error(ArgumentError)
+      end
+    end
+
     describe '#get' do
       it 'fetches a token before getting metadata' do
         token = stub_get_token


### PR DESCRIPTION
* Feature - Support IPv6 endpoints for `Aws::InstanceProfileCredentials`. It supports two shared configuration options (`ec2_metadata_service_endpoint` & `ec2_metadata_service_endpoint_mode`), two ENV variables (`AWS_EC2_METADATA_SERVICE_ENDPOINT` & `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE`), and two constructor options (`:endpoint` & `:endpoint_mode`).

* Feature - Support IPv6 endpoint for `Aws::EC2Metadata` client. It can be configured with `:endpoint` or `:endpoint_mode`.
