### PR TITLE
Fix to prevent downloading 1 byte ranges

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix file downloading edge case for 1 byte multipart ranges (#2561).
+
 1.96.1 (2021-06-10)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -94,12 +94,12 @@ module Aws
         if @chunk_size && @chunk_size > file_size
           raise ArgumentError, ":chunk_size shouldn't exceed total file size."
         else
-          @chunk_size ||= [
+          chunk_size = @chunk_size || [
             (file_size.to_f / MAX_PARTS).ceil,
             MIN_CHUNK_SIZE
           ].max.to_i
-          @chunk_size -= 1 if file_size % @chunk_size == 1
-          @chunk_size
+          chunk_size -= 1 if file_size % chunk_size == 1
+          chunk_size
         end
       end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -94,7 +94,11 @@ module Aws
         if @chunk_size && @chunk_size > file_size
           raise ArgumentError, ":chunk_size shouldn't exceed total file size."
         else
-          @chunk_size || [(file_size.to_f / MAX_PARTS).ceil, MIN_CHUNK_SIZE].max.to_i
+          @chunk_size ||= [
+            (file_size.to_f / MAX_PARTS).ceil,
+            MIN_CHUNK_SIZE
+          ].max.to_i
+          @chunk_size -= 1 if file_size % @chunk_size == 1
         end
       end
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -99,6 +99,7 @@ module Aws
             MIN_CHUNK_SIZE
           ].max.to_i
           @chunk_size -= 1 if file_size % @chunk_size == 1
+          @chunk_size
         end
       end
 


### PR DESCRIPTION
Fixes #2561. If part size would leave one byte in a part, we subtract one byte from the chunk size.