### PR TITLE
Fix Sign to not sign sigv2 cases

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix Sign to not sign Sigv2 requests to S3.
+
 3.168.3 (2022-12-02)
 ------------------
 

--- a/gems/aws-sdk-core/spec/aws/plugins/sign_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/sign_spec.rb
@@ -43,8 +43,8 @@ module Aws
         }
       end
 
-
       let(:client) { TestClient.new(client_options) }
+
       context 'sigv4' do
         let(:auth_scheme) do
           {
@@ -222,10 +222,23 @@ module Aws
         end
 
         it 'raises an error when attempting to sign a request w/out a token' do
-          client = TestClient.new(client_options.merge(token_provider: nil) )
-          expect {
+          client = TestClient.new(client_options.merge(token_provider: nil))
+          expect do
             client.operation
-          }.to raise_error(Errors::MissingBearerTokenError)
+          end.to raise_error(Errors::MissingBearerTokenError)
+        end
+      end
+
+      context 'sigv2' do
+        before do
+          allow(Struct).to receive(:responds_to?).with(:signature_version).and_return(true)
+          allow(Struct).to receive(:signature_version).and_return('s3')
+        end
+
+        it 'skips signing' do
+          resp = client.operation
+          req = resp.context.http_request
+          expect(req.headers['authorization']).to be_nil
         end
       end
 


### PR DESCRIPTION
Fixes issue in https://github.com/aws/aws-sdk-ruby/discussions/2802

Custom endpoints will still flow through endpoint resolution, but for S3, it also returns Sigv4 signing. That endpoint is merged with service defaults (also Sigv4) and then eventually signed by the generic signer. Legacy sigv2 signing, when enabled, would sign on top of generic signing, which overrode Authorization. This worked for S3 but not for 3rd party solutions coincidentally because of Date Time parsing. This change fixes the behavior so that they are mutually exclusive.