### PR TITLE
Fix error in finding union member for boolean shapes with "false" values

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-json.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-json.json
@@ -931,8 +931,9 @@
       "UnionType": {
         "type": "structure",
         "members": {
-          "S":{"shape":"StringType"},
-          "L": {"shape": "ListType"}
+          "S": {"shape":"StringType"},
+          "L": {"shape":"ListType"},
+          "B": {"shape":"BooleanType"}
         },
         "union": true
       },
@@ -943,6 +944,9 @@
         }
       },
       "StringType": {
+        "type": "string"
+      },
+      "BooleanType": {
         "type": "string"
       }
     },
@@ -964,6 +968,25 @@
           "status_code": 200,
           "headers": {},
           "body": "{\"UnionMember\": {\"S\": \"string value\"}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"B":  false}
+        },
+        "resultClass": {
+          "UnionMember": "UnionType::B"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"B\": false}}"
         }
       },
       {

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix error in finding union member for boolean shapes with `false` values.
+
 3.121.0 (2021-09-02)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -73,7 +73,7 @@ module Aws
 
     module Union
       def member
-        self.members.select { |k| self[k] }.first
+        self.members.select { |k| self[k] != nil }.first
       end
 
       def value


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
