### PR TITLE
Ensure the stream_thread is not killed before H2 connection status is updated

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure the stream_thread is not killed before H2 connection status is updated (#2779).
+
 * Feature - Add token refresh support to `SSOCredentialProvider`.
 
 3.166.0 (2022-10-26)

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -104,7 +104,7 @@ module Seahorse
           @mutex.synchronize {
             return if @socket_thread
             @socket_thread = Thread.new do
-              while !@socket.closed?
+              while @socket && !@socket.closed?
                 begin
                   data = @socket.read_nonblock(@chunk_size)
                   @h2_client << data
@@ -130,6 +130,7 @@ module Seahorse
                   self.close!
                 end
               end
+              @socket_thread = nil
             end
             @socket_thread.abort_on_exception = true
           }
@@ -141,10 +142,6 @@ module Seahorse
             if @socket
               @socket.close
               @socket = nil
-            end
-            if @socket_thread
-              Thread.kill(@socket_thread)
-              @socket_thread = nil
             end
             @status = :closed
           }


### PR DESCRIPTION
Fixes #2779 

When the underlying H2 Connection's socket closes (due to a connection read timeout or other), the `Connection#close!` method was calling `Thread.kill(@socket_thread)` before updating the `@status`.  The `close!` method was being called FROM the `@socket_thread` and so killing it, prevented the status from being updated correctly, leaving the conneciton in an incorrect state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
