### PR TITLE
Fix INI parsing of blank properties

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix parsing of ini files with mixes of blank properties and nested configurations.
+
 3.180.1 (2023-07-31)
 ------------------
 

--- a/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
@@ -38,6 +38,8 @@ s3 =
 aws_session_token = 
 s3 = 
    region = ap-southeast-1
+   blank_sub_property = 
+
       FILE
     }
 
@@ -68,6 +70,7 @@ s3 =
     it 'can parse blank properties mixed with nested configurations with spaces' do
       expect(parsed['blank-property']['aws_session_token']).to eq(' ')
       expect(parsed['blank-property']['s3']['region']).to eq('ap-southeast-1')
+      expect(parsed['blank-property']['s3']['blank_sub_property']).to eq(' ')
     end
   end
 end

--- a/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
@@ -34,34 +34,40 @@ sso_region = us-east-1
 s3 =
    endpoint_url = https://localhost:8000
 
+[profile blank-property]
+aws_session_token = 
+s3 = 
+   region = ap-southeast-1
       FILE
     }
 
+    let(:parsed) { IniParser.ini_parse(mock_config) }
+
     it 'can parse basic attributes' do
-      parsed = IniParser.ini_parse(mock_config)
       expect(parsed['default']['aws_access_key_id']).to eq("AKIABLAHBLAHBLAH")
       expect(parsed['other']['region']).to eq("ap-northeast-1")
     end
 
     it 'can parse and strip the "profile" prefix from profile names' do
-      parsed = IniParser.ini_parse(mock_config)
       expect(parsed['third']['region']).to eq("sa-east-1")
     end
 
     it 'can parse nested configuration' do
-      parsed = IniParser.ini_parse(mock_config)
       expect(parsed['default']['s3']['region']).to eq("us-west-2")
       expect(parsed['other']['s3']['region']).to eq("ap-southeast-1")
     end
 
     it 'can parse sso-session sections' do
-      parsed = IniParser.ini_parse(mock_config)
       expect(parsed['sso-session dev']['sso_region']).to eq('us-east-1')
     end
 
     it 'can parse services sections' do
-      parsed = IniParser.ini_parse(mock_config)
       expect(parsed['services test-services']['s3']['endpoint_url']).to eq('https://localhost:8000')
+    end
+
+    it 'can parse blank properties mixed with nested configurations with spaces' do
+      expect(parsed['blank-property']['aws_session_token']).to eq(' ')
+      expect(parsed['blank-property']['s3']['region']).to eq('ap-southeast-1')
     end
   end
 end


### PR DESCRIPTION
Fixes an issue introduced in #2880

Nested sections *may* have whitespace in their first line.  However, if there is not a nested property on the next non-blank line, then the blank value should be treated as a property.

Example:
```
[profile blank-property]
aws_session_token =  # has a space, this should be treated as a blank property
s3 =  # also has a space - but is followed by a subsection
   region = ap-southeast-1
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
