### PR TITLE
Use expand_path in SharedConfig to handle paths that include "~".

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -2,7 +2,7 @@ Unreleased Changes
 ------------------
 
 * Issue - Fix `to_json` usage on pageable responses when using Rails (#2733).
-* Issue -  Use `expand_path` on credential/config paths in SharedConfig (#2735).
+* Issue - Use `expand_path` on credential/config paths in SharedConfig (#2735).
 
 3.131.3 (2022-07-18)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix `to_json` usage on pageable responses when using Rails.
+* Issue - Fix `to_json` usage on pageable responses when using Rails (#2733).
+* Issue -  Use `expand_path` on credential/config paths in SharedConfig (#2735).
 
 3.131.3 (2022-07-18)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -51,10 +51,12 @@ module Aws
       @config_enabled = options[:config_enabled]
       @credentials_path = options[:credentials_path] ||
                           determine_credentials_path
+      @credentials_path = File.expand_path(@credentials_path) if @credentials_path
       @parsed_credentials = {}
       load_credentials_file if loadable?(@credentials_path)
       if @config_enabled
         @config_path = options[:config_path] || determine_config_path
+        @config_path = File.expand_path(@config_path) if @config_path
         load_config_file if loadable?(@config_path)
       end
     end

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -11,7 +11,8 @@ module Aws
     end
 
     def with_shared_credentials(profile_name = SecureRandom.hex, credentials_file = nil)
-      path = File.join('HOME', '.aws', 'credentials')
+      path = File.expand_path(
+        File.join('HOME', '.aws', 'credentials'))
       creds = random_creds
       credentials_file ||= <<-CREDS
 [#{profile_name}]
@@ -19,9 +20,9 @@ aws_access_key_id = #{creds[:access_key_id]}
 aws_secret_access_key = #{creds[:secret_access_key]}
 aws_session_token = #{creds[:session_token]}
 CREDS
+      allow(Dir).to receive(:home).and_return('HOME')
       allow(File).to receive(:exist?).with(path).and_return(true)
       allow(File).to receive(:readable?).with(path).and_return(true)
-      allow(Dir).to receive(:home).and_return('HOME')
       allow(File).to receive(:read).with(path).and_return(credentials_file)
       creds.merge(profile_name: profile_name)
     end

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -34,14 +34,14 @@ module Aws
 
       it 'defaults credentials_path to Dir.home/.aws/credentials' do
         config = SharedConfig.new
-        expect(config.credentials_path).to eq(
+        expect(config.credentials_path).to include(
           File.join('HOME', '.aws', 'credentials')
         )
       end
 
       it 'defaults config_path to Dir.home/.aws/config' do
         config = SharedConfig.new(config_enabled: true)
-        expect(config.config_path).to eq(
+        expect(config.config_path).to include(
           File.join('HOME', '.aws', 'config')
         )
       end


### PR DESCRIPTION
Fixes #2735 

SharedConfig's `loadable?` method uses `File.exists?` on the provided path, but this will return `false` for paths that include `~` unless those paths are expanded first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
