### PR TITLE
Deduplicate message batches in SQS Poller

### DIFF
--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,7 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Update QueuePoller to handle duplicate messages so that these can be deleted successfully.
+* Feature - Update QueuePoller to handle duplicate messages before yielding. 
+* Issue - Fix message batch deletion issue in (#2913) by deduping the messages.
 
 
 1.63.0 (2023-09-27)

--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update QueuePoller to handle deduplicate messages so that those messages can be deleted successfully.
+
+
 1.63.0 (2023-09-27)
 ------------------
 

--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,9 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Update QueuePoller to handle duplicate messages before yielding. 
-* Issue - Fix message batch deletion issue in (#2913) by deduping the messages.
-
+* Feature - Update QueuePoller to handle duplicate messages before yielding. Fixes bug in (#2913).
 
 1.63.0 (2023-09-27)
 ------------------

--- a/gems/aws-sdk-sqs/CHANGELOG.md
+++ b/gems/aws-sdk-sqs/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Update QueuePoller to handle deduplicate messages so that those messages can be deleted successfully.
+* Issue - Update QueuePoller to handle duplicate messages so that these can be deleted successfully.
 
 
 1.63.0 (2023-09-27)

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -4,7 +4,6 @@ require 'set'
 
 module Aws
   module SQS
-
     # A utility class for long polling messages in a loop. **Messages are
     # automatically deleted from the queue at the end of the given block.**
     #
@@ -203,7 +202,6 @@ module Aws
     #   ```
     #
     class QueuePoller
-
       # @param [String] queue_url
       # @option options [Client] :client
       # @option (see #poll)
@@ -349,10 +347,10 @@ module Aws
       # @param [Integer] seconds
       def change_message_visibility_timeout(message, seconds)
         @client.change_message_visibility({
-          queue_url: @queue_url,
-          receipt_handle: message.receipt_handle,
-          visibility_timeout: seconds,
-        })
+                                            queue_url: @queue_url,
+                                            receipt_handle: message.receipt_handle,
+                                            visibility_timeout: seconds
+                                          })
       end
 
       # @note This method should be called from inside a {#poll} block.
@@ -360,9 +358,9 @@ module Aws
       #   `#receipt_handle`.
       def delete_message(message)
         @client.delete_message({
-          queue_url: @queue_url,
-          receipt_handle: message.receipt_handle,
-        })
+                                 queue_url: @queue_url,
+                                 receipt_handle: message.receipt_handle
+                               })
       end
 
       # @note This method should be called from inside a {#poll} block.
@@ -372,16 +370,16 @@ module Aws
       def delete_messages(messages)
         @client.delete_message_batch(
           queue_url: @queue_url,
-          entries: messages.map { |msg|
+          entries: messages.map do |msg|
             { id: msg.message_id, receipt_handle: msg.receipt_handle }
-          }
+          end
         )
       end
 
       private
 
       def get_messages(config, stats)
-        config.before_request.call(stats) if config.before_request
+        config.before_request&.call(stats)
         messages = send_request(config).messages
         stats.request_count += 1
         messages
@@ -392,17 +390,18 @@ module Aws
         @client.receive_message(params)
       end
 
-      def check_idle_timeout(config, stats, messages)
-        if config.idle_timeout
-          since = stats.last_message_received_at || stats.polling_started_at
-          idle_time = Time.now - since
-          throw :stop_polling if idle_time > config.idle_timeout
-        end
+      def check_idle_timeout(config, stats, _messages)
+        return unless config.idle_timeout
+
+        since = stats.last_message_received_at || stats.polling_started_at
+        idle_time = Time.now - since
+        throw :stop_polling if idle_time > config.idle_timeout
       end
 
       def process_messages(config, stats, messages, &block)
         stats.received_message_count += messages.count
         stats.last_message_received_at = Time.now
