### PR TITLE
Fix IMDS utilities to use port from configured endpoints

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `EC2Metadata` and `InstanceProfileCredentials` to respect the port from a configured endpoint from code, ENV, or shared config.
+
 3.191.4 (2024-03-15)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/ec2_metadata.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/ec2_metadata.rb
@@ -183,7 +183,7 @@ module Aws
 
     def open_connection
       uri = URI.parse(@endpoint)
-      http = Net::HTTP.new(uri.hostname || @endpoint, @port || uri.port)
+      http = Net::HTTP.new(uri.hostname || @endpoint, uri.port || @port)
       http.open_timeout = @http_open_timeout
       http.read_timeout = @http_read_timeout
       http.set_debug_output(@http_debug_output) if @http_debug_output

--- a/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb
@@ -262,7 +262,7 @@ module Aws
 
     def open_connection
       uri = URI.parse(@endpoint)
-      http = Net::HTTP.new(uri.hostname || @endpoint, @port || uri.port)
+      http = Net::HTTP.new(uri.hostname || @endpoint, uri.port || @port)
       http.open_timeout = @http_open_timeout
       http.read_timeout = @http_read_timeout
       http.set_debug_output(@http_debug_output) if @http_debug_output


### PR DESCRIPTION
Fixes #2997

Use the configured endpoint's port if provided, otherwise, use the default port configured onto the class.