### PR TITLE
Add retry on InvocationDoesNotExist to SSM SendCommand waiter

### DIFF
--- a/apis/ssm/2014-11-06/waiters-2.json
+++ b/apis/ssm/2014-11-06/waiters-2.json
@@ -53,6 +53,11 @@
           "matcher": "path",
           "state": "failure",
           "argument": "Status"
+        },
+        {
+          "state": "retry",
+          "matcher": "error",
+          "expected": "InvocationDoesNotExist"
         }
       ]
     }

--- a/gems/aws-sdk-ssm/lib/aws-sdk-ssm/waiters.rb
+++ b/gems/aws-sdk-ssm/lib/aws-sdk-ssm/waiters.rb
@@ -136,6 +136,11 @@ module Aws::SSM
                 "matcher" => "path",
                 "state" => "failure",
                 "argument" => "status"
+              },
+              {
+                "state" => "retry",
+                "matcher" => "error",
+                "expected" => "InvocationDoesNotExist"
               }
             ]
           )


### PR DESCRIPTION
Fixes #2556 

[Do not merge] - This change needs to be merged upstream - this PR is created to demo/test the changes.

There is an eventually consistency issue with SendCommand - the command may not exist the first time the waiter attempts to check the status, resulting in an `InvocationDoesNotExist` error.   

The risk here is that a waiter given a command_id that indeed does not exist, will go through all of its retries before failing. 

Related JS issue: https://github.com/aws/aws-sdk-js/issues/3457

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
