### PR TITLE
Minor GitHub workflow changes

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -14,7 +14,5 @@ jobs:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
-                     If you wish to keep having a conversation with other community members under this issue feel free to do so.
+              This issue is now closed. Comments on closed issues are hard for our team to see. 
+              If you need more assistance, please open a new issue that references this one. 

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -34,8 +34,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 2
+        days-before-stale: 10
+        days-before-close: 4
         days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
We received some customer feedback that our closed issue message is too loud and too full of emoji, and our stale issue timings are a little too strict. This PR corrects these issues.
