### PR TITLE
Fix performance regression when checking if `aws-crt` is available.

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix performance regression when checking if `aws-crt` is available. (#2729)
+
 1.5.0 (2022-04-20)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -74,6 +74,8 @@ module Aws
     #
     class Signer
 
+      @@use_crt = nil
+
       # @overload initialize(service:, region:, access_key_id:, secret_access_key:, session_token:nil, **options)
       #   @param [String] :service The service signing name, e.g. 's3'.
       #   @param [String] :region The region name, e.g. 'us-east-1'.
@@ -833,12 +835,14 @@ module Aws
       class << self
 
         def use_crt?
-          begin
-            require 'aws-crt'
-            return true
-          rescue LoadError
-            return false
-          end
+          return @@use_crt unless @@use_crt.nil?
+          @@use_crt =
+            begin
+              require 'aws-crt'
+              true
+            rescue LoadError
+              false
+            end
         end
 
         # @api private

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -74,7 +74,13 @@ module Aws
     #
     class Signer
 
-      @@use_crt = nil
+      @@use_crt =
+        begin
+          require 'aws-crt'
+          true
+        rescue LoadError
+          false
+        end
 
       # @overload initialize(service:, region:, access_key_id:, secret_access_key:, session_token:nil, **options)
       #   @param [String] :service The service signing name, e.g. 's3'.
@@ -835,14 +841,7 @@ module Aws
       class << self
 
         def use_crt?
-          return @@use_crt unless @@use_crt.nil?
-          @@use_crt =
-            begin
-              require 'aws-crt'
-              true
-            rescue LoadError
-              false
-            end
+          @@use_crt
         end
 
         # @api private


### PR DESCRIPTION
Fixes #2729 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
