### PR TITLE
Fix to_json usage in Rails

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,10 +1,12 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `to_json` usage on pageable responses when using Rails.
+
 3.131.3 (2022-07-18)
 ------------------
 
-* Issue - Add support for serializing shapes on the body with `jsonvalue` members. 
+* Issue - Add support for serializing shapes on the body with `jsonvalue` members.
 
 3.131.2 (2022-06-20)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -146,6 +146,9 @@ module Aws
         data.to_h
       end
 
+      def to_json(options = {})
+        to_h.to_json(options)
+      end
     end
 
     # The actual decorator module implementation. It is in a distinct module


### PR DESCRIPTION
Fixes #2732 When Rails is loaded, to_json will infinitely recurse because PageableResponse is enumerable. We instead define our own to_json that applies it to the returned data.