### PR TITLE
Revert "Fixes `to_json` usage on pageable responses in custom objects…

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix `to_json` usage on pageable responses in custom objects (#2733).
-
 3.131.4 (2022-07-27)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -146,8 +146,8 @@ module Aws
         data.to_h
       end
 
-      def as_json(options = {})
-        to_h.as_json(options)
+      def to_json(options = {})
+        to_h.to_json(options)
       end
     end
 


### PR DESCRIPTION
… (#2737)"

This reverts commit 98f376003321b9c763fc2564e177ec061bfcfbe4.

We need to check usage without Rails.