+        messages = dedupe_messages(messages).values
         catch(:skip_delete) do
           yield_messages(config, messages, stats, &block)
           delete_messages(messages) unless config.skip_delete
@@ -419,9 +418,19 @@ module Aws
         end
       end
 
+      def dedupe_messages(messages)
+        u_messages = {}
+        messages.each do |msg|
+          # duplicate messages will have a different receipt handle
+          # so must provide the most recently receipt handle
+          # when deleting the message
+          u_messages[msg.message_id] = msg
+        end
+        u_messages
+      end
+
       # Statistics tracked client-side by the {QueuePoller}.
       class PollerStats
-
         def initialize
           @request_count = 0
           @received_message_count = 0
@@ -444,27 +453,25 @@ module Aws
 
         # @return [Time,nil]
         attr_accessor :polling_stopped_at
-
       end
 
       # A read-only set of configuration used by the QueuePoller.
       class PollerConfig
+        # @api private
+        CONFIG_OPTIONS = Set.new(%i[
+                                   idle_timeout
+                                   skip_delete
+                                   before_request
+                                 ])
 
         # @api private
-        CONFIG_OPTIONS = Set.new([
-          :idle_timeout,
-          :skip_delete,
-          :before_request,
-        ])
-
-        # @api private
-        PARAM_OPTIONS = Set.new([
-          :wait_time_seconds,
-          :max_number_of_messages,
-          :visibility_timeout,
-          :attribute_names,
-          :message_attribute_names,
-        ])
+        PARAM_OPTIONS = Set.new(%i[
+                                  wait_time_seconds
+                                  max_number_of_messages
+                                  visibility_timeout
+                                  attribute_names
+                                  message_attribute_names
+                                ])
 
         # @return [Integer,nil]
         attr_reader :idle_timeout
@@ -487,7 +494,7 @@ module Aws
             max_number_of_messages: 1,
             visibility_timeout: nil,
             attribute_names: ['All'],
-            message_attribute_names: ['All'],
+            message_attribute_names: ['All']
           }
           options.each do |opt_name, value|
             if CONFIG_OPTIONS.include?(opt_name)
@@ -522,7 +529,6 @@ module Aws
           PARAM_OPTIONS.each { |key| hash[key] = @request_params[key] }
           hash
         end
-
       end
     end
   end

--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -424,6 +424,7 @@ module Aws
         # when deleting the message
         messages.each_with_object({}) do |msg, unique|
           unique[msg.message_id] = msg
+          unique
         end.values
       end
 

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -115,12 +115,14 @@ module Aws
           expect(client).to receive(:receive_message)
             .exactly(2).times
             .with(
-              queue_url: queue_url,
-              wait_time_seconds: 20,
-              max_number_of_messages: 1,
-              visibility_timeout: nil,
-              attribute_names: ['All'],
-              message_attribute_names: ['All']
+              {
+                queue_url: queue_url,
+                wait_time_seconds: 20,
+                max_number_of_messages: 1,
+                visibility_timeout: nil,
+                attribute_names: ['All'],
+                message_attribute_names: ['All']
+              }
             )
             .and_return(client.stub_data(:receive_message))
           poller.before_request do |stats|
@@ -165,7 +167,7 @@ module Aws
         it 'does not have duplicated messages and given the '\
            'most recently received duplicated message' do
           message_one = sample_message(1)
