### PR TITLE
Issue: ECS Client list_container_instances() result documentation fix

### DIFF
--- a/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
+++ b/gems/aws-sdk-ecs/lib/aws-sdk-ecs/client.rb
@@ -4522,8 +4522,8 @@ module Aws::ECS
     #   resp.to_h outputs the following:
     #   {
     #     container_instance_arns: [
-    #       "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/f6bbb147-5370-4ace-8c73-c7181ded911f", 
-    #       "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/ffe3d344-77e2-476c-a4d0-bf560ad50acb", 
+    #       "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/default/f6bbb147-5370-4ace-8c73-c7181ded911f",
+    #       "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/default/ffe3d344-77e2-476c-a4d0-bf560ad50acb",
     #     ], 
     #   }
     #


### PR DESCRIPTION
The ECS container instance ARNs returned by list_container_instances() include the cluster name in tail end of the ARN, after the string "container-instance" and before the container instance ID itself. Since you need just the container instance ID in calling methods like update_container_instance_state(), knowing the proper format for value returned here is important.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
