### PR TITLE
Ensure that the ReadCallbackIO is always unwrapped

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure that the ReadCallbackIO is always unwrapped (#2761). 
+
 3.158.0 (2022-09-30)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
@@ -80,10 +80,12 @@ bytes in the body.
                 context.http_request.body,
                 callback
               )
+              @handler.call(context).tap do
+                unwrap_callback_body(context)
+              end
+            else
+              @handler.call(context)
             end
-            resp = @handler.call(context)
-            unwrap_callback_body(context)
-            resp
           end
 
           def unwrap_callback_body(context)

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
@@ -82,16 +82,22 @@ bytes in the body.
               )
               add_event_listeners(context)
             end
-            @handler.call(context)
+            resp = @handler.call(context)
+            ReadCallbackHandler.unwrap_callback_body(context)
+            resp
           end
 
           def add_event_listeners(context)
             # unwrap the request body as soon as we start receiving a response
             context.http_response.on_headers do
-              body = context.http_request.body
-              if body.is_a? ReadCallbackIO
-                context.http_request.body = body.io
-              end
+              ReadCallbackHandler.unwrap_callback_body(context)
+            end
+          end
+
+          def self.unwrap_callback_body(context)
+            body = context.http_request.body
+            if body.is_a? ReadCallbackIO
+              context.http_request.body = body.io
             end
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
@@ -80,24 +80,13 @@ bytes in the body.
                 context.http_request.body,
                 callback
               )
-              add_event_listeners(context)
             end
-            @handler.call(context)
+            resp = @handler.call(context)
+            unwrap_callback_body(context)
+            resp
           end
 
-          def add_event_listeners(context)
-            # unwrap the request body as soon as we start receiving a response
-            context.http_response.on_headers do
-              ReadCallbackHandler.unwrap_callback_body(context)
-            end
-
-            context.http_response.on_error do
-              puts "on error!"
-              ReadCallbackHandler.unwrap_callback_body(context)
-            end
-          end
-
-          def self.unwrap_callback_body(context)
+          def unwrap_callback_body(context)
             body = context.http_request.body
             if body.is_a? ReadCallbackIO
               context.http_request.body = body.io

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/request_callback.rb
@@ -82,14 +82,17 @@ bytes in the body.
               )
               add_event_listeners(context)
             end
-            resp = @handler.call(context)
-            ReadCallbackHandler.unwrap_callback_body(context)
-            resp
+            @handler.call(context)
           end
 
           def add_event_listeners(context)
             # unwrap the request body as soon as we start receiving a response
             context.http_response.on_headers do
+              ReadCallbackHandler.unwrap_callback_body(context)
+            end
+
+            context.http_response.on_error do
+              puts "on error!"
               ReadCallbackHandler.unwrap_callback_body(context)
             end
           end

--- a/gems/aws-sdk-core/spec/aws/request_callback_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/request_callback_spec.rb
@@ -50,6 +50,14 @@ module Seahorse
           expect(@call_count).to eq(2)
         end
 
+        it 'unwraps the body on networking errors' do
+          stub_request(:post, 'http://foo.com')
+            .to_timeout
+            .to_return(status: 200)
+          client.example_operation
+          expect(@call_count).to eq(2)
+        end
+
         it 'it can be used as a parameter on the operation' do
           client = client_class.new(region: 'us-west-1', endpoint: 'http://foo.com')
           expect(client.config.on_chunk_sent).to eq(nil)


### PR DESCRIPTION
Fixes #2761 - ensure that the ReadCallbackIO is always unwrapped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