-          message_dup = message_one.dup
+          message_dup = message_one.dup.merge(receipt_handle: 'foo')
           client.stub_responses(
             :receive_message,
             [{ messages: [

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -154,7 +154,7 @@ module Aws
         it 'does not have duplicated messages and given the '\
            'most recently received duplicated message' do
           message_one = sample_message(1)
-          message_dup = message_one.dup.merge(body: 'foo')
+          message_dup = message_one.dup.merge(receipt_handle: 'foo')
           client.stub_responses(:receive_message, [
                                   { messages: [
                                     message_one,
@@ -167,7 +167,7 @@ module Aws
             yielded_arr << msg
           end
           expect(yielded_arr.count).to eq(1)
-          expect(yielded_arr[0].body).to eq(message_dup[:body])
+          expect(yielded_arr[0].receipt_handle).to eq(message_dup[:receipt_handle])
         end
 
         describe 'message deletion' do

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -130,10 +130,13 @@ module Aws
         end
 
         it 'yields received messages to the block' do
-          client.stub_responses(:receive_message, [
-                                  { messages: [sample_message] },
-                                  { messages: [] }
-                                ])
+          client.stub_responses(
+            :receive_message,
+            [
+              { messages: [sample_message] },
+              { messages: [] }
+            ]
+          )
           yielded = nil
           poller.poll(idle_timeout: 0) do |msg|
             yielded = msg
@@ -142,13 +145,16 @@ module Aws
         end
 
         it 'yields an array when max messages is greater than 1' do
-          client.stub_responses(:receive_message, [
-                                  { messages: [
-                                    sample_message(1),
-                                    sample_message(2)
-                                  ] },
-                                  { messages: [] }
-                                ])
+          client.stub_responses(
+            :receive_message,
+            [
+              { messages: [
+                sample_message(1),
+                sample_message(2)
+              ] },
+              { messages: [] }
+            ]
+          )
           yielded = nil
           poller.poll(idle_timeout: 0, max_number_of_messages: 2) do |messages|
             yielded = messages
@@ -160,18 +166,18 @@ module Aws
            'most recently received duplicated message' do
           message_one = sample_message(1)
           message_dup = message_one.dup
-          client.stub_responses(:receive_message, [
-                                  { messages: [
-                                    message_one,
-                                    message_dup
-                                  ] },
-                                  { messages: [] }
-                                ])
+          client.stub_responses(
+            :receive_message,
+            [{ messages: [
+              message_one,
+              message_dup
+            ] },
+             { messages: [] }]
+          )
           yielded_arr = []
           poller.poll(idle_timeout: 0) do |msg|
             yielded_arr << msg
           end
-          puts yielded_arr
           expect(yielded_arr.count).to eq(1)
           expect(yielded_arr[0].receipt_handle).to eq(message_dup[:receipt_handle])
         end
@@ -183,47 +189,57 @@ module Aws
                 queue_url: queue_url,
                 entries: [{ id: 'id', receipt_handle: 'rh' }]
               )
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message,
+              [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0) { |msg| }
           end
 
           it 'supports batch deletion' do
             expect(client).to receive(:delete_message_batch)
-              .with({
-                      queue_url: queue_url,
-                      entries: [
-                        { id: 'id-1', receipt_handle: 'rh-1' },
-                        { id: 'id-2', receipt_handle: 'rh-2' }
-                      ]
-                    })
-            client.stub_responses(:receive_message, [
-                                    { messages: [
-                                      sample_message(1),
-                                      sample_message(2)
-                                    ] },
-                                    { messages: [] }
-                                  ])
+              .with(
+                queue_url: queue_url,
+                entries: [
+                  { id: 'id-1', receipt_handle: 'rh-1' },
+                  { id: 'id-2', receipt_handle: 'rh-2' }
+                ]
+              )
+            client.stub_responses(
+              :receive_message,
+              [
+                { messages: [
+                  sample_message(1),
+                  sample_message(2)
+                ] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0) { |msg| }
           end
 
           it 'can skip default delete behavior' do
             expect(client).not_to receive(:delete_message_batch)
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0, skip_delete: true) { |msg| }
           end
 
           it 'skips delete when :skip_delete is thrown' do
             expect(client).not_to receive(:delete_message_batch)
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0) { |_msg| throw :skip_delete }
           end
 
@@ -232,10 +248,12 @@ module Aws
               queue_url: queue_url,
               receipt_handle: 'rh'
             )
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0, skip_delete: true) do |msg|
               poller.delete_message(msg)
             end
@@ -250,13 +268,15 @@ module Aws
                   { id: 'id-2', receipt_handle: 'rh-2' }
                 ]
               )
-            client.stub_responses(:receive_message, [
-                                    { messages: [
-                                      sample_message(1),
-                                      sample_message(2)
-                                    ] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [
+                  sample_message(1),
+                  sample_message(2)
+                ] },
+                { messages: [] }
+              ]
+            )
             poller.poll(idle_timeout: 0, max_number_of_messages: 10, skip_delete: true) do |messages|
               poller.delete_messages(messages)
             end
@@ -265,10 +285,12 @@ module Aws
 
         describe 'visibility timeouts' do
           it 'provides a method to update the visibility timeout of a message' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             resp = nil
             poller.poll(idle_timeout: 0) do |msg|
               resp = poller.change_message_visibility_timeout(msg, 60)
@@ -313,13 +335,15 @@ module Aws
 
         describe 'tracking stats' do
           it 'counts the number of requests made' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [] },
-                                    { messages: [sample_message] },
-                                    { messages: [] },
-                                    { messages: [sample_message] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [] },
+                { messages: [sample_message] },
+                { messages: [] },
+                { messages: [sample_message] }
+              ]
+            )
             poller.before_request do |stats|
               throw :stop_polling if stats.received_message_count == 3
             end
