### PR TITLE
Bump the minimum version of `aws-partitions`

### DIFF
--- a/gems/aws-partitions/spec/aws_partitions_spec.rb
+++ b/gems/aws-partitions/spec/aws_partitions_spec.rb
@@ -354,7 +354,7 @@ module Aws
             Partitions::EndpointProvider.signing_service(
               'us-peccy-1',
               'crazy-peccy-service'
-            )rtitions VE
+            )
           ).to eq('crazy-peccy-signing-service')
         end
       end

--- a/gems/aws-partitions/spec/aws_partitions_spec.rb
+++ b/gems/aws-partitions/spec/aws_partitions_spec.rb
@@ -354,7 +354,7 @@ module Aws
             Partitions::EndpointProvider.signing_service(
               'us-peccy-1',
               'crazy-peccy-service'
-            )
+            )rtitions VE
           ).to eq('crazy-peccy-signing-service')
         end
       end

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - bump minimum version of `aws-partitions` (#2603).
+
 3.121.4 (2021-10-28)
 ------------------
 

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['LICENSE.txt', 'CHANGELOG.md', 'VERSION', 'lib/**/*.rb', 'ca-bundle.crt']
 
   spec.add_dependency('jmespath', '~> 1.0')
-  spec.add_dependency('aws-partitions', '~> 1', '>= 1.239.0') # necessary for STS & S3 regional
+  spec.add_dependency('aws-partitions', '~> 1', '>= 1.520.1') # necessary for STS & S3 regional
   spec.add_dependency('aws-sigv4', '~> 1.1') # necessary for making Aws::STS API calls
   spec.add_dependency('aws-eventstream', '~> 1', '>= 1.0.2') # necessary for binary eventstream
 


### PR DESCRIPTION
Required to include new methods added to `EndpointProvider`.

See: #2603 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
