### PR TITLE
Add Ruby 3.1 and JRuby 9.3 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby-9.1, jruby-9.2]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.1, jruby-9.2, jruby-9.3]
         env: [PURE_RUBY, KITCHEN_SINK]
         exclude:
           - ruby: jruby-9.1
             env: KITCHEN_SINK
           - ruby: jruby-9.2
+            env: KITCHEN_SINK
+          - ruby: jruby-9.3
             env: KITCHEN_SINK
 
     steps:


### PR DESCRIPTION
This PR adds Ruby 3.1 and JRuby 9.3 to the CI matrix.  I ran the individual tasks on my fork and confirmed they ran green with these Rubies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
