### PR TITLE
Remove content-length from async clients

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/plugin_list.rb
@@ -64,6 +64,7 @@ module AwsSdkCodeGenerator
 
     def default_async_plugins
       plugins = default_plugins.dup
+      plugins.delete('Seahorse::Client::Plugins::ContentLength')
       plugins.delete('Aws::Plugins::ResponsePaging')
       plugins.delete('Aws::Plugins::EndpointDiscovery')
       plugins.delete('Aws::Plugins::EndpointPattern')

--- a/gems/aws-sdk-kinesis/CHANGELOG.md
+++ b/gems/aws-sdk-kinesis/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove `content-length` header from `AsyncClient`.
+
 1.32.0 (2021-03-10)
 ------------------
 

--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/async_client.rb
@@ -12,7 +12,6 @@ if RUBY_VERSION >= '2.1'
     require 'http/2'
   rescue LoadError; end
 end
-require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'
 require 'aws-sdk-core/plugins/logging.rb'
 require 'aws-sdk-core/plugins/param_converter.rb'
@@ -42,7 +41,6 @@ module Aws::Kinesis
 
     set_api(ClientApi::API)
 
-    add_plugin(Seahorse::Client::Plugins::ContentLength)
     add_plugin(Aws::Plugins::CredentialsConfiguration)
     add_plugin(Aws::Plugins::Logging)
     add_plugin(Aws::Plugins::ParamConverter)

--- a/gems/aws-sdk-lexruntimev2/CHANGELOG.md
+++ b/gems/aws-sdk-lexruntimev2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove `content-length` header from `AsyncClient`.
+
 1.3.0 (2021-06-15)
 ------------------
 
@@ -20,4 +22,3 @@ Unreleased Changes
 ------------------
 
 * Feature - Initial release of `aws-sdk-lexruntimev2`.
-

--- a/gems/aws-sdk-lexruntimev2/lib/aws-sdk-lexruntimev2/async_client.rb
+++ b/gems/aws-sdk-lexruntimev2/lib/aws-sdk-lexruntimev2/async_client.rb
@@ -12,7 +12,6 @@ if RUBY_VERSION >= '2.1'
     require 'http/2'
   rescue LoadError; end
 end
-require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'
 require 'aws-sdk-core/plugins/logging.rb'
 require 'aws-sdk-core/plugins/param_converter.rb'
@@ -42,7 +41,6 @@ module Aws::LexRuntimeV2
 
     set_api(ClientApi::API)
 
-    add_plugin(Seahorse::Client::Plugins::ContentLength)
     add_plugin(Aws::Plugins::CredentialsConfiguration)
     add_plugin(Aws::Plugins::Logging)
     add_plugin(Aws::Plugins::ParamConverter)

--- a/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
+++ b/gems/aws-sdk-transcribestreamingservice/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove `content-length` header from `AsyncClient`.
+
 1.29.0 (2021-05-11)
 ------------------
 

--- a/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
+++ b/gems/aws-sdk-transcribestreamingservice/lib/aws-sdk-transcribestreamingservice/async_client.rb
@@ -12,7 +12,6 @@ if RUBY_VERSION >= '2.1'
     require 'http/2'
   rescue LoadError; end
 end
-require 'seahorse/client/plugins/content_length.rb'
 require 'aws-sdk-core/plugins/credentials_configuration.rb'
 require 'aws-sdk-core/plugins/logging.rb'
 require 'aws-sdk-core/plugins/param_converter.rb'
@@ -42,7 +41,6 @@ module Aws::TranscribeStreamingService
 
     set_api(ClientApi::API)
 
-    add_plugin(Seahorse::Client::Plugins::ContentLength)
     add_plugin(Aws::Plugins::CredentialsConfiguration)
     add_plugin(Aws::Plugins::Logging)
     add_plugin(Aws::Plugins::ParamConverter)


### PR DESCRIPTION
Async Clients currently don't adhere to (RFC7540)[https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.6]

Netty is now validating this incorrect `content-length` header.