### PR TITLE
Honor simple_attributes option in DynamoDB response stubs

### DIFF
--- a/gems/aws-sdk-dynamodb/CHANGELOG.md
+++ b/gems/aws-sdk-dynamodb/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix inconsistent behavior of `stub_responses` when `simple_attributes` is disabled.
+
 1.93.0 (2023-07-25)
 ------------------
 

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/customizations/client.rb
@@ -21,9 +21,11 @@ module Aws
       def data_to_http_resp(operation_name, data)
         api = config.api
         operation = api.operation(operation_name)
-        translator = Plugins::SimpleAttributes::ValueTranslator
-        translator = translator.new(operation.output, :marshal)
-        data = translator.apply(data)
+        if config.simple_attributes
+          translator = Plugins::SimpleAttributes::ValueTranslator
+          translator = translator.new(operation.output, :marshal)
+          data = translator.apply(data)
+        end
         ParamValidator.validate!(operation.output, data)
         protocol_helper.stub_data(api, operation, data)
       end

--- a/gems/aws-sdk-dynamodb/spec/client_spec.rb
+++ b/gems/aws-sdk-dynamodb/spec/client_spec.rb
@@ -137,6 +137,18 @@ module Aws
           expect(resp.item).to eq('id' => 'value')
         end
 
+        it 'observes the :simple_attributes configuration option' do
+          client = Client.new(stub_responses: true, simple_attributes: false)
+          expect {
+            client.stub_responses(:get_item, item: { 'id' => 'value' })
+          }.to raise_error(ArgumentError)
+
+          client.stub_responses(:get_item, item: { 'id' => { s: 'value' }})
+          resp = client.get_item(table_name: 'table', key: { 'id' => { s: 'value' }})
+          expect(resp.item.keys).to eq(['id'])
+          expect(resp.item['id'].s).to eq('value')
+        end
+
       end
 
       describe '#enumerable responses' do


### PR DESCRIPTION
Currently the behaviors of `stub_data` and `stub_responses` are inconsistent if `simple_attributes` is disabled.

```ruby
require 'aws-sdk-dynamodb'

puts Aws::DynamoDB::GEM_VERSION

c1 = Aws::DynamoDB::Client.new(stub_responses: true, simple_attributes: false)
c2 = Aws::DynamoDB::Client.new(stub_responses: true, simple_attributes: true)

c1.stub_responses(:get_item, lambda { |context|
  { item: { 'pk' => { n: '1' } } }
})
c2.stub_responses(:get_item, lambda { |context|
  { item: { 'pk' => 1 } }
})

p c1.get_item(table_name: 'test', key: { 'pk' => { n: '1' } }).item
p c1.stub_data(:get_item, item: { 'pk' => { n: '1' } }).item

p c2.get_item(table_name: 'test', key: { 'pk' => 1 }).item
p c2.stub_data(:get_item, item: { 'pk' => 1 }).item
```

```
1.93.0
{"pk"=>#<struct Aws::DynamoDB::Types::AttributeValue s=nil, n=nil, b=nil, ss=nil, ns=nil, bs=nil, m={"n"=>#<struct Aws::DynamoDB::Types::AttributeValue s="1", n=nil, b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=nil>}, l=nil, null=nil, bool=nil>}
{"pk"=>#<struct Aws::DynamoDB::Types::AttributeValue s=nil, n="1", b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=nil>}
{"pk"=>0.1e1}
{"pk"=>0.1e1}
```

This commit fixes the inconsistency.

```
{"pk"=>#<struct Aws::DynamoDB::Types::AttributeValue s=nil, n="1", b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=nil>}
{"pk"=>#<struct Aws::DynamoDB::Types::AttributeValue s=nil, n="1", b=nil, ss=nil, ns=nil, bs=nil, m=nil, l=nil, null=nil, bool=nil>}
{"pk"=>0.1e1}
{"pk"=>0.1e1}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
