### PR TITLE
fix typo "us-eas-1"

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Fixed typo in gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb.
-
 3.143.0 (2022-09-08)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Fixed typo in gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb.
+
 3.143.0 (2022-09-08)
 ------------------
 

--- a/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/assume_role_credentials_spec.rb
@@ -7,7 +7,7 @@ module Aws
 
     let(:client) {
       STS::Client.new(
-        region: 'us-eas-1',
+        region: 'us-east-1',
         credentials: credentials,
         stub_responses: true
       )


### PR DESCRIPTION
Hello, we discovered this typo coincidentally while tracking down the same typo somewhere else. Since it's in the spec, I'm not sure if this is _supposed_ to fail or not, but on the off chance that it isn't; here is a single-character fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
