### PR TITLE
Improve performance of URL signing

### DIFF
--- a/gems/aws-sdk-cloudfront/CHANGELOG.md
+++ b/gems/aws-sdk-cloudfront/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Improve performance of URL signing
+
 1.75.1 (2023-02-15)
 ------------------
 

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/signer.rb
@@ -15,7 +15,8 @@ module Aws
       # @option options [String] :private_key_path
       def initialize(options = {})
         @key_pair_id = key_pair_id(options)
-        @private_key = private_key(options)
+        @cipher = OpenSSL::Digest::SHA1.new
+        @private_key = OpenSSL::PKey::RSA.new(private_key(options))
       end
 
       private
@@ -97,8 +98,7 @@ module Aws
 
       # create the signature string with policy signed
       def sign_policy(policy)
-        key = OpenSSL::PKey::RSA.new(@private_key)
-        key.sign(OpenSSL::Digest::SHA1.new, policy)
+        @private_key.sign(@cipher, policy)
       end
 
       # create canned policy that used for signing


### PR DESCRIPTION
Changed the implementation of Signer to reuse the OpenSSL PKey object. Re-initializing that object took about half the total duration of the sign_policy call. Confirmed that the `@private_key` instance variable isn't used anywhere else.

Measuring before/after using Ruby's Benchmark module (through UrlSigner using a relatively long HTTPS URL), I observed a ~40% improvement in performance.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
