### PR TITLE
Ensure output unions work correctly with stub_responses

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure output unions work correctly with stub_responses.
+
 3.191.3 (2024-02-20)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/param_validator.rb
@@ -71,9 +71,10 @@ module Aws
         end
 
         if @validate_required && shape.union
-          if values.length > 1
+          set_values = @input ? values.length : values.to_h.length
+          if set_values > 1
             errors << "multiple values provided to union at #{context} - must contain exactly one of the supported types: #{shape.member_names.join(', ')}"
-          elsif values.length == 0
+          elsif set_values == 0
             errors << "No values provided to union at #{context} - must contain exactly one of the supported types: #{shape.member_names.join(', ')}"
           end
         end

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -87,7 +87,7 @@ module Seahorse
           if @metadata.key?(key.to_s)
             @metadata[key.to_s]
           else
-            @shape[key.to_s]
+            @shape[key.to_s] if @shape
           end
         end
 

--- a/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
+++ b/gems/aws-sdk-core/lib/seahorse/model/shapes.rb
@@ -86,8 +86,8 @@ module Seahorse
         def [](key)
           if @metadata.key?(key.to_s)
             @metadata[key.to_s]
-          else
-            @shape[key.to_s] if @shape
+          elsif @shape
+            @shape[key.to_s]
           end
         end
 

--- a/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/stubbing/empty_stub_spec.rb
@@ -80,6 +80,41 @@ module Aws
         expect(stub[:is_truncated]).to be(false)
       end
 
+      it 'supports unions' do
+
+        svc = ApiHelper.sample_service(
+          api: {
+            'operations' => {
+              'OperationName' => {
+                'http' => { 'method' => 'POST', 'requestUri' => '/' },
+                'input' => { 'shape' => 'StructureShape' },
+                'output' => { 'shape' => 'StructureShape' }
+              }
+            },
+            'shapes' => {
+              'StructureShape' => {
+                'type' => 'structure',
+                'members' => {
+                  'UnionMember' => { 'shape' => 'UnionShape' },
+                }
+              },
+              'UnionShape' => {
+                'type' => 'structure',
+                'union' => true,
+                'members' => {
+                  'StringMember' => { 'shape' => 'String' },
+                }
+              },
+              'String' => { 'type' => 'string' },
+            }
+          }
+        )
+
+        client = svc::Client.new(stub_responses: true)
+        stub = client.operation_name
+        expect(stub.union_member.member).to eq(:string_member)
+      end
+
     end
   end
 end


### PR DESCRIPTION
When using stub_responses, union members in the stub data are treated as their Type class rather than a hash (as they are for input validation).  This causes param validators to fail because the `length` method always returns the number of members (rather than the number of members with values).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
