### PR TITLE
Validate that max_number_of_messages is a positive integer

### DIFF
--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Raise ArgumentError when QueuePoller's :max_number_of_messages is nil or less than 1.
+* Issue - Raise ArgumentError when QueuePoller's :max_number_of_messages is not a positive integer.
 
 1.52.0 (2022-10-25)
 ------------------

--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Raise ArgumentError when QueuePoller's :max_number_of_messages is nil or less than 1.
+
 1.52.0 (2022-10-25)
 ------------------
 

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -498,10 +498,12 @@ module Aws
               raise ArgumentError, "invalid option #{opt_name.inspect}"
             end
           end
-          unless @request_params[:max_number_of_messages].to_i >= 1
-            raise ArgumentError,
-                  ':max_number_of_messages must be a positive integer'
+
+          max_number_of_messages = @request_params[:max_number_of_messages]
+          unless max_number_of_messages.is_a?(Integer) && max_number_of_messages.positive?
+            raise ArgumentError, ':max_number_of_messages must be a positive integer'
           end
+
           @request_params.freeze
           freeze
         end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -410,7 +410,7 @@ module Aws
       end
 
       def yield_messages(config, messages, stats, &block)
-        if config.request_params[:max_number_of_messages] == 1
+        if config.request_params[:max_number_of_messages].to_i <= 1
           messages.each do |msg|
             yield(msg, stats)
           end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -410,7 +410,7 @@ module Aws
       end
 
       def yield_messages(config, messages, stats, &block)
-        if config.request_params[:max_number_of_messages].to_i <= 1
+        if config.request_params[:max_number_of_messages] == 1
           messages.each do |msg|
             yield(msg, stats)
           end
@@ -497,6 +497,10 @@ module Aws
             else
               raise ArgumentError, "invalid option #{opt_name.inspect}"
             end
+          end
+          unless @request_params[:max_number_of_messages].to_i >= 1
+            raise ArgumentError,
+                  ':max_number_of_messages must be a positive integer'
           end
           @request_params.freeze
           freeze

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -80,18 +80,25 @@ module Aws
           })
         end
 
-        it 'raises when max messages is 0' do
-          expect {
-            QueuePoller.new(queue_url, client:client, max_number_of_messages: 0)
-          }.to raise_error(ArgumentError, /positive integer/)
-        end
+        context 'max_number_of_messages validation' do
+          subject { QueuePoller.new(queue_url, client: client, max_number_of_messages: max_number_of_messages) }
 
-        it 'raises when max messages is nil' do
-          expect {
-            QueuePoller.new(queue_url, client:client, max_number_of_messages: nil)
-          }.to raise_error(ArgumentError, /positive integer/)
-        end
+          let(:max_number_of_messages) { 1 }
 
+          it 'accepts a positive integer' do
+            expect(subject.default_config.request_params[:max_number_of_messages]).to eq(1)
+          end
+
+          [0, nil, 1.1, '1'].each do |value|
+            context "with `max_number_of_messages: #{value.inspect}`" do
+              let(:max_number_of_messages) { value }
+
+              it "raises an error" do
+                expect { subject }.to raise_error(ArgumentError, /positive integer/)
+              end
+            end
+          end
+        end
       end
 
       describe '#poll' do

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -127,6 +127,30 @@ module Aws
           expect(yielded.map(&:body)).to eq(%w(body-1 body-2))
         end
 
+        it 'yields single messages when max messages is 0' do
+          client.stub_responses(:receive_message, [
+            { messages: [sample_message] },
+            { messages: [] },
+          ])
+          yielded = nil
+          poller.poll(idle_timeout: 0, max_number_of_messages: 0) do |msg|
+            yielded = msg
+          end
+          expect(yielded.body).to eq('body')
+        end
+
+        it 'yields single messages when max messages is nil' do
+          client.stub_responses(:receive_message, [
+            { messages: [sample_message] },
+            { messages: [] },
+          ])
+          yielded = nil
+          poller.poll(idle_timeout: 0, max_number_of_messages: nil) do |msg|
+            yielded = msg
+          end
+          expect(yielded.body).to eq('body')
+        end
+
         describe 'message deletion' do
 
           it 'deletes the message at the end of the block' do

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -80,6 +80,18 @@ module Aws
           })
         end
 
+        it 'raises when max messages is 0' do
+          expect {
+            QueuePoller.new(queue_url, client:client, max_number_of_messages: 0)
+          }.to raise_error(ArgumentError, /positive integer/)
+        end
+
+        it 'raises when max messages is nil' do
+          expect {
+            QueuePoller.new(queue_url, client:client, max_number_of_messages: nil)
+          }.to raise_error(ArgumentError, /positive integer/)
+        end
+
       end
 
       describe '#poll' do
@@ -125,30 +137,6 @@ module Aws
             yielded = messages
           end
           expect(yielded.map(&:body)).to eq(%w(body-1 body-2))
-        end
-
-        it 'yields single messages when max messages is 0' do
-          client.stub_responses(:receive_message, [
-            { messages: [sample_message] },
-            { messages: [] },
-          ])
-          yielded = nil
-          poller.poll(idle_timeout: 0, max_number_of_messages: 0) do |msg|
-            yielded = msg
-          end
-          expect(yielded.body).to eq('body')
-        end
-
-        it 'yields single messages when max messages is nil' do
-          client.stub_responses(:receive_message, [
-            { messages: [sample_message] },
-            { messages: [] },
-          ])
-          yielded = nil
-          poller.poll(idle_timeout: 0, max_number_of_messages: nil) do |msg|
-            yielded = msg
-          end
-          expect(yielded.body).to eq('body')
         end
 
         describe 'message deletion' do

--- a/gems/aws-sdk/CHANGELOG.md
+++ b/gems/aws-sdk/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Issue - Correct the behavior of QueuePoller for max_number_of_messages less than 1.
-
 3.1.0 (2021-09-01)
 ------------------
 

--- a/gems/aws-sdk/CHANGELOG.md
+++ b/gems/aws-sdk/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Correct the behavior of QueuePoller for max_number_of_messages less than 1.
+
 3.1.0 (2021-09-01)
 ------------------
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

- `* Issue - Raise ArgumentError when QueuePoller's :max_number_of_messages is not a positive integer.`

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

- I do not believe the `QueuePoller` is generated.

Thank you for your contribution!

- You're welcome! :)

Reason for this PR is that the docs [here](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/QueuePoller.html) gave me some unexpected behavior:

> You can specify a maximum number of messages to receive with each
> polling attempt via `:max_number_of_messages`. When this is set to a
> positive value, greater than 1, the block will receive an array of
> messages, instead of a single message.

From the docs I expect `nil` and `0` to yield one message at a time, but it actually does `== 1` and yields an array of messages.  Let's make the unexpected behavior impossible to hit by validating the param is a positive integer.  The default behavior is unchanged: yield 1 message at a time.