### PR TITLE
Define as_json to fix nested to_json

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `to_json` usage in nested hashes by defining `as_json` (#2733).
+
 3.131.4 (2022-07-27)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/pageable_response.rb
@@ -146,8 +146,12 @@ module Aws
         data.to_h
       end
 
+      def as_json(_options = {})
+        data.to_h(data, as_json: true)
+      end
+
       def to_json(options = {})
-        to_h.to_json(options)
+        as_json.to_json(options)
       end
     end
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/structure.rb
@@ -28,18 +28,20 @@ module Aws
     # in stdlib Struct.
     #
     # @return [Hash]
-    def to_h(obj = self)
+    def to_h(obj = self, options = {})
       case obj
       when Struct
         obj.each_pair.with_object({}) do |(member, value), hash|
-          hash[member] = to_hash(value) unless value.nil?
+          member = member.to_s if options[:as_json]
+          hash[member] = to_hash(value, options) unless value.nil?
         end
       when Hash
         obj.each.with_object({}) do |(key, value), hash|
-          hash[key] = to_hash(value)
+          key = key.to_s if options[:as_json]
+          hash[key] = to_hash(value, options)
         end
       when Array
-        obj.collect { |value| to_hash(value) }
+        obj.collect { |value| to_hash(value, options) }
       else
         obj
       end


### PR DESCRIPTION
Implements as_json which needs stringified keys. Works for both Rails and non-Rails environments.

```
[1] pry(Aws)> lambda.list_functions.as_json
[Aws::Lambda::Client 200 0.437538 0 retries] list_functions()  
=> {"functions"=>
  [{"function_name"=>"CreateSong",
...

[2] pry(Aws)> lambda.list_functions.to_json
[Aws::Lambda::Client 200 0.095378 0 retries] list_functions()  
=> "{\"functions\":[{\"function_name\":\"CreateSong\", ..."

# This is expected
[3] pry(Aws)> { "foo" => lambda.list_functions }.as_json
[Aws::Lambda::Client 200 0.089956 0 retries] list_functions()  
NoMethodError: undefined method `as_json' for #<Hash:0x00007fecb985cf20>
from (pry):3:in `__binding__'

[4] pry(Aws)> { "foo" => lambda.list_functions }.to_json
[Aws::Lambda::Client 200 0.096464 0 retries] list_functions()  
=> "{\"foo\":{\"functions\":[{\"function_name\":\"CreateSong\",..."

[5] pry(Aws)> require 'rails'
=> true

[6] pry(Aws)> lambda.list_functions.as_json
[Aws::Lambda::Client 200 0.36586 0 retries] list_functions()  
=> {"functions"=>
  [{"function_name"=>"CreateSong",
...

[7] pry(Aws)> lambda.list_functions.to_json
[Aws::Lambda::Client 200 0.095083 0 retries] list_functions()  
=> "{\"functions\":[{\"function_name\":\"CreateSong"
...

[8] pry(Aws)> { "foo" => lambda.list_functions }.as_json
[Aws::Lambda::Client 200 0.093324 0 retries] list_functions()  
=> {"foo"=>
  {"functions"=>
    [{"function_name"=>"CreateSong",
...

[9] pry(Aws)> { "foo" => lambda.list_functions }.to_json
[Aws::Lambda::Client 200 0.352975 0 retries] list_functions()  
=> "{\"foo\":{\"functions\":[{\"function_name\":\"CreateSong\",...}"
```