### PR TITLE
Enhance permanent redirect error with endpoint and bucket information

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Provide `endpoint` and `bucket` attributes on `Aws::S3::Errors::PermanentRedirect` error objects.
+
 1.119.1 (2023-02-13)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations.rb
@@ -18,10 +18,12 @@ require 'aws-sdk-s3/presigner'
 
 # customizations to generated classes
 require 'aws-sdk-s3/customizations/bucket'
+require 'aws-sdk-s3/customizations/errors'
 require 'aws-sdk-s3/customizations/object'
 require 'aws-sdk-s3/customizations/object_summary'
 require 'aws-sdk-s3/customizations/multipart_upload'
 require 'aws-sdk-s3/customizations/types/list_object_versions_output'
+require 'aws-sdk-s3/customizations/types/permanent_redirect'
 
 [
   Aws::S3::Object::Collection,

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/errors.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Aws
+  module S3
+    module Errors
+      # Hijack PermanentRedirect dynamic error to also include endpoint
+      # and bucket.
+      class PermanentRedirect < ServiceError
+        # @param [Seahorse::Client::RequestContext] context
+        # @param [String] message
+        # @param [Aws::S3::Types::PermanentRedirect] data
+        def initialize(context, message, _data = Aws::EmptyStructure.new)
+          data = Aws::S3::Types::PermanentRedirect.new(message: message)
+          body = context.http_response.body_contents
+          if (endpoint = body.match(/<Endpoint>(.+?)<\/Endpoint>/))
+            data.endpoint = endpoint[1]
+          end
+          if (bucket = body.match(/<Bucket>(.+?)<\/Bucket>/))
+            data.bucket = bucket[1]
+          end
+          super(context, message, data)
+        end
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/permanent_redirect.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/customizations/types/permanent_redirect.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Aws
+  module S3
+    module Types
+      # This error is not modeled.
+      #
+      # The bucket you are attempting to access must be addressed using the
+      # specified endpoint. Please send all future requests to this endpoint.
+      #
+      # @!attribute [rw] endpoint
+      #   @return [String]
+      #
+      # @!attribute [rw] bucket
+      #   @return [String]
+      #
+      # @!attribute [rw] message
+      #   @return [String]
+      #
+      class PermanentRedirect < Struct.new(:endpoint, :bucket, :message)
+        SENSITIVE = []
+        include Aws::Structure
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds endpoint and bucket to PermanentRedirect error.

Closes #2623

```
[1] pry(Aws)> begin
[1] pry(Aws)*   s3.list_objects_v2(bucket: 'mamuller-us-east-1')  
[1] pry(Aws)* rescue Aws::S3::Errors::PermanentRedirect => e  
[1] pry(Aws)*   puts e.data  
[1] pry(Aws)*   puts e.message
[1] pry(Aws)* end  
...
{:endpoint=>"s3.amazonaws.com", :bucket=>"mamuller-us-east-1", :message=>"The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint."}
The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```