### PR TITLE
Fix error code parsing in aws query compatible json services

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix error code parsing in AWS query compatible JSON services.
+
 3.171.0 (2023-03-22)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/error_handler.rb
@@ -26,11 +26,13 @@ module Aws
       end
 
       def error_code(json, context)
-        code = if aws_query_error?(context)
-          context.http_response.headers['x-amzn-query-error'].split(';')[0]
-        else
-          json['__type']
-        end
+        code =
+          if aws_query_error?(context)
+            error = context.http_response.headers['x-amzn-query-error'].split(';')[0]
+            remove_prefix(error, context)
+          else
+            json['__type']
+          end
         code ||= json['code']
         code ||= context.http_response.headers['x-amzn-errortype']
         if code
@@ -43,6 +45,14 @@ module Aws
       def aws_query_error?(context)
         context.config.api.metadata['awsQueryCompatible'] &&
           context.http_response.headers['x-amzn-query-error']
+      end
+
+      def remove_prefix(error_code, context)
+        if prefix = context.config.api.metadata['errorPrefix']
+          error_code.sub(/^#{prefix}/, '')
+        else
+          error_code
+        end
       end
 
       def error_message(code, json)

--- a/gems/aws-sdk-core/spec/aws/json/error_handler_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/json/error_handler_spec.rb
@@ -106,7 +106,8 @@ module Aws
               'awsQueryCompatible' => {},
               'protocol' => 'json',
               'endpointPrefix' => 'svc',
-              'signatureVersion' => 'v4'
+              'signatureVersion' => 'v4',
+              'errorPrefix' => 'Prefix' # service customization needs to set this
             },
             'operations' => {
               'Foo' => {
@@ -136,7 +137,7 @@ module Aws
         it 'extracts code and message from x-amzn-query-error' do
           stub_request(:post, "https://svc.us-west-2.amazonaws.com/").
             to_return(:status => 400, headers: {
-              'x-amzn-query-error': 'AwsQueryError;Sender'
+              'x-amzn-query-error': 'Prefix.AwsQueryError;Sender'
             }, :body => error_resp)
           expect {
             client_aws_query_compatible.foo()

--- a/gems/aws-sdk-sqs/features/client.feature
+++ b/gems/aws-sdk-sqs/features/client.feature
@@ -17,5 +17,5 @@ Feature: Amazon Simple Queue Service
     Then I expect the response error code to be "NonExistentQueue"
     And I expect the response error message to include:
     """
-    The specified queue does not exist for this wsdl version.
+    The specified queue does not exist.
     """


### PR DESCRIPTION
Related to https://github.com/aws/aws-sdk-ruby/pull/2766/files

Prefix was not removed. Service sends back `AWS.SimpleQueueService.NonExistentQueue;` but the prefix part (AWS.SimpleQueueService.) needs to be parsed out. Otherwise we are creating a dynamic error that is not intended.