### PR TITLE
Fix compression trait name

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -211,8 +211,8 @@ module AwsSdkCodeGenerator
               end
             end
 
-            if operation.key?('requestCompression')
-              o.request_compression = operation['requestCompression'].each_with_object([]) do | (k,v) , arr|
+            if operation.key?('requestcompression')
+              o.request_compression = operation['requestcompression'].each_with_object([]) do |(k, v), arr|
                 arr << { key: k.inspect, value: v.inspect }
               end
             end

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Fix compression trait name to `requestcompression`.
 
 3.191.0 (2024-01-26)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,5 @@
 Unreleased Changes
 ------------------
-* Issue - Fix compression trait name to `requestcompression`.
 
 3.191.0 (2024-01-26)
 ------------------

--- a/gems/aws-sdk-core/spec/aws/plugins/request_compression_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/request_compression_spec.rb
@@ -15,28 +15,28 @@ module Aws
           'SomeOperation' => {
             'http' => { 'method' => 'POST', 'requestUri' => '/' },
             'input' => { 'shape' => 'SomeOperationRequest' },
-            'requestCompression' => {
+            'requestcompression' => {
               'encodings' => ['gzip']
             }
           },
           'OperationWithNoSupportedEncoding' => {
             'http' => { 'method' => 'POST', 'requestUri' => '/' },
             'input' => { 'shape' => 'SomeOperationRequest' },
-            'requestCompression' => {
+            'requestcompression' => {
               'encodings' => ['custom']
             }
           },
           'OperationWithSomeSupportedEncodings' => {
             'http' => { 'method' => 'POST', 'requestUri' => '/' },
             'input' => { 'shape' => 'SomeOperationRequest' },
-            'requestCompression' => {
+            'requestcompression' => {
               'encodings' => %w[custom gzip]
             }
           },
           'OperationStreaming' => {
             'http' => { 'method' => 'POST', 'requestUri' => '/' },
             'input' => { 'shape' => 'OperationStreamingRequest' },
-            'requestCompression' => {
+            'requestcompression' => {
               'encodings' => ['gzip']
             }
           }
@@ -120,7 +120,7 @@ module Aws
         end
       end
 
-      context 'requestCompression operation' do
+      context 'requestcompression operation' do
         it 'compresses the body and sets the content-encoding header' do
           resp = client.some_operation(body: uncompressed_body)
           expect(resp.context.http_request.headers['Content-Encoding']).to eq('gzip')


### PR DESCRIPTION
RequestCompression trait name is all lowercase `requestcompression` in C2J models. 
This PR updates the codegen from `requestCompression` to the correct trait name.

Updated specs and manually tested against a service.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!