### PR TITLE
Fix abort on exceptions

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix thread interruptions in multipart `download_file`, `file_uploader` and `stream_uploader` (#2944).
+
 1.139.0 (2023-11-22)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -190,7 +190,6 @@ module Aws
               raise error
             end
           end
-          thread.abort_on_exception = true
           threads << thread
         end
         threads.map(&:value).compact

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -175,7 +175,6 @@ module Aws
               error
             end
           end
-          thread.abort_on_exception = true
           threads << thread
         end
         threads.map(&:value).compact

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -192,7 +192,6 @@ module Aws
               error
             end
           end
-          thread.abort_on_exception = true
           thread
         end
       end

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -231,24 +231,6 @@ module Aws
           end.to raise_error(Aws::Errors::ChecksumError)
         end
 
-        it 'does not interrupt the main thread when an exception occurs' do
-          client.stub_responses(
-            :get_object,
-            {
-              body: 'body',
-              checksum_sha1: 'invalid'
-            }
-          )
-
-          threads = []
-          threads << Thread.new do
-            expect { large_obj.download_file(path) }
-              .to raise_error(Aws::Errors::ChecksumError)
-          end
-
-          expect { threads.each(&:join) }.not_to raise_error
-        end
-
         it 'calls on_checksum_validated on single part' do
           callback_data = {called: 0}
           mutex = Mutex.new

--- a/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
@@ -170,7 +170,6 @@ module Aws
 
           it 'reports progress for multipart uploads' do
             thread = double(value: nil)
-            allow(thread).to receive(:abort_on_exception=)
             allow(Thread).to receive(:new).and_yield.and_return(thread)
 
             client.stub_responses(:create_multipart_upload, upload_id: 'id')


### PR DESCRIPTION
Fixes #2946 

* Removing `abort_on_exception` for  `file_downloader`, `multipart_stream_uploader` and `multipart_file_uploader`
* Updated existing specs
* After reviews, planning to update outdated styling
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
