### PR TITLE
CredentialProviderChain: Fallback to client region resolution for AssumeRoleCredentials

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Use Aws.shared_config when deciding on region in CredentialProviderChain.
 
 3.167.0 (2022-11-09)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased Changes
 ------------------
-* Issue - Allow region resolution in `AssumeRoleCredentials` from `CredentailProviderChain`.
+* Issue - Allow region resolution in `AssumeRoleCredentials` from `CredentialProviderChain`.
 
 3.167.0 (2022-11-09)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased Changes
 ------------------
-* Issue - Use Aws.shared_config when deciding on region in CredentialProviderChain.
+* Issue - Allow region resolution in `AssumeRoleCredentials` from `CredentailProviderChain`.
 
 3.167.0 (2022-11-09)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -141,7 +141,7 @@ module Aws
     end
 
     def assume_role_web_identity_credentials(options)
-      region = (options[:config] && options[:config].region || Aws.shared_config.region)
+      region = options[:config].region if options[:config]
       if (role_arn = ENV['AWS_ROLE_ARN']) && (token_file = ENV['AWS_WEB_IDENTITY_TOKEN_FILE'])
         cfg = {
           role_arn: role_arn,
@@ -169,12 +169,14 @@ module Aws
     end
 
     def assume_role_with_profile(options, profile_name)
-      region = (options[:config] && options[:config].region || Aws.shared_config.region)
-      Aws.shared_config.assume_role_credentials_from_config(
+      assume_opts = {
         profile: profile_name,
-        region: region,
         chain_config: @config
-      )
+      }
+      if options[:config] && options[:config].region
+        assume_opts[:region] = options[:config].region
+      end
+      Aws.shared_config.assume_role_credentials_from_config(assume_opts)
     end
   end
 end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -141,7 +141,7 @@ module Aws
     end
 
     def assume_role_web_identity_credentials(options)
-      region = options[:config].region if options[:config]
+      region = (options[:config] && options[:config].region || Aws.shared_config.region)
       if (role_arn = ENV['AWS_ROLE_ARN']) && (token_file = ENV['AWS_WEB_IDENTITY_TOKEN_FILE'])
         cfg = {
           role_arn: role_arn,
@@ -169,7 +169,7 @@ module Aws
     end
 
     def assume_role_with_profile(options, profile_name)
-      region = (options[:config] && options[:config].region)
+      region = (options[:config] && options[:config].region || Aws.shared_config.region)
       Aws.shared_config.assume_role_credentials_from_config(
         profile: profile_name,
         region: region,

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -154,6 +154,17 @@ CREDS
         ENV['AWS_DEFAULT_PROFILE'] = 'BAD_PROFILE'
         validate_credentials(expected_creds)
       end
+
+      describe 'assume role' do
+        it 'uses the shared config region if present' do
+          allow(Aws.shared_config).to receive(:region).and_return('us-east-2')
+          expect(Aws.shared_config).to receive(:region).twice.and_return('us-east-2') #twice because each call below counts for 1
+
+
+          chain.send(:assume_role_with_profile, {}, 'default')
+          chain.send(:assume_role_web_identity_credentials, {})
+        end
+      end
     end
 
     describe 'with multiple sources of credentials' do

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -154,17 +154,6 @@ CREDS
         ENV['AWS_DEFAULT_PROFILE'] = 'BAD_PROFILE'
         validate_credentials(expected_creds)
       end
-
-      describe 'assume role' do
-        it 'uses the shared config region if present' do
-          allow(Aws.shared_config).to receive(:region).and_return('us-east-2')
-          expect(Aws.shared_config).to receive(:region).twice.and_return('us-east-2') #twice because each call below counts for 1
-
-
-          chain.send(:assume_role_with_profile, {}, 'default')
-          chain.send(:assume_role_web_identity_credentials, {})
-        end
-      end
     end
 
     describe 'with multiple sources of credentials' do

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -529,6 +529,26 @@ module Aws
             client.config.credentials.credentials.access_key_id
           ).to eq('AR_AKID')
         end
+
+        it 'allows region to be resolved when unspecified' do
+          assume_role_stub(
+            'arn:aws:iam:123456789012:role/bar',
+            'ACCESS_KEY_ARPC',
+            'AR_AKID',
+            'AR_SECRET',
+            'AR_TOKEN'
+          )
+
+          allow(ENV).to receive(:[])
+          allow(ENV).to receive(:[]).with('AWS_PROFILE').and_return('ar_from_self')
+          allow(ENV).to receive(:values_at).and_return(['us-east-1'])
+
+          credentials = CredentialProviderChain.new.resolve
+
+          expect(
+            credentials.credentials.access_key_id
+          ).to eq('AR_AKID')
+        end
       end
 
       it 'can assume a role with EC2 Instance Metadata as a source' do


### PR DESCRIPTION
The current implementation ignores any data that is retrieve through user configuration schema. By calling Aws.shared_config.region, it allows the call to attempt to retrieve the region from any configuration elsewhere in the system that wasn't provided in the configuration object.

As this is a fallback, this should have no implication on working system that already rely on the config object.