### PR TITLE
Use endpointPrefix when looking up the signing_region from the EndpointProvider

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Use endpointPrefix when looking up the `signing_region` from the `EndpointProvider`.
+
 3.121.2 (2021-10-18)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
@@ -37,7 +37,7 @@ module Aws
         if prefix && cfg.endpoint.to_s.match(/#{prefix}\.amazonaws\.com/)
           'us-east-1'
         elsif cfg.region
-          Aws::Partitions::EndpointProvider.signing_region(cfg.region, cfg.api.metadata['endpointPrefix'])
+          Aws::Partitions::EndpointProvider.signing_region(cfg.region, prefix)
         end
       end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/signature_v4.rb
@@ -37,7 +37,7 @@ module Aws
         if prefix && cfg.endpoint.to_s.match(/#{prefix}\.amazonaws\.com/)
           'us-east-1'
         elsif cfg.region
-          Aws::Partitions::EndpointProvider.signing_region(cfg.region, cfg.sigv4_name)
+          Aws::Partitions::EndpointProvider.signing_region(cfg.region, cfg.api.metadata['endpointPrefix'])
         end
       end
 

--- a/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
@@ -94,9 +94,11 @@ module Aws
             'signingName' => 'signing-name',
             'endpointPrefix' => 'api.service',
           })
-          expect(Aws::Partitions::EndpointProvider).to receive(:signing_region)
-                  .with('fips-us-east-1', 'api.service')
-                  .and_return('us-east-1')
+          expect(Aws::Partitions::EndpointProvider)
+            .to receive(:signing_region)
+            .with('fips-us-east-1', 'api.service')
+            .and_return('us-east-1')
+
           client = svc::Client.new(options.merge(
             region: 'fips-us-east-1',
             ))

--- a/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/signature_v4_spec.rb
@@ -88,6 +88,22 @@ module Aws
           expect(client.config.sigv4_region).to eq('eu-west-1')
         end
 
+        it 'uses the endpointPrefix to find the signing_region' do
+          svc = ApiHelper.sample_service(metadata: {
+            'signatureVersion' => 'v4',
+            'signingName' => 'signing-name',
+            'endpointPrefix' => 'api.service',
+          })
+          expect(Aws::Partitions::EndpointProvider).to receive(:signing_region)
+                  .with('fips-us-east-1', 'api.service')
+                  .and_return('us-east-1')
+          client = svc::Client.new(options.merge(
+            region: 'fips-us-east-1',
+            ))
+          expect(client.config.sigv4_name).to eq('signing-name')
+          expect(client.config.sigv4_region).to eq('us-east-1')
+        end
+
       end
 
       describe 'apply authtype trait' do

--- a/gems/aws-sdk-s3control/CHANGELOG.md
+++ b/gems/aws-sdk-s3control/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - use the correct service with the `EndpointProvider` to determine `sigv4_region`.
+
 1.41.0 (2021-10-18)
 ------------------
 

--- a/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_control_signer.rb
+++ b/gems/aws-sdk-s3control/lib/aws-sdk-s3control/plugins/s3_control_signer.rb
@@ -24,7 +24,7 @@ module Aws
         option(:sigv4_region) do |cfg|
           raise Aws::Errors::MissingRegionError if cfg.region.nil?
 
-          Aws::Partitions::EndpointProvider.signing_region(cfg.region, 's3')
+          Aws::Partitions::EndpointProvider.signing_region(cfg.region, 's3-control')
         end
 
         def add_handlers(handlers, _cfg)


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
