### PR TITLE
Remove before_refresh from client construction in RefreshingCredentials

### DIFF
--- a/gems/aws-sdk-cognitoidentity/CHANGELOG.md
+++ b/gems/aws-sdk-cognitoidentity/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Don't pass `:before_refresh` to Client constructors in `CognitoIdentityCredentials` (#2690).
+
 1.40.0 (2022-02-24)
 ------------------
 

--- a/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
+++ b/gems/aws-sdk-cognitoidentity/lib/aws-sdk-cognitoidentity/customizations/cognito_identity_credentials.rb
@@ -87,13 +87,16 @@ module Aws
         @logins = options.delete(:logins) || {}
         @async_refresh = false
 
+        client_opts = {}
+        options.each_pair { |k,v| client_opts[k] = v unless CLIENT_EXCLUDE_OPTIONS.include?(k) }
+
         if !@identity_pool_id && !@identity_id
           raise ArgumentError,
                 'Must provide either identity_pool_id or identity_id'
         end
 
         @client = options[:client] || CognitoIdentity::Client.new(
-          options.merge(credentials: false)
+          client_opts.merge(credentials: false)
         )
         super
       end

--- a/gems/aws-sdk-cognitoidentity/spec/cognito_identity_credentials_spec.rb
+++ b/gems/aws-sdk-cognitoidentity/spec/cognito_identity_credentials_spec.rb
@@ -46,6 +46,19 @@ module Aws
           expect(creds.client).to be(client)
         end
 
+        it 'excludes before_refresh from client construction' do
+          expect(CognitoIdentity::Client).to receive(:new)
+                                               .with({region: 'us-east-1', credentials: false})
+                                               .and_return(client)
+
+          creds = CognitoIdentityCredentials.new(
+            identity_id: identity_id,
+            region: 'us-east-1',
+            before_refresh: proc { }
+          )
+          expect(creds.client).to be(client)
+        end
+
         it 'raises an argument error when identity_pool_id and identity_id are missing' do
           expect { CognitoIdentityCredentials.new }.to raise_error(ArgumentError)
         end

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Don't pass `:before_refresh` to Client constructors in RefreshingCredential implementations (#2690).
+
 3.130.1 (2022-04-12)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_credentials.rb
@@ -49,7 +49,7 @@ module Aws
       options.each_pair do |key, value|
         if self.class.assume_role_options.include?(key)
           @assume_role_params[key] = value
-        else
+        elsif !CLIENT_EXCLUDE_OPTIONS.include?(key)
           client_opts[key] = value
         end
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/assume_role_web_identity_credentials.rb
@@ -52,7 +52,7 @@ module Aws
       options.each_pair do |key, value|
         if self.class.assume_role_web_identity_options.include?(key)
           @assume_role_web_identity_params[key] = value
-        else
+        elsif !CLIENT_EXCLUDE_OPTIONS.include?(key)
           client_opts[key] = value
         end
       end
@@ -100,11 +100,10 @@ module Aws
       # @api private
       def assume_role_web_identity_options
         @arwio ||= begin
-          input = STS::Client.api.operation(:assume_role_with_web_identity).input
+          input = Aws::STS::Client.api.operation(:assume_role_with_web_identity).input
           Set.new(input.shape.member_names)
         end
       end
-
     end
   end
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
@@ -20,6 +20,8 @@ module Aws
     SYNC_EXPIRATION_LENGTH = 300 # 5 minutes
     ASYNC_EXPIRATION_LENGTH = 600 # 10 minutes
 
+    CLIENT_EXCLUDE_OPTIONS = Set.new([:before_refresh]).freeze
+
     def initialize(options = {})
       @mutex = Mutex.new
       @before_refresh = options.delete(:before_refresh) if Hash === options

--- a/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/sso_credentials.rb
@@ -83,9 +83,13 @@ module Aws
       # validate we can read the token file
       read_cached_token
 
-      options[:region] = @sso_region
-      options[:credentials] = nil
-      @client = options[:client] || Aws::SSO::Client.new(options)
+
+      client_opts = {}
+      options.each_pair { |k,v| client_opts[k] = v unless CLIENT_EXCLUDE_OPTIONS.include?(k) }
+      client_opts[:region] = @sso_region
+      client_opts[:credentials] = nil
+
+      @client = options[:client] || Aws::SSO::Client.new(client_opts)
       @async_refresh = true
       super
     end

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -41,6 +41,16 @@ module Aws
       expect(creds.client).to be(client)
     end
 
+    it 'excludes before_refresh from client construction' do
+      allow(STS::Client).to receive(:new).with({credentials: false}).and_return(client)
+      creds = AssumeRoleCredentials.new(
+        role_arn: 'arn',
+        role_session_name: 'session',
+        before_refresh: proc {}
+      )
+      expect(creds.client).to be(client)
+    end
+
     it 'accepts a client' do
       creds = AssumeRoleCredentials.new(
         client: client,

--- a/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_web_identity_credentials_spec.rb
@@ -50,11 +50,23 @@ module Aws
       allow(client).to receive(:assume_role_with_web_identity).and_return(resp)
     end
 
-    it 'contructs a default client when not given' do
+    it 'constructs a default client when not given' do
       creds = AssumeRoleWebIdentityCredentials.new(
         role_arn: 'arn',
         web_identity_token_file: token_file_path,
         role_session_name: "session-name"
+      )
+      expect(creds.client).to be(client)
+    end
+
+    it 'excludes before_refresh from client construction' do
+      expect(STS::Client).to receive(:new).with({credentials: false}).and_return(client)
+
+      creds = AssumeRoleWebIdentityCredentials.new(
+        role_arn: 'arn',
+        web_identity_token_file: token_file_path,
+        role_session_name: "session-name",
+        before_refresh: proc { }
       )
       expect(creds.client).to be(client)
     end

--- a/gems/aws-sdk-core/spec/aws/sso_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sso_credentials_spec.rb
@@ -75,6 +75,17 @@ module Aws
         expect(creds.client).to be(client)
       end
 
+      it 'excludes before_refresh from client construction' do
+        expect(SSO::Client).to receive(:new)
+                                 .with({region: sso_region, credentials: nil})
+                                 .and_return(client)
+
+        mock_token_file(sso_start_url, cached_token)
+
+        creds = SSOCredentials.new(sso_opts.merge(before_refresh: proc {}))
+        expect(creds.client).to be(client)
+      end
+
       it 'raises an argument error when arguments are missing' do
         expect { SSOCredentials.new }.to raise_error(
           ArgumentError, /Missing required keys/


### PR DESCRIPTION
Fixes: #2690 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
