### PR TITLE
Fix Querystring Builder

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-json.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-json.json
@@ -218,7 +218,7 @@
     ]
   },
   {
-    "description": "Querystring of most supported types",
+    "description": "Querystring of supported scalar types",
     "metadata": {
       "protocol": "rest-json",
       "apiVersion": "2014-01-01"

--- a/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-json.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocols/input/rest-json.json
@@ -218,6 +218,95 @@
     ]
   },
   {
+    "description": "Querystring of most supported types",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "StringQuery": {
+            "shape": "StringType",
+            "location": "querystring",
+            "locationName": "str"
+          },
+          "ByteQuery": {
+            "shape": "ByteType",
+            "location": "querystring",
+            "locationName": "byt"
+          },
+          "IntegerQuery": {
+            "shape": "IntegerType",
+            "location": "querystring",
+            "locationName": "int"
+          },
+          "LongQuery": {
+            "shape": "LongType",
+            "location": "querystring",
+            "locationName": "lon"
+          },
+          "FloatQuery": {
+            "shape": "FloatType",
+            "location": "querystring",
+            "locationName": "flo"
+          },
+          "DoubleQuery": {
+            "shape": "DoubleType",
+            "location": "querystring",
+            "locationName": "dou"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "ByteType": {
+        "type": "byte"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "StringQuery": "a",
+          "ByteQuery": 1,
+          "IntegerQuery": 2,
+          "LongQuery": 3,
+          "FloatQuery": 1.0,
+          "DoubleQuery": 1.1
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?str=a&byt=1&int=2&lon=3&flo=1.0&dou=1.1",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "Querystring list of strings",
     "metadata": {
       "protocol": "rest-json",
@@ -262,6 +351,306 @@
         "serialized": {
           "body": "",
           "uri": "/path?item=value1&item=value2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of integers",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "IntegerList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "IntegerList": {
+        "type": "list",
+        "member": {
+          "shape": "Integer"
+        }
+      },
+      "Integer": {
+        "type": "integer"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": [1, 2]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=1&item=2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of doubles",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "DoubleList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "DoubleList": {
+        "type": "list",
+        "member": {
+          "shape": "Double"
+        }
+      },
+      "Double": {
+        "type": "double"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": [1.1, 2.2]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=1.1&item=2.2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of booleans",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "BooleanList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "BooleanList": {
+        "type": "list",
+        "member": {
+          "shape": "Boolean"
+        }
+      },
+      "Boolean": {
+        "type": "boolean"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": [true, false]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=true&item=false",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of timestamps",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "TimestampList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "TimestampList": {
+        "type": "list",
+        "member": {
+          "shape": "Timestamp"
+        }
+      },
+      "Timestamp": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=1970-01-01T00%3A00%3A01Z&item=1970-01-01T00%3A00%3A02Z",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of longs",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "LongList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "LongList": {
+        "type": "list",
+        "member": {
+          "shape": "Long"
+        }
+      },
+      "Long": {
+        "type": "long"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": [1, 2]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=1&item=2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Querystring list of floats",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "FloatList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "FloatList": {
+        "type": "list",
+        "member": {
+          "shape": "Float"
+        }
+      },
+      "Float": {
+        "type": "float"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": [1.1, 2.2]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=1.1&item=2.2",
           "headers": {}
         }
       }

--- a/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
@@ -106,9 +106,10 @@ def format_data(ref, src)
       params[key] = format_data(ref.shape.value, value)
     end
   when Seahorse::Model::Shapes::TimestampShape
-    if src.is_a?(String)
+    case src
+    when String
       Time.parse(src)
-    elsif src.is_a?(Integer)
+    else
       Time.at(src)
     end
   else src

--- a/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
+++ b/build_tools/aws-sdk-code-generator/spec/protocols_spec.rb
@@ -106,7 +106,11 @@ def format_data(ref, src)
       params[key] = format_data(ref.shape.value, value)
     end
   when Seahorse::Model::Shapes::TimestampShape
-    Time.at(src)
+    if src.is_a?(String)
+      Time.parse(src)
+    elsif src.is_a?(Integer)
+      Time.at(src)
+    end
   else src
   end
 end

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix QuerystringBuilder to support querystring lists of different types per rest-json protocol.
+* Issue - Fix query string support to lists of booleans, floats, integers and timestamps per rest-json protocol.
 
 3.185.1 (2023-10-05)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix QuerystringBuilder to handle different types.
+* Issue - Fix QuerystringBuilder to support querystring lists of different types per rest-json protocol.
 
 3.185.1 (2023-10-05)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix QuerystringBuilder to handle different types.
+
 3.185.1 (2023-10-05)
 ------------------
 


### PR DESCRIPTION
* Fixes an issue where Querystring Builder SHOULD support different types of shapes.
* Updated `rest-json.json` to cover most supported use-cases.
* Updated `querystring_builder.rb` file to today's rubocop standards


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
