### PR TITLE
Fix duplicated bytes in streaming retries

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Rewind the underlying file on a streaming retry that is not a truncated body (#2692).
+
 1.113.0 (2022-02-24)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/streaming_retry.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/plugins/streaming_retry.rb
@@ -95,6 +95,7 @@ module Aws
             end
 
             context.http_response.on_error do |error|
+              puts context.http_response.body
               if retryable_body?(context)
                 if truncated_body?(error)
                   context.http_request.headers[:range] = "bytes=#{context.http_response.body.size}-"


### PR DESCRIPTION
Fixes: #2692 

Rewind the underlying file on a streaming retry that is not a truncated body.

Testing and reproduction:
It is difficult to test/reproduce the issue, but can be done by modifying the net http handler:
```
net_resp.read_body do |chunk|
  bytes_received += chunk.bytesize
  resp.signal_data(chunk)
  if chunk.bytesize > 1000 && Thread.current[:raise_network]
    Thread.current[:raise_network] = nil
    raise NetworkingError.new(SocketError.new, "Test transient networking error")
  end
end
```

Note: Working on developing automated testing.

And then:
```
Thread.current[:raise_network] = true # hack this into handler.rb line 88.
key = "download_corruption_test"
s3 = ::Aws::S3::Resource.new
bucket = s3.bucket(bucket_name)
bucket.object(key).get(response_target: 'tmp.out', checksum_mode: "ENABLED")
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
