### PR TITLE
Fix: validate trace id

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Issue after release #2747 (#2748)
+
 3.136.0 (2022-08-25)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Issue after release #2747 (#2748)
+* Issue - Fix errors in recursion detection when `_X_AMZN_TRACE_ID` is unset (#2748).
 
 3.136.0 (2022-08-25)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/recursion_detection.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/recursion_detection.rb
@@ -20,6 +20,8 @@ module Aws
 
         private
         def validate_header(header_value)
+          return unless header_value
+
           if (header_value.chars & (0..31).map(&:chr)).any?
             raise ArgumentError, 'Invalid _X_AMZN_TRACE_ID value: '\
               'contains ASCII control characters'

--- a/gems/aws-sdk-core/spec/aws/plugins/recursion_detection_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/recursion_detection_spec.rb
@@ -99,6 +99,15 @@ module Aws
             end
           end
         end
+
+        context 'X_AMZ_TRACE_ID is unset' do
+          let(:env_trace_id) { nil }
+
+          it 'does not set the header' do
+            resp = client.operation_with_trace_id
+            expect(resp.context.http_request.headers['x-amzn-trace-id']).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Backwards compatibility, work with ENV['_X_AMZN_TRACE_ID'] unset
https://github.com/aws/aws-sdk-ruby/issues/2748