### PR TITLE
Cut down on example documentation for absurd shape sizes

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -239,6 +239,7 @@ module AwsSdkCodeGenerator
         receiver: 'client',
         resp_var: 'resp',
       ).format
+      # TODO - QuickSight is breaking this
       example if example && example.lines.count < 1000
     end
 
@@ -251,6 +252,7 @@ module AwsSdkCodeGenerator
         resp_var: 'async_resp',
         async: true
       ).format
+      # TODO - QuickSight is breaking this
       example if example && example.lines.count < 1000
     end
 
@@ -261,6 +263,7 @@ module AwsSdkCodeGenerator
           shape_ref: operation['output'],
           api: api
         ).to_s)
+        # TODO - QuickSight is breaking this
         docstring if docstring && docstring.lines.count < 1000
       end
     end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -232,17 +232,18 @@ module AwsSdkCodeGenerator
     end
 
     def request_syntax_example(method_name, operation, api)
-      SyntaxExample.new(
+      example = SyntaxExample.new(
         api: api,
         shape: Api.shape(operation['input'], api),
         method_name: method_name,
         receiver: 'client',
         resp_var: 'resp',
       ).format
+      example if example.lines.count < 1000
     end
 
     def async_request_syntax_example(method_name, operation, api)
-      SyntaxExample.new(
+      example = SyntaxExample.new(
         api: api,
         shape: Api.shape(operation['input'], api),
         method_name: method_name,
@@ -250,15 +251,17 @@ module AwsSdkCodeGenerator
         resp_var: 'async_resp',
         async: true
       ).format
+      example if example.lines.count < 1000
     end
 
     def response_structure_example(operation, api)
       output = Api.shape(operation['output'], api) if operation['output']
       if output && output['members'] && output['members'].size > 0
-        Docstring.block_comment(ClientResponseStructureExample.new(
+        docstring = Docstring.block_comment(ClientResponseStructureExample.new(
           shape_ref: operation['output'],
           api: api
         ).to_s)
+        docstring if docstring.lines.count < 1000
       end
     end
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/client_operation_documentation.rb
@@ -239,7 +239,7 @@ module AwsSdkCodeGenerator
         receiver: 'client',
         resp_var: 'resp',
       ).format
-      example if example.lines.count < 1000
+      example if example && example.lines.count < 1000
     end
 
     def async_request_syntax_example(method_name, operation, api)
@@ -251,7 +251,7 @@ module AwsSdkCodeGenerator
         resp_var: 'async_resp',
         async: true
       ).format
-      example if example.lines.count < 1000
+      example if example && example.lines.count < 1000
     end
 
     def response_structure_example(operation, api)
@@ -261,7 +261,7 @@ module AwsSdkCodeGenerator
           shape_ref: operation['output'],
           api: api
         ).to_s)
-        docstring if docstring.lines.count < 1000
+        docstring if docstring && docstring.lines.count < 1000
       end
     end
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -102,8 +102,8 @@ module AwsSdkCodeGenerator
       def struct_class_docs(shape_name, shape)
         join_docstrings([
           html_to_markdown(Api.docstring(shape_name, @api)),
-          input_example_docs(shape_name, shape),
-          output_example_docs(shape_name, shape),
+          #input_example_docs(shape_name, shape),
+          #output_example_docs(shape_name, shape),
           attribute_macros_docs(shape_name),
           see_also_tag(shape_name),
         ])
@@ -112,7 +112,7 @@ module AwsSdkCodeGenerator
       def eventstream_class_docs(shape_name, shape)
         join_docstrings([
           html_to_markdown(Api.docstring(shape_name, @api)),
-          input_example_docs(shape_name, shape),
+          #input_example_docs(shape_name, shape),
           eventstream_docs(shape_name),
           see_also_tag(shape_name),
         ])


### PR DESCRIPTION
QuickSight got very massive.

```
mamuller@147dda1143b7 aws-sdk-ruby % git diff --stat
 gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/client.rb | 227336 +++--------------------------------------------------------------
 gems/aws-sdk-quicksight/lib/aws-sdk-quicksight/types.rb  | 423340 +------------------------------------------------------------------------------------------------------------------------
 2 files changed, 7515 insertions(+), 643161 deletions(-)
```