### PR TITLE
Remove dependencies on bigdecimal and base64

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove base64 as dependency.
+
 3.191.2 (2024-02-14)
 ------------------
 
@@ -20,7 +22,7 @@ Unreleased Changes
 
 * Feature - Updated Aws::SSO::Client with the latest API changes.
 
-* Feature - Add RBS signature files to support static type checking.
+* Feature - Add RBS signature files to support static type checking
 
 3.190.3 (2024-01-16)
 ------------------

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-partitions', '~> 1', '>= 1.651.0') # necessary for new endpoint resolution
   spec.add_dependency('aws-sigv4', '~> 1.8') # necessary for s3 express auth
   spec.add_dependency('aws-eventstream', '~> 1', '>= 1.3.0') # necessary for binary eventstream
-  spec.add_dependency('base64') # necessary for base64 encoding/decoding
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/version-3/gems/aws-sdk-core',

--- a/services.json
+++ b/services.json
@@ -371,19 +371,13 @@
       "Aws::DynamoDB::Plugins::ExtendedRetries",
       "Aws::DynamoDB::Plugins::SimpleAttributes",
       "Aws::DynamoDB::Plugins::CRC32Validation"
-    ],
-    "dependencies": {
-      "bigdecimal": null
-    }
+    ]
   },
   "DynamoDBStreams": {
     "models": "streams.dynamodb/2012-08-10",
     "addPlugins": [
       "Aws::DynamoDBStreams::Plugins::SimpleAttributes"
-    ],
-    "dependencies": {
-      "bigdecimal": null
-    }
+    ]
   },
   "EBS": {
     "models": "ebs/2019-11-02"


### PR DESCRIPTION
Forcing dependencies on bigdecimal may break use cases where dev tools are not available which were previously working.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
