### PR TITLE
Improve SSOCredential error messages when cache file is missing

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Improve `SooCredentials` error handling when profile file does not exist (#2605)
+* Issue - Improve `SSOCredentials` error handling when profile file does not exist (#2605)
 
 3.121.5 (2021-10-29)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Improve `SooCredentials` error handling when profile file does not exist (#2605)
+
 3.121.5 (2021-10-29)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
@@ -100,7 +100,7 @@ module Aws
         raise ArgumentError, 'Cached SSO Token is expired.'
       end
       cached_token
-    rescue Aws::Json::ParseError, ArgumentError
+    rescue Errno::ENOENT, Aws::Json::ParseError, ArgumentError
       raise Errors::InvalidSSOCredentials, SSO_LOGIN_GUIDANCE
     end
 

--- a/gems/aws-sdk-core/spec/aws/sso_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sso_credentials_spec.rb
@@ -87,6 +87,17 @@ module Aws
         end.to raise_error(ArgumentError, /Missing required keys/)
       end
 
+      it 'raises an InvalidSSOCredentials error when  token file is missing' do
+        start_url_sha1 = OpenSSL::Digest::SHA1.hexdigest(sso_start_url.encode('utf-8'))
+        allow(Dir).to receive(:home).and_return('HOME')
+        path = File.join(Dir.home, '.aws', 'sso', 'cache', "#{start_url_sha1}.json")
+
+        allow(File).to receive(:read).with(path).and_raise(Errno::ENOENT)
+
+        expect do
+          SSOCredentials.new(sso_opts)
+        end.to raise_error(Aws::Errors::InvalidSSOCredentials)
+      end
       it 'raises an InvalidSSOCredentials error when  token file is missing fields' do
         mock_token_file(sso_start_url, {'accessToken' =>  access_token})
 


### PR DESCRIPTION
Fixes #2605 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
