### PR TITLE
Update ec2 test cases for presigned url copy snapshot

### DIFF
--- a/gems/aws-sdk-ec2/spec/client_spec.rb
+++ b/gems/aws-sdk-ec2/spec/client_spec.rb
@@ -87,7 +87,7 @@ module Aws
 
         it 'requires a source region' do
           expect { client.copy_snapshot }
-            .to raise_error(ArgumentError, /source region/)
+            .to raise_error(ArgumentError, /Source region/)
         end
 
         it 'populates :presigned_url' do


### PR DESCRIPTION
Update and align test cases with other SDKs for the copy snapshot presigned url feature.