### PR TITLE
Fix re-initialization of some constants in seahorse client

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix re-initialization of some constants in seahorse client.
+
 3.190.1 (2023-12-20)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/h2/handler.rb
@@ -11,18 +11,22 @@ module Seahorse
     # @api private
     module H2
 
-      NETWORK_ERRORS = [
-        SocketError, EOFError, IOError, Timeout::Error,
-        Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
-        Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError,
-        Errno::EHOSTUNREACH, Errno::ECONNREFUSED,# OpenSSL::SSL::SSLErrorWaitReadable
-      ]
+      unless (const_defined?(:NETWORK_ERRORS))
+        NETWORK_ERRORS = [
+          SocketError, EOFError, IOError, Timeout::Error,
+          Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
+          Errno::EINVAL, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError,
+          Errno::EHOSTUNREACH, Errno::ECONNREFUSED,# OpenSSL::SSL::SSLErrorWaitReadable
+        ]
+      end
 
-      # @api private
-      DNS_ERROR_MESSAGES = [
-        'getaddrinfo: nodename nor servname provided, or not known', # MacOS
-        'getaddrinfo: Name or service not known' # GNU
-      ]
+      unless (const_defined?(:DNS_ERROR_MESSAGES))
+        # @api private
+        DNS_ERROR_MESSAGES = [
+          'getaddrinfo: nodename nor servname provided, or not known', # MacOS
+          'getaddrinfo: Name or service not known' # GNU
+        ]
+      }
 
       class Handler < Client::Handler
 

--- a/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/plugins/content_length.rb
@@ -10,9 +10,11 @@ module Seahorse
           # https://github.com/ruby/net-http/blob/master/lib/net/http/requests.rb
           # Methods without body are forwards compatible, because content-length
           # may be set for requests without body but is technically incorrect.
-          METHODS_WITHOUT_BODY = Set.new(
-            %w[GET HEAD DELETE OPTIONS TRACE COPY MOVE]
-          )
+          unless (const_defined?(:METHODS_WITHOUT_BODY))
+            METHODS_WITHOUT_BODY = Set.new(
+              %w[GET HEAD DELETE OPTIONS TRACE COPY MOVE]
+            )
+          end
 
           def call(context)
             body = context.http_request.body


### PR DESCRIPTION
I am using the AWS Ruby SDK indirectly, and my logs are full of messages like this (to the point of making my logs unreadable).
```
<redacted path>/aws-sdk-core-3.190.0/lib/seahorse/client/h2/handler.rb:14: warning: already initialized constant Seahorse::Client::H2::NETWORK_ERRORS
<redacted path>/aws-sdk-core-3.190.0/lib/seahorse/client/h2/handler.rb:14: warning: previous definition of NETWORK_ERRORS was here
```
There are three different constants for which this is happening. This PR adds a guard for the initialization of each of those three constants.

I am aware that it is possible that this _might_ also be fixed by changing the way the other gem is using the AWS SDK, but I have not investigated that because I do not have enough control/influence over that (non-public, proprietary) gem to make any changes to it.


**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
