### PR TITLE
Fix endpoint matcher host label validation

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix host label validation in endpoint matchers.
+
 3.181.0 (2023-08-22)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/endpoints/matchers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/endpoints/matchers.rb
@@ -83,7 +83,7 @@ module Aws
           return labels.all? { |l| valid_host_label?(l) }
         end
 
-        value.match?(/\A(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\z/)
+        !!(value =~ /\A(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\z/)
       end
 
       # AWS
@@ -122,7 +122,7 @@ module Aws
         end
 
         # must be between 3 and 63 characters long, no uppercase
-        value.match?(/\A(?!-)[a-z0-9-]{3,63}(?<!-)\z/) &&
+        value =~ /\A(?!-)[a-z0-9-]{3,63}(?<!-)\z/ &&
           # not an IP address
           value !~ /(\d+\.){3}\d+/
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/endpoints/matchers.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/endpoints/matchers.rb
@@ -79,11 +79,11 @@ module Aws
         return false if value.empty?
 
         if allow_sub_domains
-          labels = value.split('.')
+          labels = value.split('.', -1)
           return labels.all? { |l| valid_host_label?(l) }
         end
 
-        value =~ /\A(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\z/
+        value.match?(/\A(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\z/)
       end
 
       # AWS
@@ -114,13 +114,17 @@ module Aws
 
       # aws.isVirtualHostableS3Bucket(value: string, allowSubDomains: bool) bool
       def self.aws_virtual_hostable_s3_bucket?(value, allow_sub_domains = false)
-        !!(value.size < 64 &&
-          # regular naming rules
-          value =~ /^[a-z0-9][a-z0-9\-#{'.' if allow_sub_domains}]+[a-z0-9]$/ &&
-          # not IP address
-          value !~ /(\d+\.){3}\d+/ &&
-          # no dash and hyphen together
-          value !~ /[.-]{2}/)
+        return false if value.empty?
+
+        if allow_sub_domains
+          labels = value.split('.', -1)
+          return labels.all? { |l| aws_virtual_hostable_s3_bucket?(l) }
+        end
+
+        # must be between 3 and 63 characters long, no uppercase
+        value.match?(/\A(?!-)[a-z0-9-]{3,63}(?<!-)\z/) &&
+          # not an IP address
+          value !~ /(\d+\.){3}\d+/
       end
     end
   end

--- a/gems/aws-sdk-core/spec/aws/endpoints/test-cases/is-virtual-hostable-s3-bucket.json
+++ b/gems/aws-sdk-core/spec/aws/endpoints/test-cases/is-virtual-hostable-s3-bucket.json
@@ -24,6 +24,17 @@
       }
     },
     {
+      "documentation": "bucket--with-multiple-dash: isVirtualHostable",
+      "params": {
+        "BucketName": "bucket--with-multiple-dash"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket--with-multiple-dash.s3.amazonaws.com"
+        }
+      }
+    },
+    {
       "documentation": "BucketName: not isVirtualHostable (uppercase characters)",
       "params": {
         "BucketName": "BucketName"
@@ -139,6 +150,15 @@
       "documentation": "bucket.-name: not isVirtualHostable (invalid label, starts with a -)",
       "params": {
         "BucketName": "bucket.-name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket..name: not isVirtualHostable (consequetive dots)",
+      "params": {
+        "BucketName": "bucket..name"
       },
       "expect": {
         "error": "not isVirtualHostableS3Bucket"

--- a/gems/aws-sdk-core/spec/aws/endpoints/test-cases/valid-hostlabel.json
+++ b/gems/aws-sdk-core/spec/aws/endpoints/test-cases/valid-hostlabel.json
@@ -51,6 +51,33 @@
       "expect": {
         "error": "Invalid hostlabel"
       }
+    },
+    {
+      "documentation": "ending with a dot is not a valid hostlabel",
+      "params": {
+        "Region": "part1."
+      },
+      "expect": {
+        "error": "Invalid hostlabel"
+      }
+    },
+    {
+      "documentation": "multiple consecutive dots are not allowed",
+      "params": {
+        "Region": "part1..part2"
+      },
+      "expect": {
+        "error": "Invalid hostlabel"
+      }
+    },
+    {
+      "documentation": "labels cannot start with a dash",
+      "params": {
+        "Region": "part1.-part2"
+      },
+      "expect": {
+        "error": "Invalid hostlabel"
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes host label validation by correctly validating cases like "bucket--name" or "bucket-name."