### PR TITLE
Refactor PageableResponse to avoid busting Ruby's constant cache

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fixed `Aws::PageableResponse` invalidating Ruby's global constant cache.
+
 3.128.0 (2022-03-04)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/response_paging.rb
@@ -10,7 +10,7 @@ module Aws
         def call(context)
           context[:original_params] = context.params
           resp = @handler.call(context)
-          resp.extend(PageableResponse)
+          PageableResponse.apply(resp)
           resp.pager = context.operation[:pager] || Aws::Pager::NullPager.new
           resp
         end

--- a/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/pageable_response_spec.rb
@@ -6,7 +6,7 @@ module Aws
   describe PageableResponse do
 
     def pageable(resp, pager)
-      resp.extend(PageableResponse)
+      PageableResponse.apply(resp)
       resp.pager = pager
       resp.context[:original_params] = resp.context.params.freeze
       resp
@@ -257,6 +257,18 @@ module Aws
         expect(page.respond_to?(:foo)).to be(true)
       end
 
+    end
+
+    describe '.apply' do
+
+      it 'does not bump RubyVM.stat(:global_constant_state)' do
+        skip "Only applies to MRI"  unless defined? RubyVM.stat
+
+        object = Object.new
+        expect {
+          PageableResponse.apply(object)
+        }.to_not change { RubyVM.stat(:global_constant_state) }
+      end
     end
 
   end

--- a/gems/aws-sdk-core/spec/aws/resources/collection_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/resources/collection_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-module Enumerable
-  class Enumerator; end
-end
 require_relative '../../spec_helper'
 
 module Aws


### PR DESCRIPTION
Ruby has a global constant cache, which is basically a counter
that is incremented anytime a constant is set or modified.

Whenever it is bumped, the vast majority of the Ruby VM inline caches
are invalidated, as well as JITed code. So busting this cache
at "runtime" is very detrimental to performance.

`Object#extend` doesn't normally bust the cache, except if the
module contains constants of it's own:

```ruby
module A; end
obj.extend(A) # The global cache is preserved

module B
  FOO = 1
end
obj.extend(B) # The global cache is invalidated
```

In this case, the constant causing the invalidation is
`Aws::PageableResponse::LastPageError`.

So to avoid regularly flushing the cache, this PR move all
pagination methods to a submodule, and include this one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
