### PR TITLE
Skip bucket region cache if custom endpoint is provided

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Skip `#check_for_cached_region` if custom endpoint provided
+
 1.120.0 (2023-03-31)
 ------------------
 

--- a/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
+++ b/gems/aws-sdk-s3/spec/client/region_detection_spec.rb
@@ -92,6 +92,20 @@ module Aws
           end.to raise_error(Aws::S3::Errors::AuthorizationHeaderMalformed)
         end
 
+        it 'does not redirect custom endpoints when the region is cached' do
+          S3::BUCKET_REGIONS['bucket'] = 'us-west-2'
+          stub_request(:put, 'http://bucket.localhost:9000/key')
+            .to_return(status: [200, 'Ok'])
+
+          client = S3::Client.new(
+            client_opts.merge(endpoint: 'http://localhost:9000')
+          )
+          expect_auth({ 'signingRegion' => 'us-east-1' })
+          resp = client.put_object(bucket: 'bucket', key: 'key', body: 'body')
+          host = resp.context.http_request.endpoint.host
+          expect(host).to eq('bucket.localhost')
+        end
+
         it 'does not redirect regional endpoints' do
           stub_request(
             :put, 'https://bucket.s3.us-east-2.amazonaws.com/key'


### PR DESCRIPTION
#2842 was reverted because of breaking tests. This approach seems to be correct. It uses a custom endpoint method that checks dns suffix rather than whether endpoint was set or not (an unfortunate quirk for v3)