### PR TITLE
Update old AWS API Documentation links

### DIFF
--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client.rb
@@ -362,7 +362,7 @@ module Aws::CloudFront
     #     alias: "string", # required
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/AssociateAlias2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_AssociateAlias.html AWS API Documentation
     #
     # @overload associate_alias(params = {})
     # @param [Hash] params ({})
@@ -471,7 +471,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateCachePolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateCachePolicy.html AWS API Documentation
     #
     # @overload create_cache_policy(params = {})
     # @param [Hash] params ({})
@@ -518,7 +518,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateCloudFrontOriginAccessIdentity2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateCloudFrontOriginAccessIdentity.html AWS API Documentation
     #
     # @overload create_cloud_front_origin_access_identity(params = {})
     # @param [Hash] params ({})
@@ -995,7 +995,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html AWS API Documentation
     #
     # @overload create_distribution(params = {})
     # @param [Hash] params ({})
@@ -1464,7 +1464,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateDistributionWithTags2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistributionWithTags.html AWS API Documentation
     #
     # @overload create_distribution_with_tags(params = {})
     # @param [Hash] params ({})
@@ -1538,7 +1538,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateFieldLevelEncryptionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateFieldLevelEncryptionConfig.html AWS API Documentation
     #
     # @overload create_field_level_encryption_config(params = {})
     # @param [Hash] params ({})
@@ -1598,7 +1598,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateFieldLevelEncryptionProfile2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateFieldLevelEncryptionProfile.html AWS API Documentation
     #
     # @overload create_field_level_encryption_profile(params = {})
     # @param [Hash] params ({})
@@ -1668,7 +1668,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateFunction.html AWS API Documentation
     #
     # @overload create_function(params = {})
     # @param [Hash] params ({})
@@ -1714,7 +1714,7 @@ module Aws::CloudFront
     #   resp.invalidation.invalidation_batch.paths.items[0] #=> String
     #   resp.invalidation.invalidation_batch.caller_reference #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateInvalidation2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateInvalidation.html AWS API Documentation
     #
     # @overload create_invalidation(params = {})
     # @param [Hash] params ({})
@@ -1771,7 +1771,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateKeyGroup2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateKeyGroup.html AWS API Documentation
     #
     # @overload create_key_group(params = {})
     # @param [Hash] params ({})
@@ -1817,7 +1817,7 @@ module Aws::CloudFront
     #
     #   resp.monitoring_subscription.realtime_metrics_subscription_config.realtime_metrics_subscription_status #=> String, one of "Enabled", "Disabled"
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateMonitoringSubscription2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateMonitoringSubscription.html AWS API Documentation
     #
     # @overload create_monitoring_subscription(params = {})
     # @param [Hash] params ({})
@@ -1916,7 +1916,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateOriginRequestPolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateOriginRequestPolicy.html AWS API Documentation
     #
     # @overload create_origin_request_policy(params = {})
     # @param [Hash] params ({})
@@ -1964,7 +1964,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreatePublicKey2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreatePublicKey.html AWS API Documentation
     #
     # @overload create_public_key(params = {})
     # @param [Hash] params ({})
@@ -2042,7 +2042,7 @@ module Aws::CloudFront
     #   resp.realtime_log_config.fields #=> Array
     #   resp.realtime_log_config.fields[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateRealtimeLogConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateRealtimeLogConfig.html AWS API Documentation
     #
     # @overload create_realtime_log_config(params = {})
     # @param [Hash] params ({})
@@ -2131,7 +2131,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateStreamingDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateStreamingDistribution.html AWS API Documentation
     #
     # @overload create_streaming_distribution(params = {})
     # @param [Hash] params ({})
@@ -2230,7 +2230,7 @@ module Aws::CloudFront
     #   resp.location #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/CreateStreamingDistributionWithTags2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateStreamingDistributionWithTags.html AWS API Documentation
     #
     # @overload create_streaming_distribution_with_tags(params = {})
     # @param [Hash] params ({})
@@ -2267,7 +2267,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteCachePolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteCachePolicy.html AWS API Documentation
     #
     # @overload delete_cache_policy(params = {})
     # @param [Hash] params ({})
@@ -2294,7 +2294,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteCloudFrontOriginAccessIdentity2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteCloudFrontOriginAccessIdentity.html AWS API Documentation
     #
     # @overload delete_cloud_front_origin_access_identity(params = {})
     # @param [Hash] params ({})
