### PR TITLE
[docs] chunk_size should be Integer instead of String.

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Issue - [docs] chunk_size should be Integer instead of String.
-
 1.112.0 (2022-02-03)
 ------------------
 

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - [docs] chunk_size should be Integer instead of String.
+
 1.112.0 (2022-02-03)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/object.rb
@@ -464,7 +464,7 @@ module Aws
       #  customizing each range size in multipart_download,
       #  By default, `auto` mode is enabled, which performs multipart_download
       #
-      # @option options [String] chunk_size required in get_range mode.
+      # @option options [Integer] chunk_size required in get_range mode.
       #
       # @option options [Integer] thread_count (10) Customize threads used in
       #   the multipart download.


### PR DESCRIPTION
repro code:
```rb
require 'aws-sdk-s3'
r = Aws::S3::Resource.new(stub_responses: { head_object: { content_length: 1 } })
o = r.bucket("a").object("b")
o.download_file("tmp", mode: "get_range", chunk_size: "1")
#=> /Users/ksss/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/aws-sdk-s3-1.112.0/lib/aws-sdk-s3/file_downloader.rb:94:in `>': comparison of String with 1 failed (ArgumentError)
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
