### PR TITLE
Fix space trimming of header values in sigv4 signer

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix an issue where quoted strings with multiple spaces are not trimmed. (#2758)
+
 1.5.1 (2022-07-19)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -589,7 +589,7 @@ module Aws
       end
 
       def canonical_header_value(value)
-        value.match(/^".*"$/) ? value : value.gsub(/\s+/, ' ').strip
+        value.gsub(/\s+/, ' ').strip
       end
 
       def host(uri)

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -527,29 +527,6 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
           EOF
         end
 
-        it 'leaves whitespace in quoted values in-tact' do
-          signature = Signer.new(options).sign_request(
-            http_method: 'PUT',
-            url: 'http://domain.com',
-            headers: {
-              'Abc' => '"a  b  c"', # quoted header values preserve spaces
-              'X-Amz-Date' => '20160101T112233Z',
-            }
-          )
-          expect(signature.canonical_request).to eq(<<-EOF.strip)
-PUT
-/
-
-abc:"a  b  c"
-host:domain.com
-x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-x-amz-date:20160101T112233Z
-
-abc;host;x-amz-content-sha256;x-amz-date
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-          EOF
-        end
-
         it 'normalizes valueless-querystring keys with a trailing =' do
           signature = Signer.new(options).sign_request(
             http_method: 'PUT',


### PR DESCRIPTION
Fixes #2758

SigV4 signer had explicit behavior and test case where quoted header values were not trimmed. The specification seems to indicate that it should always be trimmed and makes no mention of quotes. This behavior has existed for 9 years, and was likely a "safe assumption."