@@ -2321,7 +2321,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteDistribution.html AWS API Documentation
     #
     # @overload delete_distribution(params = {})
     # @param [Hash] params ({})
@@ -2348,7 +2348,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteFieldLevelEncryptionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteFieldLevelEncryptionConfig.html AWS API Documentation
     #
     # @overload delete_field_level_encryption_config(params = {})
     # @param [Hash] params ({})
@@ -2375,7 +2375,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteFieldLevelEncryptionProfile2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteFieldLevelEncryptionProfile.html AWS API Documentation
     #
     # @overload delete_field_level_encryption_profile(params = {})
     # @param [Hash] params ({})
@@ -2410,7 +2410,7 @@ module Aws::CloudFront
     #     if_match: "string", # required
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteFunction.html AWS API Documentation
     #
     # @overload delete_function(params = {})
     # @param [Hash] params ({})
@@ -2447,7 +2447,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteKeyGroup2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteKeyGroup.html AWS API Documentation
     #
     # @overload delete_key_group(params = {})
     # @param [Hash] params ({})
@@ -2470,7 +2470,7 @@ module Aws::CloudFront
     #     distribution_id: "string", # required
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteMonitoringSubscription2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteMonitoringSubscription.html AWS API Documentation
     #
     # @overload delete_monitoring_subscription(params = {})
     # @param [Hash] params ({})
@@ -2510,7 +2510,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteOriginRequestPolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteOriginRequestPolicy.html AWS API Documentation
     #
     # @overload delete_origin_request_policy(params = {})
     # @param [Hash] params ({})
@@ -2537,7 +2537,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeletePublicKey2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeletePublicKey.html AWS API Documentation
     #
     # @overload delete_public_key(params = {})
     # @param [Hash] params ({})
@@ -2574,7 +2574,7 @@ module Aws::CloudFront
     #     arn: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteRealtimeLogConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteRealtimeLogConfig.html AWS API Documentation
     #
     # @overload delete_realtime_log_config(params = {})
     # @param [Hash] params ({})
@@ -2644,7 +2644,7 @@ module Aws::CloudFront
     #     if_match: "string",
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DeleteStreamingDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteStreamingDistribution.html AWS API Documentation
     #
     # @overload delete_streaming_distribution(params = {})
     # @param [Hash] params ({})
@@ -2691,7 +2691,7 @@ module Aws::CloudFront
     #   resp.function_summary.function_metadata.last_modified_time #=> Time
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/DescribeFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DescribeFunction.html AWS API Documentation
     #
     # @overload describe_function(params = {})
     # @param [Hash] params ({})
@@ -2755,7 +2755,7 @@ module Aws::CloudFront
     #   resp.cache_policy.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetCachePolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetCachePolicy.html AWS API Documentation
     #
     # @overload get_cache_policy(params = {})
     # @param [Hash] params ({})
@@ -2814,7 +2814,7 @@ module Aws::CloudFront
     #   resp.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetCachePolicyConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetCachePolicyConfig.html AWS API Documentation
     #
     # @overload get_cache_policy_config(params = {})
     # @param [Hash] params ({})
@@ -2847,7 +2847,7 @@ module Aws::CloudFront
     #   resp.cloud_front_origin_access_identity.cloud_front_origin_access_identity_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetCloudFrontOriginAccessIdentity2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetCloudFrontOriginAccessIdentity.html AWS API Documentation
     #
     # @overload get_cloud_front_origin_access_identity(params = {})
     # @param [Hash] params ({})
@@ -2878,7 +2878,7 @@ module Aws::CloudFront
     #   resp.cloud_front_origin_access_identity_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetCloudFrontOriginAccessIdentityConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetCloudFrontOriginAccessIdentityConfig.html AWS API Documentation
     #
     # @overload get_cloud_front_origin_access_identity_config(params = {})
     # @param [Hash] params ({})
@@ -3092,7 +3092,7 @@ module Aws::CloudFront
     #
     #   * distribution_deployed
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistribution.html AWS API Documentation
     #
     # @overload get_distribution(params = {})
     # @param [Hash] params ({})
@@ -3278,7 +3278,7 @@ module Aws::CloudFront
     #   resp.distribution_config.is_ipv6_enabled #=> Boolean
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetDistributionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistributionConfig.html AWS API Documentation
     #
     # @overload get_distribution_config(params = {})
     # @param [Hash] params ({})
