### PR TITLE
Drop nil values when deserializing json maps

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/protocol-tests-ignore-list.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocol-tests-ignore-list.json
@@ -19,7 +19,6 @@
   "rest-json" : {
     "input" : [],
     "output" : [
-      {"RestJsonDeserializesDenseSetMapAndSkipsNull": "Seeking clarification from Smithy"}
     ]
   },
   "rest-xml" : {

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Omit keys with `nil` value in json maps when deserializing.
+
 3.192.0 (2024-04-16)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Omit keys with `nil` value in json maps when deserializing.
+* Issue - Drop key/value pair if value is `nil` when deserializing json maps.
 
 3.192.0 (2024-04-16)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -70,6 +70,7 @@ module Aws
         target = {} if target.nil?
         values.each do |key, value|
           next if value.nil?
+
           target[key] = parse_ref(ref.shape.value, value)
         end
         target

--- a/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/json/parser.rb
@@ -69,6 +69,7 @@ module Aws
       def map(ref, values, target = nil)
         target = {} if target.nil?
         values.each do |key, value|
+          next if value.nil?
           target[key] = parse_ref(ref.shape.value, value)
         end
         target


### PR DESCRIPTION
This PR addresses a fix to pass this specific [test case](https://github.com/aws/aws-sdk-ruby/blob/d7ef82fc2b40ab1fa41f0d3a1232f1630f50d3ee/build_tools/aws-sdk-code-generator/spec/protocol-tests/output/rest-json.json#L2816).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