@@ -328,42 +352,48 @@ module Aws
           end
 
           it 'counts the number of messages yielded in single mode' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats.received_message_count).to eq(5)
           end
 
           it 'counts the number of messages yielded in batch mode' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [
-                                      sample_message,
-                                      sample_message,
-                                      sample_message
-                                    ] },
-                                    { messages: [
-                                      sample_message,
-                                      sample_message,
-                                      sample_message
-                                    ] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [
+                  sample_message,
+                  sample_message,
+                  sample_message
+                ] },
+                { messages: [
+                  sample_message,
+                  sample_message,
+                  sample_message
+                ] },
+                { messages: [] }
+              ]
+            )
             stats = poller.poll(idle_timeout: 0, max_number_of_messages: 3) { |msgs| }
             expect(stats.received_message_count).to eq(6)
           end
 
           it 'tracks when a message was most recently received' do
-            client.stub_responses(:receive_message,
-                                  [
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message,
+              [
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats.last_message_received_at).to be_kind_of(Time)
           end
@@ -388,12 +418,14 @@ module Aws
           end
 
           it 'yields a stats object to #poll' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             yielded = nil
             poller.poll(idle_timeout: 0) do |_msg, stats|
               yielded = stats
@@ -405,12 +437,14 @@ module Aws
           end
 
           it 'returns a stats object' do
-            client.stub_responses(:receive_message, [
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [sample_message] },
-                                    { messages: [] }
-                                  ])
+            client.stub_responses(
+              :receive_message, [
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [sample_message] },
+                { messages: [] }
+              ]
+            )
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats).to be_kind_of(QueuePoller::PollerStats)
             expect(stats.request_count).to eq(4)

--- a/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
+++ b/gems/aws-sdk-sqs/spec/queue_poller_spec.rb
@@ -5,12 +5,11 @@ require_relative 'spec_helper'
 module Aws
   module SQS
     describe QueuePoller do
-
-      let(:queue_url) { "https://sqs.us-east-1.amazonaws.com/12345/test" }
+      let(:queue_url) { 'https://sqs.us-east-1.amazonaws.com/12345/test' }
 
       let(:client) { Client.new(stub_responses: true) }
 
-      let(:options) {{ client: client }}
+      let(:options) { { client: client } }
 
       let(:poller) { QueuePoller.new(queue_url, options) }
 