@@ -3323,7 +3323,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption.field_level_encryption_config.content_type_profile_config.content_type_profiles.items[0].content_type #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetFieldLevelEncryption2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetFieldLevelEncryption.html AWS API Documentation
     #
     # @overload get_field_level_encryption(params = {})
     # @param [Hash] params ({})
@@ -3366,7 +3366,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_config.content_type_profile_config.content_type_profiles.items[0].content_type #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetFieldLevelEncryptionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetFieldLevelEncryptionConfig.html AWS API Documentation
     #
     # @overload get_field_level_encryption_config(params = {})
     # @param [Hash] params ({})
@@ -3407,7 +3407,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_profile.field_level_encryption_profile_config.encryption_entities.items[0].field_patterns.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetFieldLevelEncryptionProfile2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetFieldLevelEncryptionProfile.html AWS API Documentation
     #
     # @overload get_field_level_encryption_profile(params = {})
     # @param [Hash] params ({})
@@ -3447,7 +3447,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_profile_config.encryption_entities.items[0].field_patterns.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetFieldLevelEncryptionProfileConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetFieldLevelEncryptionProfileConfig.html AWS API Documentation
     #
     # @overload get_field_level_encryption_profile_config(params = {})
     # @param [Hash] params ({})
@@ -3487,7 +3487,7 @@ module Aws::CloudFront
     #   resp.etag #=> String
     #   resp.content_type #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetFunction.html AWS API Documentation
     #
     # @overload get_function(params = {})
     # @param [Hash] params ({})
@@ -3531,7 +3531,7 @@ module Aws::CloudFront
     #
     #   * invalidation_completed
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetInvalidation2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetInvalidation.html AWS API Documentation
     #
     # @overload get_invalidation(params = {})
     # @param [Hash] params ({})
@@ -3574,7 +3574,7 @@ module Aws::CloudFront
     #   resp.key_group.key_group_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetKeyGroup2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetKeyGroup.html AWS API Documentation
     #
     # @overload get_key_group(params = {})
     # @param [Hash] params ({})
@@ -3615,7 +3615,7 @@ module Aws::CloudFront
     #   resp.key_group_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetKeyGroupConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetKeyGroupConfig.html AWS API Documentation
     #
     # @overload get_key_group_config(params = {})
     # @param [Hash] params ({})
@@ -3645,7 +3645,7 @@ module Aws::CloudFront
     #
     #   resp.monitoring_subscription.realtime_metrics_subscription_config.realtime_metrics_subscription_status #=> String, one of "Enabled", "Disabled"
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetMonitoringSubscription2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetMonitoringSubscription.html AWS API Documentation
     #
     # @overload get_monitoring_subscription(params = {})
     # @param [Hash] params ({})
@@ -3706,7 +3706,7 @@ module Aws::CloudFront
     #   resp.origin_request_policy.origin_request_policy_config.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetOriginRequestPolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetOriginRequestPolicy.html AWS API Documentation
     #
     # @overload get_origin_request_policy(params = {})
     # @param [Hash] params ({})
@@ -3761,7 +3761,7 @@ module Aws::CloudFront
     #   resp.origin_request_policy_config.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetOriginRequestPolicyConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetOriginRequestPolicyConfig.html AWS API Documentation
     #
     # @overload get_origin_request_policy_config(params = {})
     # @param [Hash] params ({})
@@ -3796,7 +3796,7 @@ module Aws::CloudFront
     #   resp.public_key.public_key_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetPublicKey2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetPublicKey.html AWS API Documentation
     #
     # @overload get_public_key(params = {})
     # @param [Hash] params ({})
@@ -3829,7 +3829,7 @@ module Aws::CloudFront
     #   resp.public_key_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetPublicKeyConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetPublicKeyConfig.html AWS API Documentation
     #
     # @overload get_public_key_config(params = {})
     # @param [Hash] params ({})
@@ -3875,7 +3875,7 @@ module Aws::CloudFront
     #   resp.realtime_log_config.fields #=> Array
     #   resp.realtime_log_config.fields[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetRealtimeLogConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetRealtimeLogConfig.html AWS API Documentation
     #
     # @overload get_realtime_log_config(params = {})
     # @param [Hash] params ({})
@@ -3938,7 +3938,7 @@ module Aws::CloudFront
     #
     #   * streaming_distribution_deployed
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetStreamingDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetStreamingDistribution.html AWS API Documentation
     #
     # @overload get_streaming_distribution(params = {})
     # @param [Hash] params ({})
