### PR TITLE
Ensure exceptions have event_type if they are used in event streams

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -44,6 +44,7 @@ module AwsSdkCodeGenerator
         'box' => false,
         'fault' => false,
         'error' => false,
+        'exception_event' => false, # internal, exceptions cannot be events
         'deprecated' => false,
         'deprecatedMessage' => false,
         'type' => false,

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/types_module.rb
@@ -28,14 +28,13 @@ module AwsSdkCodeGenerator
 
       # @return [Array<StructClass>]
       def structures
-        unless @service.protocol_settings.empty?
-          if @service.protocol_settings['h2'] == 'eventstream'
-            @service.api['shapes'].each do |_, shape|
-              if shape['eventstream']
-                # add event trait to all members if not exists
-                shape['members'].each do |name, ref|
-                  @service.api['shapes'][ref['shape']]['event'] = true
-                end
+        @service.api['shapes'].each do |_, shape|
+          if shape['eventstream']
+            # add internal exception_event ctrait to all exceptions
+            # exceptions will not have the event trait.
+            shape['members'].each do |name, ref|
+              if !!@service.api['shapes'][ref['shape']]['exception']
+                @service.api['shapes'][ref['shape']]['exception_event'] = true
               end
             end
           end
@@ -93,7 +92,7 @@ module AwsSdkCodeGenerator
             sensitive: sensitive
           )
         end
-        if shape['event']
+        if shape['event'] || shape['exception_event']
           members << StructMember.new(member_name: 'event_type')
         end
         members

--- a/gems/aws-sdk-bedrockruntime/CHANGELOG.md
+++ b/gems/aws-sdk-bedrockruntime/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix exception handling with event streaming operations.
+
 1.1.0 (2023-10-02)
 ------------------
 

--- a/gems/aws-sdk-sagemakerruntime/CHANGELOG.md
+++ b/gems/aws-sdk-sagemakerruntime/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix exception handling with event streaming operations.
+
 1.56.0 (2023-09-27)
 ------------------
 


### PR DESCRIPTION
Fixes #2942

Exceptions used in event streams were hacked to add the "event" property, but only when the protocol was h2. S3's SelectObjectContent is the only operation where h2 is not used in event streams, but it has no exceptions, only event shapes - BedrockRuntime was the first case. Bedrock also re-uses exceptions for both an eventstream operation and normal operation.

Bedrock (and presumably SagemakerRuntime) exceptions would fail to parse because they are missing event_type. To fix this, we use an internal property to determine if the exception is used in events, and if so, add event_type. Since we no longer add "event," the exception is not added to errors either, unless it's used outside of event streaming context.