### PR TITLE
Make stubs thread safe by adding a mutex per stubbed request

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Make stubs thread safe by creating new responses for each operation call (#2675).
+
 3.129.0 (2022-03-08)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -301,9 +301,7 @@ module Aws
 
     def validate_stub(operation_name, data)
       if Hash === data && data.keys.sort != [:body, :headers, :status_code]
-        api = config.api
-        operation = api.operation(operation_name)
-        ParamValidator.new(operation.output, input: false).validate!(data)
+        data_to_http_resp(operation_name, data)
       end
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/stub_responses.rb
@@ -51,7 +51,11 @@ requests are made, and retries are disabled.
           stub = context.client.next_stub(context)
           resp = Seahorse::Client::Response.new(context: context)
           async_mode = context.client.is_a? Seahorse::Client::AsyncBase
-          apply_stub(stub, resp, async_mode)
+          if Hash === stub && stub[:mutex]
+            stub[:mutex].synchronize { apply_stub(stub, resp, async_mode) }
+          else
+            apply_stub(stub, resp, async_mode)
+          end
 
           async_mode ? Seahorse::Client::AsyncResponse.new(
             context: context, stream: context[:input_event_stream_handler].event_emitter.stream, sync_queue: Queue.new) : resp


### PR DESCRIPTION
Fixes #2675. 

Previously we were creating 1 Response object for each stub added (at the time it was added to the client), each operation call would then reference the same response object, with the same body object, causing race conditions.  This change moves the conversion of stub data into response objects to operation call time - thus ensuring that each call gets its own response.  

Todo: Still need to evaluate other possible impacts/backwards compatibility issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
