### PR TITLE
Fix parsing of timestamps in headers with ms precision.

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-xml.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-xml.json
@@ -739,6 +739,40 @@
           },
           "body": ""
         }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "string",
+          "Integer": 1,
+          "TrueBool": true,
+          "FalseBool": false,
+          "Float": 1.5,
+          "Double": 1.5,
+          "Long": 100,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-str": "string",
+            "x-int": "1",
+            "x-true-bool": "true",
+            "x-false-bool": "false",
+            "x-float": "1.5",
+            "x-double": "1.5",
+            "x-long": "100",
+            "x-char": "a",
+            "x-timestamp": "Sun, 25 Jan 2015 08:00:00.000 GMT"
+          },
+          "body": ""
+        }
       }
     ]
   },

--- a/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-xml.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/output/rest-xml.json
@@ -748,28 +748,48 @@
           "name": "OperationName"
         },
         "result": {
-          "Str": "string",
-          "Integer": 1,
-          "TrueBool": true,
-          "FalseBool": false,
-          "Float": 1.5,
-          "Double": 1.5,
-          "Long": 100,
-          "Char": "a",
           "Timestamp": 1422172800
         },
         "response": {
           "status_code": 200,
           "headers": {
-            "x-str": "string",
-            "x-int": "1",
-            "x-true-bool": "true",
-            "x-false-bool": "false",
-            "x-float": "1.5",
-            "x-double": "1.5",
-            "x-long": "100",
-            "x-char": "a",
             "x-timestamp": "Sun, 25 Jan 2015 08:00:00.000 GMT"
+          },
+          "body": ""
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-timestamp": "1422172800"
+          },
+          "body": ""
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-timestamp": "1422172800.0"
           },
           "body": ""
         }

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix parsing of ISO8601 timestamps with millisecond precision in headers.
+
 * Feature - Support modeled dualstack endpoints. It can be configured with shared configuration (`use_dualstack_endpoint`), an ENV variable (`AWS_USE_DUALSTACK_ENDPOINT`), and a constructor option (`:use_dualstack_endpoint`). Requests made to services without a dualstack endpoint will fail.
 
 * Feature - Support modeled fips endpoints. It can be configured with shared configuration (`use_fips_endpoint`), an ENV variable (`AWS_USE_FIPS_ENDPOINT`), and a constructor option (`:use_fips_endpoint`). Requests made to services without a fips endpoint will fail.

--- a/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/rest/response/headers.rb
@@ -41,7 +41,7 @@ module Aws
           when FloatShape then value.to_f
           when BooleanShape then value == 'true'
           when TimestampShape
-            if value =~ /\d+(\.\d*)/
+            if value =~ /^\d+(\.\d*)/
               Time.at(value.to_f)
             elsif value =~ /^\d+$/
               Time.at(value.to_i)


### PR DESCRIPTION
The regex we use to check if a timestamp header value is a float was missing a `^` (as we use to check for integers) and so iso8601 dates with millisecond precision were matching it and being incorrectly parsed as floats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
