### PR TITLE
Improve performance of `UrlSigner#signed_url`

### DIFF
--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Improve performance of `UrlSigner#signed_url` (#2824).
+
 1.75.0 (2023-02-08)
 ------------------
 

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/url_signer.rb
@@ -33,7 +33,7 @@ module Aws
           policy: params[:policy]
         )
 
-        start_flag = URI.parse(uri).query ? '&' : '?'
+        start_flag = uri.include?('?') ? '&' : '?'
         signature = signed_content.map{ |k, v| "#{k}=#{v}" }.join('&').gsub("\n", '')
         uri = "#{uri}#{start_flag}#{signature}"
 


### PR DESCRIPTION
Fixes #2824 

Benchmarking `URI.parse(uri).query` vs `uri.include?` - `URI.parse` is about 50x slower.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
