### PR TITLE
Deprecate GameSparks part 1

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -42,6 +42,8 @@ module BuildTools
       # WARNING: not thread-safe
       @services ||= begin
         manifest.inject({}) do |hash, (name, config)|
+          next hash if config['deprecated']
+
           service = build_service(name, config)
           hash[service.identifier] = service
           hash

--- a/gems/aws-sdk-gamesparks/CHANGELOG.md
+++ b/gems/aws-sdk-gamesparks/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Deprecated this service.
+
 1.11.0 (2023-09-27)
 ------------------
 

--- a/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
+++ b/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'aws-sdk-gamesparks'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
   spec.summary       = 'AWS SDK for Ruby - GameSparks'
-  spec.description   = 'Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
+  spec.description   = '[DEPRECATED] Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
   spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'

--- a/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
+++ b/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
   spec.required_ruby_version = '>= 2.3'
+
+  spec.post_install_message = 'aws-sdk-gamesparks is deprecated'
 end

--- a/services.json
+++ b/services.json
@@ -456,7 +456,7 @@
     "models": "gamelift/2015-10-01"
   },
   "GameSparks": {
-    "models": "gamesparks/2021-08-17"
+    "deprecated": true
   },
   "Glacier": {
     "models": "glacier/2012-06-01",


### PR DESCRIPTION
GameSparks is deprecated. This adds a deprecated field to services.json and service enumeration will skip it.

Manually add a changelog and change to gemspec to update description and add a post-install that it is deprecated.

Readme and aws-sdk-resources will be updated since GameSparks will no longer be part of service enumeration.