### PR TITLE
chore: add command to generate API reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,7 @@ unsure if your idea is something we would be open to, please ask us; Open an iss
 Specifically, here are a few things that we would appreciate help on:
 
 1. **Waiters** – Waiter configurations are located in the apis directory.
-2. **Docs** – We  greatly appreciate contributions to our documentation. The docs are written as code comments
-   and via a pair of [YARD](https://github.com/lsegal/yard) plugins.
+2. **Docs** – We  greatly appreciate contributions to our documentation. The docs are written as code comments.
 3. **Tests** – We maintain high code coverage, but if there are any tests you feel are missing, please add them.
 4. **Convenience features** – Are there any features you feel would add value to the SDK? Contributions in this
    area would be greatly appreciated.
@@ -55,6 +54,16 @@ The AWS SDK for Ruby is unit tested using RSpec. You can run the unit tests of t
 
 To run integration tests, create a `integration-test-config.json` file at the root of this repository. It should
 contain a `"region"` and credentials. Running rake test when this file is present will enable integration tests.
+
+## Generating documentation
+
+The documentation is generated via a pair of [YARD](https://github.com/lsegal/yard) plugins.
+You can generate documentation by running the following commands:
+
+    bundle install
+    bundle exec rake docs
+
+The documentation will be generated in the `api-docs/` directory.
 
 [issues]: https://github.com/aws/aws-sdk-ruby/issues
 [pull-requests]: https://github.com/aws/aws-sdk-ruby/pulls

--- a/tasks/docs.rake
+++ b/tasks/docs.rake
@@ -1,0 +1,8 @@
+desc 'Generate the API documentation.'
+task(:docs) do
+  env = {}
+  ENV['DOCSTRINGS'] = '1'
+  ENV['SITEMAP_BASEURL'] = 'http://docs.aws.amazon.com/sdk-for-ruby/v3/api/'
+  ENV['BASEURL'] = 'http://docs.aws.amazon.com/'
+  sh(env, 'bundle exec yard')
+end


### PR DESCRIPTION
### Description

Added rake script to test documentation.

### Testing

Verified that the documentation is created in `api-docs` folder on running `bundle exec rake docs`