### PR TITLE
Deprecate GameSparks part 1 (again - new approach)

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/service.rb
@@ -20,6 +20,7 @@ module AwsSdkCodeGenerator
     # @option options [Hash<gem,version>] :gem_dependencies ({})
     # @option options [Hash] :add_plugins ({})
     # @option options [Hash] :remove_plugins ([])
+    # @option options [Boolean] :deprecated (false)
     def initialize(options)
       @name = options.fetch(:name)
       @identifier = name.downcase
@@ -57,6 +58,7 @@ module AwsSdkCodeGenerator
       @require_endpoint_discovery = api.fetch('operations', []).any? do |_, o|
         o['endpointdiscovery'] && o['endpointdiscovery']['required']
       end
+      @deprecated = options[:deprecated] || false
     end
 
     # @return [String] The service name, e.g. "S3"
@@ -145,6 +147,11 @@ module AwsSdkCodeGenerator
 
     # @return [Boolean] true if any operation requires endpoint_discovery
     attr_reader :require_endpoint_discovery
+
+    # @return [Boolean] true if the service is deprecated
+    def deprecated?
+      @deprecated
+    end
 
     # @api private
     def inspect

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/gemspec.rb
@@ -54,7 +54,9 @@ module AwsSdkCodeGenerator
           if @service.short_name != @service.full_name
             abbreviation = " (#{@service.short_name})"
           end
-          desc = "Official AWS Ruby gem for #{@service.full_name}#{abbreviation}. "
+          desc = ''
+          desc += '[DEPRECATED] ' if @service.deprecated?
+          desc += "Official AWS Ruby gem for #{@service.full_name}#{abbreviation}. "
           desc += 'This gem is part of the AWS SDK for Ruby.'
         end
         desc
@@ -70,6 +72,10 @@ module AwsSdkCodeGenerator
         @service.gem_dependencies.map do |gem, version|
           Dependency.new(gem, version)
         end
+      end
+
+      def deprecated?
+        @service.deprecated?
       end
 
       Dependency = Struct.new(:gem, :version)

--- a/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
@@ -28,4 +28,8 @@ Gem::Specification.new do |spec|
   {{/dependencies}}
 
   spec.required_ruby_version = '>= 2.3'
+
+  {{#deprecated?}}
+  spec.post_install_message = '{{gem_name}} is deprecated'
+  {{/deprecated?}}
 end

--- a/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/gemspec.mustache
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   {{/dependencies}}
 
   spec.required_ruby_version = '>= 2.3'
-
   {{#deprecated?}}
   spec.post_install_message = '{{gem_name}} is deprecated'
   {{/deprecated?}}

--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -42,8 +42,6 @@ module BuildTools
       # WARNING: not thread-safe
       @services ||= begin
         manifest.inject({}) do |hash, (name, config)|
-          next hash if config['deprecated']
-
           service = build_service(name, config)
           hash[service.identifier] = service
           hash
@@ -74,7 +72,8 @@ module BuildTools
         endpoint_tests: model_path('endpoint-tests-1.json', config['models']),
         gem_dependencies: gem_dependencies(api, config['dependencies'] || {}),
         add_plugins: add_plugins(api, config['addPlugins'] || []),
-        remove_plugins: config['removePlugins'] || []
+        remove_plugins: config['removePlugins'] || [],
+        deprecated: config['deprecated']
       )
     end
 

--- a/gems/aws-sdk-gamesparks/CHANGELOG.md
+++ b/gems/aws-sdk-gamesparks/CHANGELOG.md
@@ -1,12 +1,12 @@
 Unreleased Changes
 ------------------
 
+* Feature - Deprecated this service.
+
 1.12.0 (2023-10-17)
 ------------------
 
 * Feature - Code Generated Changes, see `./build_tools` or `aws-sdk-core`'s CHANGELOG.md for details.
-
-* Feature - Deprecated this service.
 
 1.11.0 (2023-09-27)
 ------------------

--- a/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
+++ b/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
   spec.required_ruby_version = '>= 2.3'
-
 end

--- a/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
+++ b/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'aws-sdk-gamesparks'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
   spec.summary       = 'AWS SDK for Ruby - GameSparks'
-  spec.description   = '[DEPRECATED] Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
+  spec.description   = 'Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
   spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.post_install_message = 'aws-sdk-gamesparks is deprecated'
 end

--- a/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
+++ b/gems/aws-sdk-gamesparks/aws-sdk-gamesparks.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'aws-sdk-gamesparks'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
   spec.summary       = 'AWS SDK for Ruby - GameSparks'
-  spec.description   = 'Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
+  spec.description   = '[DEPRECATED] Official AWS Ruby gem for GameSparks. This gem is part of the AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
   spec.homepage      = 'https://github.com/aws/aws-sdk-ruby'
   spec.license       = 'Apache-2.0'
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sigv4', '~> 1.1')
 
   spec.required_ruby_version = '>= 2.3'
+
+  spec.post_install_message = 'aws-sdk-gamesparks is deprecated'
 end

--- a/services.json
+++ b/services.json
@@ -456,7 +456,8 @@
     "models": "gamelift/2015-10-01"
   },
   "GameSparks": {
-    "models": "gamesparks/2021-08-17"
+    "models": "gamesparks/2021-08-17",
+    "deprecated": true
   },
   "Glacier": {
     "models": "glacier/2012-06-01",


### PR DESCRIPTION
Changes were reverted because deprecated: true needed to be removed to succeed release: https://github.com/aws/aws-sdk-ruby/commit/86c691f5f9636a8b0d218a54bb26489c9729ce7e#diff-fee98911c4846caeed54e476cfe7c70e0afd75e199ac2b048efc813a1e2380b0

Original part 1: https://github.com/aws/aws-sdk-ruby/pull/2926

New plan - add deprecate, release, then remove entry entirely.