### PR TITLE
Minimum of expiration time and expires_in for presigned urls

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -10,7 +10,7 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.174.0"
+    MINIMUM_CORE_VERSION = "3.176.0"
 
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add :expiration accessor to `CredentialProvider` and do not refresh credentials when checking expiration.
+
 3.175.0 (2023-06-15)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider.rb
@@ -6,6 +6,9 @@ module Aws
     # @return [Credentials]
     attr_reader :credentials
 
+    # @param [Time]
+    attr_reader :expiration
+
     # @return [Boolean]
     def set?
       !!credentials && credentials.set?

--- a/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb
@@ -36,12 +36,6 @@ module Aws
       @credentials
     end
 
-    # @return [Time,nil]
-    def expiration
-      refresh_if_near_expiration!
-      @expiration
-    end
-
     # Refresh credentials.
     # @return [void]
     def refresh!

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Select minimum expiration time for presigned urls between the expiration time option and the credential expiration time.
+
 1.126.0 (2023-06-16)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
@@ -49,7 +49,8 @@ module Aws
       #   before the presigned URL expires. Defaults to 15 minutes. As signature
       #   version 4 has a maximum expiry time of one week for presigned URLs,
       #   attempts to set this value to greater than one week (604800) will
-      #   raise an exception.
+      #   raise an exception. The min value of this option and the credentials
+      #   expiration time is used in the presigned URL.
       #
       # @option params [Time] :time (Time.now) The starting time for when the
       #   presigned url becomes active.
@@ -96,7 +97,8 @@ module Aws
       #   before the presigned URL expires. Defaults to 15 minutes. As signature
       #   version 4 has a maximum expiry time of one week for presigned URLs,
       #   attempts to set this value to greater than one week (604800) will
-      #   raise an exception.
+      #   raise an exception. The min value of this option and the credentials
+      #   expiration time is used in the presigned URL.
       #
       # @option params [Time] :time (Time.now) The starting time for when the
       #   presigned url becomes active.

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,8 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Select the minimum expiration time for presigned urls between
-  the expiration time option and the credential expiration time.
+* Feature - Select the minimum expiration time for presigned urls between the expiration time option and the credential expiration time.
 
 1.5.2 (2022-09-30)
 ------------------

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Feature - Select the minimum expiration time for presigned urls between
+  the expiration time option and the credential expiration time.
+
 1.5.2 (2022-09-30)
 ------------------
 

--- a/services.json
+++ b/services.json
@@ -918,7 +918,7 @@
     "models": "s3/2006-03-01",
     "dependencies": {
       "aws-sdk-kms": "~> 1",
-      "aws-sigv4": "~> 1.4"
+      "aws-sigv4": "~> 1.6"
     },
     "addPlugins": [
       "Aws::S3::Plugins::Accelerate",


### PR DESCRIPTION
Behavior change where `expiration` does not refresh. In doing so, we can check expiration on credentials freely and use it to calculate the expiration time of a presigned url. If expiration of credentials is shorter than the provided expires_in, use the credentials expiration.