### PR TITLE
EC2: Acceptor for the "snapshot_completed" waiter to make it handle the "error" state

### DIFF
--- a/apis/ec2/2016-11-15/waiters-2.json
+++ b/apis/ec2/2016-11-15/waiters-2.json
@@ -376,6 +376,12 @@
           "matcher": "pathAll",
           "state": "success",
           "argument": "Snapshots[].State"
+        },
+        {
+          "expected": "error",
+          "matcher": "pathAny",
+          "state": "failure",
+          "argument": "Snapshots[].State"
         }
       ]
     },

--- a/gems/aws-sdk-ec2/CHANGELOG.md
+++ b/gems/aws-sdk-ec2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Updated the "snapshot_completed" waiter to consider "error" as a terminal state. (#2586)
+
 1.263.0 (2021-09-14)
 ------------------
 

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/waiters.rb
@@ -967,12 +967,20 @@ module Aws::EC2
           delay: 15,
           poller: Aws::Waiters::Poller.new(
             operation_name: :describe_snapshots,
-            acceptors: [{
-              "expected" => "completed",
-              "matcher" => "pathAll",
-              "state" => "success",
-              "argument" => "snapshots[].state"
-            }]
+            acceptors: [
+              {
+                "expected" => "completed",
+                "matcher" => "pathAll",
+                "state" => "success",
+                "argument" => "snapshots[].state"
+              },
+              {
+                "expected" => "error",
+                "matcher" => "pathAny",
+                "state" => "failure",
+                "argument" => "snapshots[].state"
+              }
+            ]
           )
         }.merge(options))
       end


### PR DESCRIPTION
Hi! In this PR I added a new acceptor for the "snapshot_completed" waiter to make it fail when a snapshot reaches the "error" state. Now, instead of waiting until max attempts are reached, it fails early with `FailureStateError`.

This PR fixes #2586.

I was able to test this code with a snapshot of an EBS volume that has reached the "error" state:

```ruby
ec2 = Aws::EC2::Client.new(region: 'ca-central-1')
ec2.wait_until(:snapshot_completed, { snapshot_ids: ['snap-04d5f646b4ccf4654'] }, max_attempts: 1, delay: 60)
# => ... `block in poll': stopped waiting, encountered a failure state (Aws::Waiters::Errors::FailureStateError)
```

With a completed snapshot, it returns the result as expected:

```ruby
ec2.wait_until(:snapshot_completed, { snapshot_ids: ['snap-00d97207c7fc26109'] }, max_attempts: 1, delay: 60)
# => #<struct Aws::EC2::Types::DescribeSnapshotsResult ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.