### PR TITLE
Reduce memory usage in H2::Connection when `http_wire_log` is not set.

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Reduce memory usage in H2::Connection when `http_wire_log` is not set.
+
 3.170.0 (2023-01-25)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/connection.rb
@@ -43,7 +43,9 @@ module Seahorse
           @h2_client = HTTP2::Client.new(
             settings_max_concurrent_streams: max_concurrent_streams
           )
-          @logger = options[:logger] || Logger.new($stdout) if @http_wire_trace
+          @logger = if @http_wire_trace
+            options[:logger] || Logger.new($stdout)
+          end
           @chunk_size = options[:read_chunk_size] || CHUNKSIZE
           @errors = []
           @status = :ready
@@ -180,11 +182,13 @@ module Seahorse
               @socket.flush
             end
           end
-          @h2_client.on(:frame_sent) do |frame|
-            debug_output("frame: #{frame.inspect}", :send)
-          end
-          @h2_client.on(:frame_received) do |frame|
-            debug_output("frame: #{frame.inspect}", :receive)
+          if @http_wire_trace
+            @h2_client.on(:frame_sent) do |frame|
+              debug_output("frame: #{frame.inspect}", :send)
+            end
+            @h2_client.on(:frame_received) do |frame|
+              debug_output("frame: #{frame.inspect}", :receive)
+            end
           end
         end
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
