### PR TITLE
Add a before_refresh callback to AssumeRoleCredentials

### DIFF
--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
@@ -85,7 +85,6 @@ module Aws
         @identity_id = options.delete(:identity_id)
         @custom_role_arn = options.delete(:custom_role_arn)
         @logins = options.delete(:logins) || {}
-        @before_refresh = options.delete(:before_refresh)
 
         if !@identity_pool_id && !@identity_id
           raise ArgumentError,
@@ -114,8 +113,6 @@ module Aws
       private
 
       def refresh
-        @before_refresh.call(self) if @before_refresh
-
         resp = @client.get_credentials_for_identity(
           identity_id: identity_id,
           custom_role_arn: @custom_role_arn

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add a before_refresh callback to AssumeRoleCredentials (#2529). 
 * Issue - Raise a `NoSuchProfileError` when config and credentials files don't exist.
 
 3.126.1 (2022-02-14)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
@@ -17,6 +17,11 @@ module Aws
   #
   # If you omit `:client` option, a new {STS::Client} object will be
   # constructed.
+  #
+  # The AssumeRoleCredentials also provides a `before_refresh` callback
+  # that can be used to help manage refreshing tokens.
+  # `before_refresh` is called when AWS credentials are required and need
+  # to be refreshed and it is called with the AssumeRoleCredentials object.
   class AssumeRoleCredentials
 
     include CredentialProvider
@@ -49,8 +54,6 @@ module Aws
         end
       end
       @client = client_opts[:client] || STS::Client.new(client_opts)
-      @before_refresh = options.delete(:before_refresh)
-
       super
     end
 
@@ -63,9 +66,6 @@ module Aws
     private
 
     def refresh
-
-      @before_refresh.call(self) if @before_refresh
-
       c = @client.assume_role(@assume_role_params).credentials
       @credentials = Credentials.new(
         c.access_key_id,

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
@@ -39,6 +39,11 @@ module Aws
     #   encoded UUID is generated as the session name
     #
     # @option options [STS::Client] :client
+    #
+    # @option options [Callable] before_refresh Proc called before
+    #   credentials are refreshed. `before_refresh` is called
+    #   with an instance of this object when
+    #   AWS credentials are required and need to be refreshed.
     def initialize(options = {})
       client_opts = {}
       @assume_role_web_identity_params = {}

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ecs_credentials.rb
@@ -43,6 +43,10 @@ module Aws
     # @option options [IO] :http_debug_output (nil) HTTP wire
     #   traces are sent to this object.  You can specify something
     #   like $stdout.
+    # @option options [Callable] before_refresh Proc called before
+    #   credentials are refreshed. `before_refresh` is called
+    #   with an instance of this object when
+    #   AWS credentials are required and need to be refreshed.
     def initialize options = {}
       @retries = options[:retries] || 5
       @ip_address = options[:ip_address] || '169.254.170.2'

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -63,6 +63,10 @@ module Aws
     # @option options [Integer] :token_ttl Time-to-Live in seconds for EC2
     #   Metadata Token used for fetching Metadata Profile Credentials, defaults
     #   to 21600 seconds
+    # @option options [Callable] before_refresh Proc called before
+    #   credentials are refreshed. `before_refresh` is called
+    #   with an instance of this object when
+    #   AWS credentials are required and need to be refreshed.
     def initialize(options = {})
       @retries = options[:retries] || 1
       endpoint_mode = resolve_endpoint_mode(options)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
@@ -19,7 +19,7 @@ module Aws
 
     def initialize(options = {})
       @mutex = Mutex.new
-      @before_refresh = options.delete(:before_refresh)
+      @before_refresh = options.delete(:before_refresh) if Hash === options
 
       @before_refresh.call(self) if @before_refresh
       refresh

--- a/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
@@ -63,6 +63,11 @@ module Aws
     #
     # @option options [SSO::Client] :client Optional `SSO::Client`.  If not
     #   provided, a client will be constructed.
+    #
+    # @option options [Callable] before_refresh Proc called before
+    #   credentials are refreshed. `before_refresh` is called
+    #   with an instance of this object when
+    #   AWS credentials are required and need to be refreshed.
     def initialize(options = {})
 
       missing_keys = SSO_REQUIRED_OPTS.select { |k| options[k].nil? }

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -102,5 +102,21 @@ module Aws
       c.credentials
     end
 
+    it 'calls before_refresh with self' do
+      before_refresh_called = false
+      before_refresh = proc do |cred_provider|
+        before_refresh_called = true
+        expect(cred_provider).to be_instance_of(AssumeRoleCredentials)
+      end
+
+      AssumeRoleCredentials.new(
+        role_arn: 'arn',
+        role_session_name: 'session',
+        before_refresh: before_refresh
+      )
+
+      expect(before_refresh_called).to be(true)
+    end
+
   end
 end


### PR DESCRIPTION
Fixes: #2529 

This provides a `before_refresh` hook that will get called before new credentials are fetched allowing users to refresh the token used (or update any other parameters as required).  Applications likely have a wide range of strategies for updating MFA tokens, so rather than attempt to provide default implementations this just provides a hook for application code to update the token when its needed.

Note - the TokenProvider interface/implementation as suggested in #2529 could be confused with [Bearer Token Auth](https://awslabs.github.io/smithy/1.0/spec/core/auth-traits.html#httpbearerauth-trait) so I've gone with a generic callback hook instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
