### PR TITLE
Retry throttling errors in CloudFormation waiters

### DIFF
--- a/apis/cloudformation/2010-05-15/waiters-2.json
+++ b/apis/cloudformation/2010-05-15/waiters-2.json
@@ -15,6 +15,11 @@
           "matcher": "error",
           "expected": "ValidationError",
           "state": "retry"
+        },
+        {
+          "matcher": "error",
+          "expected": "Throttling",
+          "state": "retry"
         }
       ]
     },
@@ -112,6 +117,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -173,6 +183,11 @@
           "expected": "UPDATE_COMPLETE",
           "matcher": "pathAny",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -259,6 +274,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -296,6 +316,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -321,6 +346,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -341,6 +371,11 @@
           "expected": "FAILED",
           "matcher": "path",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     }

--- a/gems/aws-sdk-cloudformation/CHANGELOG.md
+++ b/gems/aws-sdk-cloudformation/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Retry Throttling errors in CloudFormation waiters
+
 1.103.0 (2024-03-19)
 ------------------
 

--- a/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
+++ b/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb
@@ -113,6 +113,11 @@ module Aws::CloudFormation
                 "expected" => "ValidationError",
                 "matcher" => "error",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )
@@ -235,6 +240,11 @@ module Aws::CloudFormation
                 "expected" => "ValidationError",
                 "matcher" => "error",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )
@@ -321,6 +331,11 @@ module Aws::CloudFormation
                 "expected" => "UPDATE_COMPLETE",
                 "matcher" => "pathAny",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )
@@ -362,6 +377,11 @@ module Aws::CloudFormation
               {
                 "matcher" => "error",
                 "expected" => "ValidationError",
+                "state" => "retry"
+              },
+              {
+                "matcher" => "error",
+                "expected" => "Throttling",
                 "state" => "retry"
               }
             ]
@@ -437,6 +457,11 @@ module Aws::CloudFormation
                 "expected" => "ValidationError",
                 "matcher" => "error",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )
@@ -499,6 +524,11 @@ module Aws::CloudFormation
                 "expected" => "ValidationError",
                 "matcher" => "error",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )
@@ -606,6 +636,11 @@ module Aws::CloudFormation
                 "expected" => "FAILED",
                 "matcher" => "path",
                 "state" => "failure"
+              },
+              {
+                "expected" => "Throttling",
+                "matcher" => "error",
+                "state" => "retry"
               }
             ]
           )


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
