### PR TITLE
Handle sso session names with quotes/spaces

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add support for sso-session names with whitespace configured by the CLI `aws sso configure` command (#2895).
+
 3.180.2 (2023-08-07)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -385,7 +385,7 @@ module Aws
           sso_role_name: prof_config['sso_role_name'],
           sso_session: prof_config['sso_session'],
           sso_region: sso_region,
-          sso_start_url: prof_config['sso_start_url']
+          sso_start_url: sso_start_url
           )
       end
     end
@@ -458,12 +458,8 @@ module Aws
     end
 
     def sso_session(cfg, profile, sso_session_name)
-      sso_session = cfg["sso-session #{sso_session_name}"]
-
-      if sso_session.nil? && sso_session_name.match(/\s/)
-        # aws sso-configure may add quotes around sso session names with whitespace
-        sso_session = cfg["sso-session '#{sso_session_name}'"]
-      end
+      # aws sso-configure may add quotes around sso session names with whitespace
+      sso_session = cfg["sso-session #{sso_session_name}"] || cfg["sso-session '#{sso_session_name}'"]
 
       unless sso_session
         raise ArgumentError,

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -95,7 +95,7 @@ module Aws
 
       it 'prefers sso credentials over assume role' do
         expect(SSOCredentials).to receive(:new).with(
-          sso_start_url: nil,
+          sso_start_url: 'START_URL',
           sso_region: 'us-east-1',
           sso_account_id: 'SSO_ACCOUNT_ID',
           sso_role_name: 'SSO_ROLE_NAME',
@@ -163,7 +163,7 @@ module Aws
 
       it 'loads SSO credentials from when the session name has quotes' do
         expect(SSOCredentials).to receive(:new).with(
-          sso_start_url: nil,
+          sso_start_url: 'START_URL',
           sso_region: 'us-east-1',
           sso_account_id: 'SSO_ACCOUNT_ID',
           sso_role_name: 'SSO_ROLE_NAME',
@@ -389,7 +389,7 @@ module Aws
 
         it 'supports :source_profile from sso credentials' do
           expect(SSOCredentials).to receive(:new).with(
-            sso_start_url: nil,
+            sso_start_url: 'START_URL',
             sso_region: 'us-east-1',
             sso_account_id: 'SSO_ACCOUNT_ID',
             sso_role_name: 'SSO_ROLE_NAME',

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -161,6 +161,29 @@ module Aws
         ).to eq('SSO_AKID')
       end
 
+      it 'loads SSO credentials from when the session name has quotes' do
+        expect(SSOCredentials).to receive(:new).with(
+          sso_start_url: nil,
+          sso_region: 'us-east-1',
+          sso_account_id: 'SSO_ACCOUNT_ID',
+          sso_role_name: 'SSO_ROLE_NAME',
+          sso_session: 'sso test session'
+        ).and_return(
+          double(
+            'creds',
+            set?: true,
+            credentials: double(access_key_id: 'SSO_AKID')
+          )
+        )
+        client = ApiHelper.sample_rest_xml::Client.new(
+          profile: 'sso_creds_session_with_quotes',
+          token_provider: nil
+        )
+        expect(
+          client.config.credentials.credentials.access_key_id
+        ).to eq('SSO_AKID')
+      end
+
       it 'raises when attempting to load an incomplete SSO Profile' do
         expect do
           ApiHelper.sample_rest_xml::Client.new(

--- a/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/ini_parser_spec.rb
@@ -30,6 +30,9 @@ region = sa-east-1
 [sso-session dev]
 sso_region = us-east-1
 
+[sso-session 'profile with spaces']
+sso_region = us-east-1
+
 [services test-services]
 s3 =
    endpoint_url = https://localhost:8000

--- a/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
+++ b/gems/aws-sdk-core/spec/fixtures/credentials/mock_shared_config
@@ -169,6 +169,16 @@ sso_account_id = 123456789012
 source_profile = sso_creds
 role_arn = arn:aws:iam::123456789012:role/bar
 
+[profile sso_creds_session_with_quotes]
+sso_account_id = SSO_ACCOUNT_ID
+sso_role_name = SSO_ROLE_NAME
+sso_session = sso test session
+region = us-west-1
+
+[sso-session 'sso test session']
+sso_region = us-east-1
+sso_start_url = START_URL
+
 [profile sts_regional]
 aws_access_key_id = AKID
 aws_secret_access_key = SECRET


### PR DESCRIPTION
Fixes #2894 

The `aws configure sso` command will add quotes to sso-session names with whitespace.  Eg:
```
[sso-session 'My Profile']
```

This PR adds flexible support for loading those sso sessions (first checking for unquoted and then looking for the quoted version).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
