### PR TITLE
Ensure default message for ServiceError is a string

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure default message for ServiceError is a string (#2643).
+
 3.125.5 (2022-01-19)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb
@@ -18,7 +18,7 @@ module Aws
         @code = self.class.code
         @context = context
         @data = data
-        @message = message && !message.empty? ? message : self.class
+        @message = message && !message.empty? ? message : self.class.to_s
         super(@message)
       end
 


### PR DESCRIPTION
Fixes: #2643 

Behavior was originally introduced in #2416. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
