### PR TITLE
Allow generating presigned STS URLs for the legacy global endpoint

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow `Aws::STS::Presigner` to generate presigned STS URLs for the legacy global endpoint if the `Client` is configured to do so.
+
 3.121.6 (2021-11-02)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-sts/presigner.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-sts/presigner.rb
@@ -52,14 +52,9 @@ module Aws
           credentials_provider: req.context.config.credentials
         )
 
-        url = Aws::Partitions::EndpointProvider.resolve(
-          req.context.config.region, 'sts', 'regional'
-        )
-        url += "/?#{param_list}"
-
         signer.presign_url(
           http_method: 'GET',
-          url: url,
+          url: req.context.config.endpoint.to_s + "/?#{param_list}",
           body: '',
           headers: options[:headers]
         ).to_s

--- a/gems/aws-sdk-core/spec/aws/sts/presigner_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sts/presigner_spec.rb
@@ -39,6 +39,56 @@ module Aws
 
           expect(actual_url).to eq(expected_url)
         end
+
+        it 'can presign with legacy sts endpoint' do
+          client = Aws::STS::Client.new(
+            region: 'us-west-2',
+            sts_regional_endpoints: 'legacy',
+            credentials: Credentials.new('akid', 'secret')
+          )
+          pre = Presigner.new(client: client)
+
+          expected_url = 'https://sts.amazonaws.com/'\
+                         '?Action=GetCallerIdentity&Version=2011-06-15'\
+                         '&X-Amz-Algorithm=AWS4-HMAC-SHA256'\
+                         '&X-Amz-Credential=akid%2F20160101'\
+                         '%2Fus-west-2%2Fsts%2Faws4_request'\
+                         '&X-Amz-Date=20160101T112233Z'\
+                         '&X-Amz-Expires=900'\
+                         '&X-Amz-SignedHeaders=host%3Bx-k8s-aws-id'\
+                         '&X-Amz-Signature=eb82f89680e51b8f315703878fb360674f6'\
+                         '0998df071047f95ea52dfd4f101db'
+          actual_url = pre.get_caller_identity_presigned_url(
+            headers: { 'X-K8s-Aws-Id' => 'my-eks-cluster' }
+          )
+
+          expect(actual_url).to eq(expected_url)
+        end
+
+        it 'can presign with custom sts endpoint' do
+          client = Aws::STS::Client.new(
+            region: 'us-west-2',
+            endpoint: 'https://example.com',
+            credentials: Credentials.new('akid', 'secret')
+          )
+          pre = Presigner.new(client: client)
+
+          expected_url = 'https://example.com/'\
+                         '?Action=GetCallerIdentity&Version=2011-06-15'\
+                         '&X-Amz-Algorithm=AWS4-HMAC-SHA256'\
+                         '&X-Amz-Credential=akid%2F20160101'\
+                         '%2Fus-west-2%2Fsts%2Faws4_request'\
+                         '&X-Amz-Date=20160101T112233Z'\
+                         '&X-Amz-Expires=900'\
+                         '&X-Amz-SignedHeaders=host%3Bx-k8s-aws-id'\
+                         '&X-Amz-Signature=6f2ee9fe2a4bf5f5fa5de41b0e555e7de33'\
+                         'c64a4afbc7b1e1169295aa4edc0f3'
+          actual_url = pre.get_caller_identity_presigned_url(
+            headers: { 'X-K8s-Aws-Id' => 'my-eks-cluster' }
+          )
+
+          expect(actual_url).to eq(expected_url)
+        end
       end
     end
   end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!

Fixes #2607.