### PR TITLE
Fix Checksum algo spec to pass JRuby CI

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Updated `checksum_algorithm` plugin with a permanent fix to pass JRuby CI.
+* Issue - Updated `checksum_algorithm` plugin to use IO.copy_stream for JRuby.
 
 3.173.0 (2023-05-18)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Updated `checksum_algorithm` plugin with a permanent fix to pass JRuby CI.
+
 3.173.0 (2023-05-18)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
@@ -314,7 +314,7 @@ module Aws
           @io.rewind
         end
 
-        def read(length, buf)
+        def read(length, buf = nil)
           # account for possible leftover bytes at the end, if we have trailer bytes, send them
           if @trailer_io
             return @trailer_io.read(length, buf)

--- a/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
@@ -181,6 +181,7 @@ module Aws
             expect(headers['x-amz-decoded-content-length']).to eq('11')
             # capture the body by reading it into a new IO object
             body = StringIO.new
+            # IO.copy_stream is the same method used by Net::Http to write our body to the socket
             IO.copy_stream(context.http_request.body, body)
             body.rewind
             expect(body.read).to eq "b\r\nHello World\r\n0\r\nx-amz-checksum-sha256:pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=\r\n\r\n"

--- a/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
@@ -181,12 +181,6 @@ module Aws
             expect(headers['x-amz-decoded-content-length']).to eq('11')
             # capture the body by reading it into a new IO object
             body = StringIO.new
-            # if (defined?(JRUBY_VERSION))
-            #   body <<  context.http_request.body.read(1000, String.new) + context.http_request.body.read(1000, String.new)
-            # else
-            #   # IO.copy_stream is the same method used by Net::Http to write our body to the socket
-            #   IO.copy_stream(context.http_request.body, body)
-            # end
             IO.copy_stream(context.http_request.body, body)
             body.rewind
             expect(body.read).to eq "b\r\nHello World\r\n0\r\nx-amz-checksum-sha256:pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=\r\n\r\n"
@@ -196,11 +190,11 @@ module Aws
         end
 
         it 'handles header-based auth with checksum in header' do
-            client.stub_responses(:some_operation, -> (context) do
-              expect(context.http_request.headers['x-amz-checksum-sha256']).to eq('pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=')
-              expect(context.http_request.body.read).to eq('Hello World')
-            end)
-            client.some_operation(checksum_algorithm: 'sha256', body: 'Hello World')
+          client.stub_responses(:some_operation, -> (context) do
+            expect(context.http_request.headers['x-amz-checksum-sha256']).to eq('pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=')
+            expect(context.http_request.body.read).to eq('Hello World')
+          end)
+          client.some_operation(checksum_algorithm: 'sha256', body: 'Hello World')
         end
 
         it 'handles sigv4-streaming auth with checksum in trailer' do

--- a/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
@@ -181,12 +181,13 @@ module Aws
             expect(headers['x-amz-decoded-content-length']).to eq('11')
             # capture the body by reading it into a new IO object
             body = StringIO.new
-            if (defined?(JRUBY_VERSION))
-              body <<  context.http_request.body.read(1000, String.new) + context.http_request.body.read(1000, String.new)
-            else
-              # IO.copy_stream is the same method used by Net::Http to write our body to the socket
-              IO.copy_stream(context.http_request.body, body)
-            end
+            # if (defined?(JRUBY_VERSION))
+            #   body <<  context.http_request.body.read(1000, String.new) + context.http_request.body.read(1000, String.new)
+            # else
+            #   # IO.copy_stream is the same method used by Net::Http to write our body to the socket
+            #   IO.copy_stream(context.http_request.body, body)
+            # end
+            IO.copy_stream(context.http_request.body, body)
             body.rewind
             expect(body.read).to eq "b\r\nHello World\r\n0\r\nx-amz-checksum-sha256:pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4=\r\n\r\n"
           end)


### PR DESCRIPTION
Checksum algorithm's unit test relating to unsigned-payload auth has been failing JRuby CI. At the time of the plugin release, we quickly patched a fix to match with other SDKs' release timing.  This PR addresses a permanent fix so that JRuby CI passes.