### PR TITLE
Fix transient spec failures

### DIFF
--- a/gems/aws-sdk-core/spec/aws/plugins/retries/clock_skew_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/retries/clock_skew_spec.rb
@@ -67,7 +67,7 @@ module Aws
           let(:server_time) { (Time.now.utc + 1000).to_s }
           it 'updates the corrections' do
             subject.update_clock_correction(context)
-            expect(subject.clock_correction(endpoint)).to be_within(1).of(1000)
+            expect(subject.clock_correction(endpoint)).to be_within(5).of(1000)
           end
 
           it 'does not update corrections for other end points' do
@@ -90,7 +90,7 @@ module Aws
           let(:server_time) { (Time.now.utc + 1000).to_s }
           it 'updates the skew' do
             subject.update_estimated_skew(context)
-            expect(subject.estimated_skew(endpoint)).to be_within(1).of(1000)
+            expect(subject.estimated_skew(endpoint)).to be_within(5).of(1000)
           end
         end
       end

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -170,11 +170,14 @@ module Aws
           end
 
           n_calls = 0
+          mutex = Mutex.new
           callback = proc do |bytes, part_sizes, total|
-            expect(bytes.size).to eq(4)
-            expect(part_sizes.size).to eq(4)
-            expect(total).to eq(20*one_meg)
-            n_calls += 1
+            mutex.synchronize do
+              expect(bytes.size).to eq(4)
+              expect(part_sizes.size).to eq(4)
+              expect(total).to eq(20*one_meg)
+              n_calls += 1
+            end
           end
 
           large_obj.download_file(path, progress_callback: callback)
@@ -218,10 +221,11 @@ module Aws
         end
 
         it 'raises an error when checksum validation fails on multipart' do
-          thread = double(value: nil)
           client.stub_responses(:get_object, {body: 'body', checksum_sha1: 'invalid'})
+
+          thread = double(value: nil)
+          allow(thread).to receive(:abort_on_exception=)
           expect(Thread).to receive(:new).and_yield.and_return(thread)
-          allow(thread).to receive(:abort_on_exception)
 
           expect do
             large_obj.download_file(path)
@@ -230,12 +234,15 @@ module Aws
 
         it 'calls on_checksum_validated on single part' do
           callback_data = {called: 0}
+          mutex = Mutex.new
           client.stub_responses(
             :get_object,
             {body: 'body', checksum_sha1: 'Agg/RXngimEkJcDBoX7ket14O5Q='}
           )
           callback = proc do |_alg, _resp|
-            callback_data[:called] += 1
+            mutex.synchronize do
+              callback_data[:called] += 1
+            end
           end
 
           small_obj.download_file(path, on_checksum_validated: callback)
@@ -252,8 +259,11 @@ module Aws
               checksum_sha1: 'Agg/RXngimEkJcDBoX7ket14O5Q='
             }
           )
+          mutex = Mutex.new
           callback = proc do |_alg, _resp|
-            callback_data[:called] += 1
+            mutex.synchronize do
+              callback_data[:called] += 1
+            end
           end
 
           large_obj.download_file(path, on_checksum_validated: callback)

--- a/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
@@ -173,11 +173,14 @@ module Aws
           client.stub_responses(:create_multipart_upload, upload_id: 'id')
           client.stub_responses(:complete_multipart_upload)
           result = []
+          mutex = Mutex.new
           allow(client).to receive(:upload_part) do |part|
-            result << [
-              part[:part_number],
-              part[:body].read.size
-            ]
+            mutex.synchronize do
+              result << [
+                part[:part_number],
+                part[:body].read.size
+              ]
+            end
           end.and_return(double(:upload_part, etag: 'etag'))
           object.upload_stream(part_size: 7 * 1024 * 1024) do |write_stream|
             17.times { write_stream << one_mb }
@@ -195,11 +198,14 @@ module Aws
           client.stub_responses(:create_multipart_upload, upload_id: 'id')
           client.stub_responses(:complete_multipart_upload)
           result = []
+          mutex = Mutex.new
           allow(client).to receive(:upload_part) do |part|
-            result << [
-              part[:part_number],
-              part[:body].read.size
-            ]
+            mutex.synchronize do
+              result << [
+                part[:part_number],
+                part[:body].read.size
+              ]
+            end
           end.and_return(double(:upload_part, etag: 'etag'))
           object.upload_stream do |write_stream|
             17.times { write_stream << one_mb }
@@ -375,11 +381,14 @@ module Aws
             client.stub_responses(:create_multipart_upload, upload_id: 'id')
             client.stub_responses(:complete_multipart_upload)
             result = []
+            mutex = Mutex.new
             allow(client).to receive(:upload_part) do |part|
-              result << [
-                part[:part_number],
-                part[:body].read.size
-              ]
+              mutex.synchronize do
+                result << [
+                  part[:part_number],
+                  part[:body].read.size
+                ]
+              end
             end.and_return(double(:upload_part, etag: 'etag'))
             object.upload_stream(tempfile: true) do |write_stream|
               17.times { write_stream << one_mb }

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -267,6 +267,7 @@ module Aws
 
           it 'polls until :idle_timeout seconds have past without messages' do
             now = Time.now
+            allow(Time).to receive(:now).and_return(now)
             one_minute_later = now + 61
             expect(client).to receive(:receive_message).exactly(10).times.
               and_return(client.stub_data(:receive_message))


### PR DESCRIPTION
Fixes to specs which have been transiently failing recently (mostly in JRuby).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