@@ -18,20 +17,19 @@ module Aws
         suffix = n ? "-#{n}" : ''
         {
           message_id: "id#{suffix}",
-          receipt_handle:"rh#{suffix}",
-          body: "body#{suffix}",
+          receipt_handle: "rh#{suffix}",
+          body: "body#{suffix}"
         }
       end
 
       describe 'configuration' do
-
         it 'raises an error on unknown configuration options' do
-          expect {
-            QueuePoller.new(queue_url, client:client, bad:'option')
-          }.to raise_error(ArgumentError, 'invalid option :bad')
-          expect {
-            QueuePoller.new(queue_url, client:client).poll(bad:'option') {|m|}
-          }.to raise_error(ArgumentError, 'invalid option :bad')
+          expect do
+            QueuePoller.new(queue_url, client: client, bad: 'option')
+          end.to raise_error(ArgumentError, 'invalid option :bad')
+          expect do
+            QueuePoller.new(queue_url, client: client).poll(bad: 'option') { |m| }
+          end.to raise_error(ArgumentError, 'invalid option :bad')
         end
 
         it 'is immutable' do
@@ -44,44 +42,50 @@ module Aws
           expect(poller.default_config.idle_timeout).to be(nil)
           expect(poller.default_config.skip_delete).to be(false)
           expect(poller.default_config.before_request).to be(nil)
-          expect(poller.default_config.request_params).to eq({
-            wait_time_seconds: 20,
-            max_number_of_messages: 1,
-            visibility_timeout: nil,
-            attribute_names: ['All'],
-            message_attribute_names: ['All'],
-          })
+          expect(poller.default_config.request_params)
+            .to eq({
+                     wait_time_seconds: 20,
+                     max_number_of_messages: 1,
+                     visibility_timeout: nil,
+                     attribute_names: ['All'],
+                     message_attribute_names: ['All']
+                   })
         end
 
         it 'accepts configuration options to the constructor' do
           client = double('client')
           callback = double('callback')
           poller = QueuePoller.new(queue_url, {
-            client: client,
-            idle_timeout: 60,
-            skip_delete: true,
-            before_request: callback,
-            wait_time_seconds: 10,
-            max_number_of_messages: 10,
-            visibility_timeout: 10,
-            attribute_names: ['attr-name'],
-            message_attribute_names: ['msg-attr-name'],
-          })
+                                     client: client,
+                                     idle_timeout: 60,
+                                     skip_delete: true,
+                                     before_request: callback,
+                                     wait_time_seconds: 10,
+                                     max_number_of_messages: 10,
+                                     visibility_timeout: 10,
+                                     attribute_names: ['attr-name'],
+                                     message_attribute_names: ['msg-attr-name']
+                                   })
           expect(poller.client).to be(client)
           expect(poller.default_config.idle_timeout).to eq(60)
           expect(poller.default_config.skip_delete).to be(true)
           expect(poller.default_config.before_request).to be(callback)
-          expect(poller.default_config.request_params).to eq({
-            wait_time_seconds: 10,
-            max_number_of_messages: 10,
-            visibility_timeout: 10,
-            attribute_names: ['attr-name'],
-            message_attribute_names: ['msg-attr-name'],
-          })
+          expect(poller.default_config.request_params)
+            .to eq({
+                     wait_time_seconds: 10,
+                     max_number_of_messages: 10,
+                     visibility_timeout: 10,
+                     attribute_names: ['attr-name'],
+                     message_attribute_names: ['msg-attr-name']
+                   })
         end
 
         context 'max_number_of_messages validation' do
-          subject { QueuePoller.new(queue_url, client: client, max_number_of_messages: max_number_of_messages) }
+          subject do
+            QueuePoller.new(queue_url,
+                            client: client,
+                            max_number_of_messages: max_number_of_messages)
+          end
 
           let(:max_number_of_messages) { 1 }
 
@@ -93,7 +97,7 @@ module Aws
             context "with `max_number_of_messages: #{value.inspect}`" do
               let(:max_number_of_messages) { value }
 
