### PR TITLE
Have param validator check and require AccountId

### DIFF
--- a/build_tools/customizations.rb
+++ b/build_tools/customizations.rb
@@ -207,7 +207,6 @@ module BuildTools
           label = label.delete('{}')
           input_shape = api['shapes'][operation['input']['shape']]
           input_shape['members'][label].delete('hostLabel')
-          input_shape['required']&.delete(label)
         end
       end
     end

--- a/gems/aws-sdk-s3control/CHANGELOG.md
+++ b/gems/aws-sdk-s3control/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow `AccountId` to be validated by the param validator rather than in `EndpointParameters`.
+
 1.74.0 (2023-11-28)
 ------------------
 


### PR DESCRIPTION
Undos removing "required" from shaperefs for AccountIds used in host prefix, using api model as the source.

Changes from:

```
[1] pry(Aws)> s3control.list_regional_buckets
ArgumentError: AccountId is required but not set
from /Users/mamuller/workplace/aws-sdk-ruby/gems/aws-sdk-s3control/lib/aws-sdk-s3control/endpoint_provider.rb:178:in `resolve_endpoint'
```

to

```
[1] pry(Aws)> s3control.list_regional_buckets
ArgumentError: missing required parameter params[:account_id]
from /Users/mamuller/workplace/aws-sdk-ruby/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb:35:in `validate!'
```