### PR TITLE
Fix flaky auth_token spec caused by time zone sensitivity

### DIFF
--- a/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
+++ b/gems/aws-sdk-rds/spec/auth_token_generator_spec.rb
@@ -68,7 +68,7 @@ module Aws
           )
           expect(token).to match(/#{endpoint}\/\?Action=connect/)
           expect(token).to match(/DBUser=#{user_name}/)
-          expect(token).to match(/X-Amz-Credential=akid%2F#{now.strftime('%Y%m%d')}%2F#{region}%2Frds-db%2Faws4_request/)
+          expect(token).to match(/X-Amz-Credential=akid%2F#{now.utc.strftime('%Y%m%d')}%2F#{region}%2Frds-db%2Faws4_request/)
         end
 
       end


### PR DESCRIPTION
The `RDS::AuthTokenGenerator` spec was written in a way that assumed the system clock is always UTC. This meant that the spec would always pass in CI, since the GitHub Actions runner uses UTC, but sometimes fail when running locally.
    
Specifically, after 4pm PST, the local date and UTC dates are different, leading to a mismatch in the expected and actual date.
    
This commit explicitly converts the date to UTC with `.utc` so that the spec now consistently passes regardless of local time zone.

✅ By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
