### PR TITLE
Parse a response with consecutive spaces correctly when ox is used as the XML parser

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Parse a response with consecutive spaces correctly when ox is used as the XML parser.
+
 3.125.0 (2021-12-21)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/engines/ox.rb
@@ -16,7 +16,7 @@ module Aws
           Ox.sax_parse(
             @stack, StringIO.new(xml),
             :convert_special => true,
-            :skip => :skip_white
+            :skip => :skip_return
           )
         end
 

--- a/gems/aws-sdk-core/spec/api_helper.rb
+++ b/gems/aws-sdk-core/spec/api_helper.rb
@@ -67,6 +67,8 @@ module ApiHelper
             'Integer' => { 'shape' => 'IntegerShape' },
             'Long' => { 'shape' => 'LongShape' },
             'String' => { 'shape' => 'StringShape' },
+            'StringWithConsecutiveSpaces' => { 'shape' => 'StringShape' },
+            'StringWithLF' => { 'shape' => 'StringShape' },
             'Timestamp' => { 'shape' => 'TimestampShape' },
             'EventStream' => { 'shape' => 'EventStream' },
             'DocumentType' => { 'shape' => 'DocumentShape' }

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -25,6 +25,8 @@ module Aws
           integer: 0,
           long: 0,
           string: "StringShape",
+          string_with_consecutive_spaces: "StringShape",
+          string_with_lf: "StringShape",
           sensitive_string: 'SensitiveStringShape',
           timestamp: now,
         })

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -9,10 +9,15 @@ module Aws
       [:ox, :oga, :nokogiri, :libxml, :rexml].each do |engine|
         describe("ENGINE: #{engine}") do
 
-          begin
-            Parser.engine = engine
-          rescue LoadError
-            next
+          around do |example|
+            previous_engine = Parser.engine
+            begin
+              Parser.engine = engine
+              example.run
+            rescue LoadError
+            ensure
+              Parser.engine = previous_engine
+            end
           end
 
           let(:shapes) { ApiHelper.sample_shapes }

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -110,6 +110,8 @@ module Aws
               <Integer>123</Integer>
               <Long>321</Long>
               <String>Hello</String>
+              <StringWithConsecutiveSpaces>foo  bar</StringWithConsecutiveSpaces>
+              <StringWithLF>foo\nbar</StringWithLF>
               <Timestamp>123456789</Timestamp>
             </xml>
             XML
@@ -145,6 +147,8 @@ module Aws
               long: 321,
               string: "Hello",
               timestamp: Time.at(123456789),
+              string_with_consecutive_spaces: "foo  bar",
+              string_with_lf: "foo\nbar",
             })
           end
 


### PR DESCRIPTION
Ox.sax_parse collapses consecutive white spaces into a single space if the option "skip" is `:skip_white`. As a result, responses are parsed incorrectly.
For example, assume that you have an S3 object whose key is "foo&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bar\n", which includes five consecutive spaces and a LF. The response of the following code includes the object with the key "foo bar", not "foo&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bar\n":

```ruby
Aws::S3::Client.new.list_objects_v2(bucket: bucket)
```

This PR fixes the issue.

Here is reproducible code:

```ruby
require 'ox'
require 'aws-sdk-s3'

BUCKET = ENV.fetch('BUCKET') do
  raise 'Environment variable "BUCKET" is required'
end

client = Aws::S3::Client.new
key = "foo     bar\n"
client.put_object(bucket: BUCKET, key: key)
client.list_objects_v2(bucket: BUCKET, prefix: key).contents.each do |o|
  puts "key:"
  p o.key
end
client.delete_object(bucket: BUCKET, key: key)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.