@@ -3983,7 +3983,7 @@ module Aws::CloudFront
     #   resp.streaming_distribution_config.enabled #=> Boolean
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/GetStreamingDistributionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetStreamingDistributionConfig.html AWS API Documentation
     #
     # @overload get_streaming_distribution_config(params = {})
     # @param [Hash] params ({})
@@ -4065,7 +4065,7 @@ module Aws::CloudFront
     #   resp.cache_policy_list.items[0].cache_policy.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_strings.items #=> Array
     #   resp.cache_policy_list.items[0].cache_policy.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_strings.items[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListCachePolicies2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListCachePolicies.html AWS API Documentation
     #
     # @overload list_cache_policies(params = {})
     # @param [Hash] params ({})
@@ -4113,7 +4113,7 @@ module Aws::CloudFront
     #   resp.cloud_front_origin_access_identity_list.items[0].s3_canonical_user_id #=> String
     #   resp.cloud_front_origin_access_identity_list.items[0].comment #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListCloudFrontOriginAccessIdentities2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListCloudFrontOriginAccessIdentities.html AWS API Documentation
     #
     # @overload list_cloud_front_origin_access_identities(params = {})
     # @param [Hash] params ({})
@@ -4198,7 +4198,7 @@ module Aws::CloudFront
     #   resp.conflicting_aliases_list.items[0].distribution_id #=> String
     #   resp.conflicting_aliases_list.items[0].account_id #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListConflictingAliases2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListConflictingAliases.html AWS API Documentation
     #
     # @overload list_conflicting_aliases(params = {})
     # @param [Hash] params ({})
@@ -4399,7 +4399,7 @@ module Aws::CloudFront
     #   resp.distribution_list.items[0].alias_icp_recordals[0].cname #=> String
     #   resp.distribution_list.items[0].alias_icp_recordals[0].icp_recordal_status #=> String, one of "APPROVED", "SUSPENDED", "PENDING"
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributions2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributions.html AWS API Documentation
     #
     # @overload list_distributions(params = {})
     # @param [Hash] params ({})
@@ -4454,7 +4454,7 @@ module Aws::CloudFront
     #   resp.distribution_id_list.items #=> Array
     #   resp.distribution_id_list.items[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributionsByCachePolicyId2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByCachePolicyId.html AWS API Documentation
     #
     # @overload list_distributions_by_cache_policy_id(params = {})
     # @param [Hash] params ({})
@@ -4509,7 +4509,7 @@ module Aws::CloudFront
     #   resp.distribution_id_list.items #=> Array
     #   resp.distribution_id_list.items[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributionsByKeyGroup2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByKeyGroup.html AWS API Documentation
     #
     # @overload list_distributions_by_key_group(params = {})
     # @param [Hash] params ({})
@@ -4564,7 +4564,7 @@ module Aws::CloudFront
     #   resp.distribution_id_list.items #=> Array
     #   resp.distribution_id_list.items[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributionsByOriginRequestPolicyId2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByOriginRequestPolicyId.html AWS API Documentation
     #
     # @overload list_distributions_by_origin_request_policy_id(params = {})
     # @param [Hash] params ({})
@@ -4786,7 +4786,7 @@ module Aws::CloudFront
     #   resp.distribution_list.items[0].alias_icp_recordals[0].cname #=> String
     #   resp.distribution_list.items[0].alias_icp_recordals[0].icp_recordal_status #=> String, one of "APPROVED", "SUSPENDED", "PENDING"
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributionsByRealtimeLogConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByRealtimeLogConfig.html AWS API Documentation
     #
     # @overload list_distributions_by_realtime_log_config(params = {})
     # @param [Hash] params ({})
@@ -4994,7 +4994,7 @@ module Aws::CloudFront
     #   resp.distribution_list.items[0].alias_icp_recordals[0].cname #=> String
     #   resp.distribution_list.items[0].alias_icp_recordals[0].icp_recordal_status #=> String, one of "APPROVED", "SUSPENDED", "PENDING"
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListDistributionsByWebACLId2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByWebACLId.html AWS API Documentation
     #
     # @overload list_distributions_by_web_acl_id(params = {})
     # @param [Hash] params ({})
