### PR TITLE
Fixes `to_json` usage on pageable responses in custom objects

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `to_json` usage on pageable responses in custom objects (#2733).
+
 3.131.4 (2022-07-27)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -146,8 +146,8 @@ module Aws
         data.to_h
       end
 
-      def to_json(options = {})
-        to_h.to_json(options)
+      def as_json(options = {})
+        to_h.as_json(options)
       end
     end
 


### PR DESCRIPTION
This PR aims to resolve #2732. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
