### PR TITLE
Raise when accelerate and fips are provided in s3

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Raise error when `use_fips_endpoint` is used with `use_accelerate_endpoint`.
+
 1.105.0 (2021-11-04)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -46,7 +46,7 @@ each bucket. [Go here for more information](http://docs.aws.amazon.com/AmazonS3/
               raise ArgumentError,
                     'Cannot use both :use_accelerate_endpoint and :endpoint'
             end
-            # Raise if :endpoint and accelerate are both provided
+            # Raise if :use_fips_endpoint and accelerate are both provided
             if accelerate && context.config.use_fips_endpoint
               raise ArgumentError,
                     'Cannot use both :use_accelerate_endpoint and '\

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/accelerate.rb
@@ -46,6 +46,12 @@ each bucket. [Go here for more information](http://docs.aws.amazon.com/AmazonS3/
               raise ArgumentError,
                     'Cannot use both :use_accelerate_endpoint and :endpoint'
             end
+            # Raise if :endpoint and accelerate are both provided
+            if accelerate && context.config.use_fips_endpoint
+              raise ArgumentError,
+                    'Cannot use both :use_accelerate_endpoint and '\
+                    ':use_fips_endpoint'
+            end
             context[:use_accelerate_endpoint] = accelerate
             @handler.call(context)
           end

--- a/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/accelerate_spec.rb
@@ -65,6 +65,26 @@ module Aws
           )
         end
 
+        it 'raises when accelerate and endpoint are configured' do
+          expect do
+            Client.new(
+              options.merge(
+                use_accelerate_endpoint: true, endpoint: 'https://amazon.com'
+              )
+            ).put_object(bucket: 'bucket-name', key: 'key')
+          end.to raise_error(ArgumentError, /:endpoint/)
+        end
+
+        it 'raises when accelerate and use_fips_endpoint are configured' do
+          expect do
+            Client.new(
+              options.merge(
+                use_accelerate_endpoint: true, use_fips_endpoint: true
+              )
+            ).put_object(bucket: 'bucket-name', key: 'key')
+          end.to raise_error(ArgumentError, /:use_fips_endpoint/)
+        end
+
         it 'does not apply to #create_bucket' do
           resp = accelerated_client.create_bucket(bucket: 'bucket-name')
           expect(resp.context.http_request.endpoint.to_s).to eq(


### PR DESCRIPTION
There are no fips/accelerate endpoints, and this might break compliance if non-fips endpoint is used. We must raise an error (hopefully too breaking)