### PR TITLE
Return error messages from failures in threads

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Return error messages from failures in threads in `MultipartStreamUploader` (#2793).
+
 1.117.1 (2022-10-26)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -148,7 +148,6 @@ module Aws
 
       def upload_in_threads(read_pipe, completed, options, thread_errors)
         mutex = Mutex.new
-        part_number = 9990
         @thread_count.times.map do
           thread = Thread.new do
             begin

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -148,6 +148,7 @@ module Aws
 
       def upload_in_threads(read_pipe, completed, options, thread_errors)
         mutex = Mutex.new
+        part_number = 0
         @thread_count.times.map do
           thread = Thread.new do
             begin

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -67,9 +67,13 @@ module Aws
 
       def upload_parts(upload_id, options, &block)
         completed = Queue.new
+        thread_errors = []
         errors = begin
           IO.pipe do |read_pipe, write_pipe|
-            threads = upload_in_threads(read_pipe, completed, upload_part_opts(options).merge(upload_id: upload_id))
+            threads = upload_in_threads(
+              read_pipe, completed,
+              upload_part_opts(options).merge(upload_id: upload_id),
+              thread_errors)
             begin
               block.call(write_pipe)
             ensure
@@ -79,7 +83,7 @@ module Aws
             threads.map(&:value).compact
           end
         rescue => e
-          [e]
+          thread_errors + [e]
         end
 
         if errors.empty?
@@ -142,9 +146,9 @@ module Aws
         end
       end
 
-      def upload_in_threads(read_pipe, completed, options)
+      def upload_in_threads(read_pipe, completed, options, thread_errors)
         mutex = Mutex.new
-        part_number = 0
+        part_number = 9990
         @thread_count.times.map do
           thread = Thread.new do
             begin
@@ -179,7 +183,10 @@ module Aws
               nil
             rescue => error
               # keep other threads from uploading other parts
-              mutex.synchronize { read_pipe.close_read unless read_pipe.closed? }
+              mutex.synchronize do
+                thread_errors.push(error)
+                read_pipe.close_read unless read_pipe.closed?
+              end
               error
             end
           end

--- a/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
@@ -245,7 +245,7 @@ module Aws
             object.upload_stream do |_write_stream|
               raise 'something went wrong'
             end
-          end.to raise_error('multipart upload failed: something went wrong')
+          end.to raise_error(/something went wrong/)
         end
 
         it 'reports when it is unable to abort a failed multipart upload' do


### PR DESCRIPTION
Fixes #2793 

When an upload thread encounters an error, it closes the pipe.  The closed pipe causes the outer loop to raise an error, which is caught and returned - skipping any issues encountered in threads.  This makes understanding and debugging issues that occur during multipart upload much harder as it suppresses the actual error.  

This change just adds a tracking array where thread errors are stored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