@@ -5050,7 +5050,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_list.items[0].content_type_profile_config.content_type_profiles.items[0].profile_id #=> String
     #   resp.field_level_encryption_list.items[0].content_type_profile_config.content_type_profiles.items[0].content_type #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListFieldLevelEncryptionConfigs2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListFieldLevelEncryptionConfigs.html AWS API Documentation
     #
     # @overload list_field_level_encryption_configs(params = {})
     # @param [Hash] params ({})
@@ -5102,7 +5102,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_profile_list.items[0].encryption_entities.items[0].field_patterns.items[0] #=> String
     #   resp.field_level_encryption_profile_list.items[0].comment #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListFieldLevelEncryptionProfiles2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListFieldLevelEncryptionProfiles.html AWS API Documentation
     #
     # @overload list_field_level_encryption_profiles(params = {})
     # @param [Hash] params ({})
@@ -5164,7 +5164,7 @@ module Aws::CloudFront
     #   resp.function_list.items[0].function_metadata.created_time #=> Time
     #   resp.function_list.items[0].function_metadata.last_modified_time #=> Time
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListFunctions2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListFunctions.html AWS API Documentation
     #
     # @overload list_functions(params = {})
     # @param [Hash] params ({})
@@ -5218,7 +5218,7 @@ module Aws::CloudFront
     #   resp.invalidation_list.items[0].create_time #=> Time
     #   resp.invalidation_list.items[0].status #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListInvalidations2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListInvalidations.html AWS API Documentation
     #
     # @overload list_invalidations(params = {})
     # @param [Hash] params ({})
@@ -5270,7 +5270,7 @@ module Aws::CloudFront
     #   resp.key_group_list.items[0].key_group.key_group_config.items[0] #=> String
     #   resp.key_group_list.items[0].key_group.key_group_config.comment #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListKeyGroups2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListKeyGroups.html AWS API Documentation
     #
     # @overload list_key_groups(params = {})
     # @param [Hash] params ({})
@@ -5348,7 +5348,7 @@ module Aws::CloudFront
     #   resp.origin_request_policy_list.items[0].origin_request_policy.origin_request_policy_config.query_strings_config.query_strings.items #=> Array
     #   resp.origin_request_policy_list.items[0].origin_request_policy.origin_request_policy_config.query_strings_config.query_strings.items[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListOriginRequestPolicies2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListOriginRequestPolicies.html AWS API Documentation
     #
     # @overload list_origin_request_policies(params = {})
     # @param [Hash] params ({})
@@ -5393,7 +5393,7 @@ module Aws::CloudFront
     #   resp.public_key_list.items[0].encoded_key #=> String
     #   resp.public_key_list.items[0].comment #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListPublicKeys2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListPublicKeys.html AWS API Documentation
     #
     # @overload list_public_keys(params = {})
     # @param [Hash] params ({})
@@ -5450,7 +5450,7 @@ module Aws::CloudFront
     #   resp.realtime_log_configs.marker #=> String
     #   resp.realtime_log_configs.next_marker #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListRealtimeLogConfigs2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListRealtimeLogConfigs.html AWS API Documentation
     #
     # @overload list_realtime_log_configs(params = {})
     # @param [Hash] params ({})
@@ -5506,7 +5506,7 @@ module Aws::CloudFront
     #   resp.streaming_distribution_list.items[0].price_class #=> String, one of "PriceClass_100", "PriceClass_200", "PriceClass_All"
     #   resp.streaming_distribution_list.items[0].enabled #=> Boolean
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListStreamingDistributions2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListStreamingDistributions.html AWS API Documentation
     #
     # @overload list_streaming_distributions(params = {})
     # @param [Hash] params ({})
@@ -5536,7 +5536,7 @@ module Aws::CloudFront
     #   resp.tags.items[0].key #=> String
     #   resp.tags.items[0].value #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/ListTagsForResource2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListTagsForResource.html AWS API Documentation
     #
     # @overload list_tags_for_resource(params = {})
     # @param [Hash] params ({})
@@ -5587,7 +5587,7 @@ module Aws::CloudFront
     #   resp.function_summary.function_metadata.created_time #=> Time
     #   resp.function_summary.function_metadata.last_modified_time #=> Time
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/PublishFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_PublishFunction.html AWS API Documentation
     #
     # @overload publish_function(params = {})
     # @param [Hash] params ({})
@@ -5620,7 +5620,7 @@ module Aws::CloudFront
     #     },
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/TagResource2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_TagResource.html AWS API Documentation
     #
     # @overload tag_resource(params = {})
     # @param [Hash] params ({})
