### PR TITLE
(Static Stability) use provided expires_in in presigned url when credentials are expired

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - (Static Stability) use provided `expires_in` in presigned url when credentials are expired.
+
 1.6.0 (2023-06-28)
 ------------------
 

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -603,6 +603,78 @@ CHECKSUM
         end
 
       end
+
+      describe '#presign_url' do
+        let(:now) { Time.now }
+
+        let(:credentials) do
+          {
+            access_key_id: 'akid',
+            secret_access_key: 'secret',
+            session_token: nil,
+            expiration: expiration
+          }
+        end
+
+        let(:signer_options) do
+          {
+            service: 'SERVICE',
+            region: 'REGION',
+            credentials_provider: double(credentials: double(credentials), expiration: expiration),
+          }
+        end
+
+        let(:presign_options) do
+          {
+            http_method: 'GET',
+            url: 'https://example.com',
+            expires_in: expires_in,
+            time: now
+          }
+        end
+
+        let(:expires_in) { 60 }
+
+        let(:signer) { Signer.new(signer_options) }
+
+        context 'expiration is nil' do
+          let(:expiration) { nil }
+
+          it 'creates a presigned url with the provided expires_at' do
+            url = signer.presign_url(presign_options)
+            expect(url.to_s).to include('X-Amz-Expires=60')
+          end
+        end
+
+        context 'expiration is after expires_at' do
+          let(:expiration) { now + 3600 }
+
+          it 'creates a presigned url with the provided expires_at' do
+            url = signer.presign_url(presign_options)
+            expect(url.to_s).to include('X-Amz-Expires=60')
+          end
+        end
+
+        context 'expiration is before expires_at' do
+          let(:expiration) { now + 10 }
+
+          it 'creates a presigned url that expires at the credential expiration time' do
+            url = signer.presign_url(presign_options)
+            expect(url.to_s).to include('X-Amz-Expires=10')
+          end
+        end
+
+        context 'expired credentials (static stability)' do
+          let(:expiration) { now - 10 }
+
+          it 'creates a presigned url with the provided expires_at' do
+            url = signer.presign_url(presign_options)
+            expect(url.to_s).to include('X-Amz-Expires=60')
+          end
+        end
+
+
+      end
     end
   end
 end

--- a/gems/aws-sigv4/spec/signer_spec.rb
+++ b/gems/aws-sigv4/spec/signer_spec.rb
@@ -672,8 +672,6 @@ CHECKSUM
             expect(url.to_s).to include('X-Amz-Expires=60')
           end
         end
-
-
       end
     end
   end


### PR DESCRIPTION
See #2673 for original change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