-              it "raises an error" do
+              it 'raises an error' do
                 expect { subject }.to raise_error(ArgumentError, /positive integer/)
               end
             end
@@ -102,16 +106,18 @@ module Aws
       end
 
       describe '#poll' do
-
         it 'receives messages in a loop' do
-          expect(client).to receive(:receive_message).exactly(2).times.with({
-            queue_url: queue_url,
-            wait_time_seconds: 20,
-            max_number_of_messages: 1,
-            visibility_timeout: nil,
-            attribute_names: ['All'],
-            message_attribute_names: ['All'],
-          }).and_return(client.stub_data(:receive_message))
+          expect(client).to receive(:receive_message)
+            .exactly(2).times
+            .with({
+                    queue_url: queue_url,
+                    wait_time_seconds: 20,
+                    max_number_of_messages: 1,
+                    visibility_timeout: nil,
+                    attribute_names: ['All'],
+                    message_attribute_names: ['All']
+                  })
+            .and_return(client.stub_data(:receive_message))
           poller.before_request do |stats|
             throw :stop_polling if stats.request_count >= 2
           end
@@ -120,9 +126,9 @@ module Aws
 
         it 'yields received messages to the block' do
           client.stub_responses(:receive_message, [
-            { messages: [sample_message] },
-            { messages: [] },
-          ])
+                                  { messages: [sample_message] },
+                                  { messages: [] }
+                                ])
           yielded = nil
           poller.poll(idle_timeout: 0) do |msg|
             yielded = msg
@@ -132,133 +138,152 @@ module Aws
 
         it 'yields an array when max messages is greater than 1' do
           client.stub_responses(:receive_message, [
-            { messages: [
-                sample_message(1),
-                sample_message(2),
-              ]
-            },
-            { messages: [] },
-          ])
+                                  { messages: [
+                                    sample_message(1),
+                                    sample_message(2)
+                                  ] },
+                                  { messages: [] }
+                                ])
           yielded = nil
-          poller.poll(idle_timeout: 0, max_number_of_messages:2) do |messages|
+          poller.poll(idle_timeout: 0, max_number_of_messages: 2) do |messages|
             yielded = messages
           end
-          expect(yielded.map(&:body)).to eq(%w(body-1 body-2))
+          expect(yielded.map(&:body)).to eq(%w[body-1 body-2])
+        end
+
+        it 'does not have duplicated messages and given the '\
+           'most recently received duplicated message' do
+          message_one = sample_message(1)
+          message_dup = message_one.dup.merge(body: 'foo')
+          client.stub_responses(:receive_message, [
+                                  { messages: [
+                                    message_one,
+                                    message_dup
+                                  ] },
+                                  { messages: [] }
+                                ])
+          yielded_arr = []
+          poller.poll(idle_timeout: 0) do |msg|
+            yielded_arr << msg
+          end
+          expect(yielded_arr.count).to eq(1)
+          expect(yielded_arr[0].body).to eq(message_dup[:body])
         end
 
         describe 'message deletion' do
-
           it 'deletes the message at the end of the block' do
-            expect(client).to receive(:delete_message_batch).with({
-              queue_url: queue_url,
-              entries: [
-                { id: 'id', receipt_handle: 'rh' },
-              ]
-            })
+            expect(client).to receive(:delete_message_batch)
+              .with({
+                      queue_url: queue_url,
+                      entries: [
+                        { id: 'id', receipt_handle: 'rh' }
+                      ]
+                    })
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             poller.poll(idle_timeout: 0) { |msg| }
           end
 
           it 'supports batch deletion' do
