### PR TITLE
Links DAX acronym in aws-sdk-dax documentation to product page

### DIFF
--- a/gems/aws-sdk-dax/CHANGELOG.md
+++ b/gems/aws-sdk-dax/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased Changes
 ------------------
 
+1.48.1 (2023-09-30)
+------------------
+
+* Documentation - Added product offering link in the client.
+
 1.48.0 (2023-09-27)
 ------------------
 

--- a/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
+++ b/gems/aws-sdk-dax/lib/aws-sdk-dax/client.rb
@@ -37,7 +37,7 @@ require 'aws-sdk-core/plugins/protocols/json_rpc.rb'
 Aws::Plugins::GlobalConfiguration.add_identifier(:dax)
 
 module Aws::DAX
-  # An API client for DAX.  To construct a client, you need to configure a `:region` and `:credentials`.
+  # An API client for [DAX](https://aws.amazon.com/dynamodb/dax/).  To construct a client, you need to configure a `:region` and `:credentials`.
   #
   #     client = Aws::DAX::Client.new(
   #       region: region_name,


### PR DESCRIPTION
This PR links the yardoc reference of `DAX` to the product offering to help clarify which service this gem is associated to. I was originally trying to look at the source for `aws-sdk-ecs` but landed here by mistake and was curious was DAX meant, so I looked it up and thought this might help others in the future. 