@@ -5697,7 +5697,7 @@ module Aws::CloudFront
     #   resp.test_result.function_error_message #=> String
     #   resp.test_result.function_output #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/TestFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_TestFunction.html AWS API Documentation
     #
     # @overload test_function(params = {})
     # @param [Hash] params ({})
@@ -5725,7 +5725,7 @@ module Aws::CloudFront
     #     },
     #   })
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UntagResource2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UntagResource.html AWS API Documentation
     #
     # @overload untag_resource(params = {})
     # @param [Hash] params ({})
@@ -5832,7 +5832,7 @@ module Aws::CloudFront
     #   resp.cache_policy.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateCachePolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateCachePolicy.html AWS API Documentation
     #
     # @overload update_cache_policy(params = {})
     # @param [Hash] params ({})
@@ -5877,7 +5877,7 @@ module Aws::CloudFront
     #   resp.cloud_front_origin_access_identity.cloud_front_origin_access_identity_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateCloudFrontOriginAccessIdentity2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateCloudFrontOriginAccessIdentity.html AWS API Documentation
     #
     # @overload update_cloud_front_origin_access_identity(params = {})
     # @param [Hash] params ({})
@@ -6418,7 +6418,7 @@ module Aws::CloudFront
     #   resp.distribution.alias_icp_recordals[0].icp_recordal_status #=> String, one of "APPROVED", "SUSPENDED", "PENDING"
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateDistribution.html AWS API Documentation
     #
     # @overload update_distribution(params = {})
     # @param [Hash] params ({})
@@ -6499,7 +6499,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption.field_level_encryption_config.content_type_profile_config.content_type_profiles.items[0].content_type #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateFieldLevelEncryptionConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateFieldLevelEncryptionConfig.html AWS API Documentation
     #
     # @overload update_field_level_encryption_config(params = {})
     # @param [Hash] params ({})
@@ -6566,7 +6566,7 @@ module Aws::CloudFront
     #   resp.field_level_encryption_profile.field_level_encryption_profile_config.encryption_entities.items[0].field_patterns.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateFieldLevelEncryptionProfile2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateFieldLevelEncryptionProfile.html AWS API Documentation
     #
     # @overload update_field_level_encryption_profile(params = {})
     # @param [Hash] params ({})
@@ -6632,7 +6632,7 @@ module Aws::CloudFront
     #   resp.function_summary.function_metadata.last_modified_time #=> Time
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateFunction2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateFunction.html AWS API Documentation
     #
     # @overload update_function(params = {})
     # @param [Hash] params ({})
@@ -6693,7 +6693,7 @@ module Aws::CloudFront
     #   resp.key_group.key_group_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateKeyGroup2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateKeyGroup.html AWS API Documentation
     #
     # @overload update_key_group(params = {})
     # @param [Hash] params ({})
@@ -6790,7 +6790,7 @@ module Aws::CloudFront
     #   resp.origin_request_policy.origin_request_policy_config.query_strings_config.query_strings.items[0] #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateOriginRequestPolicy2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateOriginRequestPolicy.html AWS API Documentation
     #
     # @overload update_origin_request_policy(params = {})
     # @param [Hash] params ({})
@@ -6840,7 +6840,7 @@ module Aws::CloudFront
     #   resp.public_key.public_key_config.comment #=> String
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdatePublicKey2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdatePublicKey.html AWS API Documentation
     #
     # @overload update_public_key(params = {})
     # @param [Hash] params ({})
@@ -6928,7 +6928,7 @@ module Aws::CloudFront
     #   resp.realtime_log_config.fields #=> Array
     #   resp.realtime_log_config.fields[0] #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateRealtimeLogConfig2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateRealtimeLogConfig.html AWS API Documentation
     #
     # @overload update_realtime_log_config(params = {})
     # @param [Hash] params ({})
@@ -7018,7 +7018,7 @@ module Aws::CloudFront
     #   resp.streaming_distribution.streaming_distribution_config.enabled #=> Boolean
     #   resp.etag #=> String
     #
-    # @see http://docs.aws.amazon.com/goto/WebAPI/cloudfront-2020-05-31/UpdateStreamingDistribution2020_05_31 AWS API Documentation
+    # @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateStreamingDistribution.html AWS API Documentation
     #
     # @overload update_streaming_distribution(params = {})
     # @param [Hash] params ({})


### PR DESCRIPTION
There are broken links connecting to AWS API Documentation. To deal with this, I've made this PR.