-            expect(client).to receive(:delete_message_batch).with({
-              queue_url: queue_url,
-              entries: [
-                { id: 'id-1', receipt_handle: 'rh-1' },
-                { id: 'id-2', receipt_handle: 'rh-2' },
-              ]
-            })
+            expect(client).to receive(:delete_message_batch)
+              .with({
+                      queue_url: queue_url,
+                      entries: [
+                        { id: 'id-1', receipt_handle: 'rh-1' },
+                        { id: 'id-2', receipt_handle: 'rh-2' }
+                      ]
+                    })
             client.stub_responses(:receive_message, [
-              { messages: [
-                sample_message(1),
-                sample_message(2),
-              ] },
-              { messages: [] },
-            ])
+                                    { messages: [
+                                      sample_message(1),
+                                      sample_message(2)
+                                    ] },
+                                    { messages: [] }
+                                  ])
             poller.poll(idle_timeout: 0) { |msg| }
           end
 
           it 'can skip default delete behavior' do
             expect(client).not_to receive(:delete_message_batch)
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             poller.poll(idle_timeout: 0, skip_delete: true) { |msg| }
           end
 
           it 'skips delete when :skip_delete is thrown' do
             expect(client).not_to receive(:delete_message_batch)
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
-            poller.poll(idle_timeout: 0) { |msg| throw :skip_delete }
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
+            poller.poll(idle_timeout: 0) { |_msg| throw :skip_delete }
           end
 
           it 'provides the ability to manually delete messages' do
             expect(client).to receive(:delete_message).with({
-              queue_url: queue_url,
-              receipt_handle: 'rh',
-            })
+                                                              queue_url: queue_url,
+                                                              receipt_handle: 'rh'
+                                                            })
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             poller.poll(idle_timeout: 0, skip_delete: true) do |msg|
               poller.delete_message(msg)
             end
           end
 
           it 'provides the ability to manually delete message batches' do
-            expect(client).to receive(:delete_message_batch).with({
-              queue_url: queue_url,
-              entries: [
-                { id: 'id-1', receipt_handle: 'rh-1' },
-                { id: 'id-2', receipt_handle: 'rh-2' },
-              ]
-            })
+            expect(client).to receive(:delete_message_batch)
+              .with({
+                      queue_url: queue_url,
+                      entries: [
+                        { id: 'id-1', receipt_handle: 'rh-1' },
+                        { id: 'id-2', receipt_handle: 'rh-2' }
+                      ]
+                    })
             client.stub_responses(:receive_message, [
-              { messages: [
-                sample_message(1),
-                sample_message(2),
-              ] },
-              { messages: [] },
-            ])
-            poller.poll(idle_timeout:0, max_number_of_messages:10, skip_delete:true) do |messages|
+                                    { messages: [
+                                      sample_message(1),
+                                      sample_message(2)
+                                    ] },
+                                    { messages: [] }
+                                  ])
+            poller.poll(idle_timeout: 0, max_number_of_messages: 10, skip_delete: true) do |messages|
               poller.delete_messages(messages)
             end
           end
         end
 
         describe 'visibility timeouts' do
-
           it 'provides a method to update the visibility timeout of a message' do
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             resp = nil
-            poller.poll(idle_timeout:0) do |msg|
+            poller.poll(idle_timeout: 0) do |msg|
               resp = poller.change_message_visibility_timeout(msg, 60)
             end
             expect(resp.context.operation_name.to_s).to eq('change_message_visibility')
-            expect(resp.context.params).to eq({
-              queue_url: queue_url,
-              receipt_handle: 'rh',
-              visibility_timeout: 60,
-            })
+            expect(resp.context.params)
+              .to eq({
+                       queue_url: queue_url,
+                       receipt_handle: 'rh',
+                       visibility_timeout: 60
+                     })
           end
-
         end
 
         describe 'stop polling' do
-
           it 'polls until :stop_polling is thrown from #before_request' do
-            expect(client).to receive(:receive_message).exactly(10).times.
-              and_return(client.stub_data(:receive_message))
+            expect(client).to receive(:receive_message)
+              .exactly(10).times
+              .and_return(client.stub_data(:receive_message))
             poller.before_request do |stats|
               throw :stop_polling if stats.request_count == 10
             end
