### PR TITLE
Respect thread_count argument in multipart uploads

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Fix bug where thread_count option was not being respected for multipart uploads.
+* Issue - Fix bug where thread_count option was not being respected for multipart uploads.
 
 1.146.0 (2024-03-18)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Fix bug where thread_count option was not being respected for multipart uploads.
+
 1.146.0 (2024-03-18)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -31,8 +31,10 @@ module Aws
       )
 
       # @option options [Client] :client
+      # @option options [Integer] :thread_count (THREAD_COUNT)
       def initialize(options = {})
         @client = options[:client] || Client.new
+        @thread_count = options[:thread_count]
       end
 
       # @return [Client]
@@ -44,14 +46,11 @@ module Aws
       # @option options [Proc] :progress_callback
       #   A Proc that will be called when each chunk of the upload is sent.
       #   It will be invoked with [bytes_read], [total_sizes]
-      # @option options [Integer] :thread_count (THREAD_COUNT)
-      #   The thread count to use for multipart uploads.
       # @return [Seahorse::Client::Response] - the CompleteMultipartUploadResponse
       def upload(source, options = {})
         if File.size(source) < MIN_PART_SIZE
           raise ArgumentError, FILE_TOO_SMALL
         else
-          @thread_count = options[:thread_count] || THREAD_COUNT
           upload_id = initiate_upload(options)
           parts = upload_parts(upload_id, source, options)
           complete_upload(upload_id, parts, options)
@@ -148,7 +147,7 @@ module Aws
         if (callback = options[:progress_callback])
           progress = MultipartProgress.new(pending, callback)
         end
-        @thread_count.times do
+        (@thread_count || options[:thread_count] || THREAD_COUNT).times do
           thread = Thread.new do
             begin
               while part = pending.shift

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -34,7 +34,7 @@ module Aws
       # @option options [Integer] :thread_count (THREAD_COUNT)
       def initialize(options = {})
         @client = options[:client] || Client.new
-        @thread_count = options[:thread_count]
+        @thread_count = options[:thread_count] || THREAD_COUNT
       end
 
       # @return [Client]
@@ -147,7 +147,7 @@ module Aws
         if (callback = options[:progress_callback])
           progress = MultipartProgress.new(pending, callback)
         end
-        (@thread_count || options[:thread_count] || THREAD_COUNT).times do
+        options.fetch(:thread_count, @thread_count).times do
           thread = Thread.new do
             begin
               while part = pending.shift

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -31,10 +31,8 @@ module Aws
       )
 
       # @option options [Client] :client
-      # @option options [Integer] :thread_count (THREAD_COUNT)
       def initialize(options = {})
         @client = options[:client] || Client.new
-        @thread_count = options[:thread_count] || THREAD_COUNT
       end
 
       # @return [Client]
@@ -46,11 +44,14 @@ module Aws
       # @option options [Proc] :progress_callback
       #   A Proc that will be called when each chunk of the upload is sent.
       #   It will be invoked with [bytes_read], [total_sizes]
+      # @option options [Integer] :thread_count (THREAD_COUNT)
+      #   The thread count to use for multipart uploads.
       # @return [Seahorse::Client::Response] - the CompleteMultipartUploadResponse
       def upload(source, options = {})
         if File.size(source) < MIN_PART_SIZE
           raise ArgumentError, FILE_TOO_SMALL
         else
+          @thread_count = options[:thread_count] || THREAD_COUNT
           upload_id = initiate_upload(options)
           parts = upload_parts(upload_id, source, options)
           complete_upload(upload_id, parts, options)

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -43,6 +43,7 @@ module Aws
 
       # @option options [required,String] :bucket
       # @option options [required,String] :key
+      # @option options [Integer] :thread_count (THREAD_COUNT)
       # @return [Seahorse::Client::Response] - the CompleteMultipartUploadResponse
       def upload(options = {}, &block)
         Aws::Plugins::UserAgent.feature('s3-transfer') do
@@ -152,7 +153,7 @@ module Aws
       def upload_in_threads(read_pipe, completed, options, thread_errors)
         mutex = Mutex.new
         part_number = 0
-        @thread_count.times.map do
+        options.fetch(:thread_count, @thread_count).times.map do
           thread = Thread.new do
             begin
               loop do

--- a/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_file_spec.rb
@@ -185,6 +185,21 @@ module Aws
             object.upload_file(one_hundred_seventeen_meg_file, content_type: 'text/plain', progress_callback: callback)
           end
 
+          it 'defaults to THREAD_COUNT without the thread_count option' do
+            expect(Thread).to receive(:new).exactly(S3::MultipartFileUploader::THREAD_COUNT).times.and_return(double(value: nil))
+            client.stub_responses(:create_multipart_upload, upload_id: 'id')
+            client.stub_responses(:complete_multipart_upload)
+            object.upload_file(one_hundred_seventeen_meg_file)
+          end
+
+          it 'respects the thread_count option' do
+            custom_thread_count = 20
+            expect(Thread).to receive(:new).exactly(custom_thread_count).times.and_return(double(value: nil))
+            client.stub_responses(:create_multipart_upload, upload_id: 'id')
+            client.stub_responses(:complete_multipart_upload)
+            object.upload_file(one_hundred_seventeen_meg_file, thread_count: custom_thread_count)
+          end
+
           it 'raises an error if the multipart threshold is too small' do
             error_msg = 'unable to multipart upload files smaller than 5MB'
             expect do

--- a/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/upload_stream_spec.rb
@@ -47,6 +47,14 @@ module Aws
           end
         end
 
+        it 'respects the thread_count option' do
+          custom_thread_count = 20
+          expect(Thread).to receive(:new).exactly(custom_thread_count).times.and_return(double(value: nil))
+          client.stub_responses(:create_multipart_upload, upload_id: 'id')
+          client.stub_responses(:complete_multipart_upload)
+          object.upload_stream(thread_count: custom_thread_count) { |_write_stream| }
+        end
+
         it 'uses multipart APIs' do
           client.stub_responses(:create_multipart_upload, upload_id: 'id')
           client.stub_responses(:upload_part, etag: 'etag')


### PR DESCRIPTION
## Observed Behavior ##
A method call in form:

`Aws::S3::Object.new(...).upload(some_file, thread_count: 20)`

only utilizes 10 threads to perform the upload.

## Reasoning ##
[MultipartFileUploader](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb#L37) accepts a `thread_count` option in its initializer, which sets instance variable `@thread_count` - however, [FileUploader](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/lib/aws-sdk-s3/file_uploader.rb#L42) only passes its own `@options` to the `MultipartFileUploader` initializer, which does not include a`thread_count` key value pair.

The `thread_count` option is therefore ignored due to the preference in method [upload_in_threads](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb#L150) for the instance variable value of `@thread_count`.

## Solution ##
I moved the setting of instance variable `@thread_count` to the [upload](https://github.com/kspector/aws-sdk-ruby/blob/a2bf07e28fddaa8534e6f24afd8253651f5e09f6/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb#L54) method, which mirrors the location of its counterpart in [FileDownloader -> download](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb#L27C9-L27C63).

I also added two tests to assert the default and specific cases, the [latter of which](https://github.com/kspector/aws-sdk-ruby/blob/a2bf07e28fddaa8534e6f24afd8253651f5e09f6/gems/aws-sdk-s3/spec/object/upload_file_spec.rb#L195-L201) fails against the current state of the codebase.