@@ -269,28 +294,28 @@ module Aws
             now = Time.now
             allow(Time).to receive(:now).and_return(now)
             one_minute_later = now + 61
-            expect(client).to receive(:receive_message).exactly(10).times.
-              and_return(client.stub_data(:receive_message))
+            expect(client).to receive(:receive_message)
+              .exactly(10).times
+              .and_return(client.stub_data(:receive_message))
             poller.before_request do |stats|
               if stats.request_count == 9
-                allow(Time).to receive(:now).and_return(one_minute_later)
+                allow(Time).to receive(:now)
+                  .and_return(one_minute_later)
               end
             end
             poller.poll(idle_timeout: 60) { |msg| }
           end
-
         end
 
         describe 'tracking stats' do
-
           it 'counts the number of requests made' do
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-              { messages: [sample_message] },
-              { messages: [] },
-              { messages: [sample_message] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [] },
+                                    { messages: [sample_message] },
+                                    { messages: [] },
+                                    { messages: [sample_message] }
+                                  ])
             poller.before_request do |stats|
               throw :stop_polling if stats.received_message_count == 3
             end
@@ -300,40 +325,41 @@ module Aws
 
           it 'counts the number of messages yielded in single mode' do
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats.received_message_count).to eq(5)
           end
 
           it 'counts the number of messages yielded in batch mode' do
             client.stub_responses(:receive_message, [
-              { messages: [
-                sample_message,
-                sample_message,
-                sample_message,
-              ] },
-              { messages: [
-                sample_message,
-                sample_message,
-                sample_message,
-              ] },
-              { messages: [] },
-            ])
-            stats = poller.poll(idle_timeout: 0, max_number_of_messages:3) { |msgs| }
+                                    { messages: [
+                                      sample_message,
+                                      sample_message,
+                                      sample_message
+                                    ] },
+                                    { messages: [
+                                      sample_message,
+                                      sample_message,
+                                      sample_message
+                                    ] },
+                                    { messages: [] }
+                                  ])
+            stats = poller.poll(idle_timeout: 0, max_number_of_messages: 3) { |msgs| }
             expect(stats.received_message_count).to eq(6)
           end
 
           it 'tracks when a message was most recently received' do
-            client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+            client.stub_responses(:receive_message,
+                                  [
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats.last_message_received_at).to be_kind_of(Time)
           end
@@ -359,13 +385,13 @@ module Aws
 
           it 'yields a stats object to #poll' do
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             yielded = nil
-            poller.poll(idle_timeout: 0) do |msg, stats|
+            poller.poll(idle_timeout: 0) do |_msg, stats|
               yielded = stats
             end
             expect(yielded).to be_kind_of(QueuePoller::PollerStats)
@@ -376,18 +402,17 @@ module Aws
 
           it 'returns a stats object' do
             client.stub_responses(:receive_message, [
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [sample_message] },
-              { messages: [] },
-            ])
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [sample_message] },
+                                    { messages: [] }
+                                  ])
             stats = poller.poll(idle_timeout: 0) { |msg| }
             expect(stats).to be_kind_of(QueuePoller::PollerStats)
             expect(stats.request_count).to eq(4)
             expect(stats.received_message_count).to eq(3)
             expect(stats.last_message_received_at).to be_kind_of(Time)
           end
-
         end
       end
     end


### PR DESCRIPTION
Fixes an issue mentioned in [#2908](https://github.com/aws/aws-sdk-ruby/issues/2913)

This PR ensures that there's no duplicate messages before yield. To successfully delete a message, it must have the "most recently receipt handle" as mentioned [here](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html) under Receipt handle.

Also, ran rubocop to keep the files up to today's standards.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the CHANGELOG.md file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with Feature or Issue in the correct format.

For generated code changes, please checkout below instructions first:
https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!

