### PR TITLE
Fix Aws::EC2::Resource not to set max_results automatically when the options contains the parameter that cannot be used with the parameter max_results

### DIFF
--- a/gems/aws-sdk-ec2/CHANGELOG.md
+++ b/gems/aws-sdk-ec2/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix Aws::EC2::Resource not to set max_results automatically when the options contains the parameter that cannot be used with the parameter max_results.
+
 1.457.0 (2024-05-13)
 ------------------
 

--- a/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
+++ b/gems/aws-sdk-ec2/lib/aws-sdk-ec2/customizations/resource.rb
@@ -9,22 +9,38 @@ module Aws
     # to ensure results are paginated.
     module ResourcePaginationFix
       def images(options = {})
-        options[:max_results] ||= 1000
+        # Prevent the error:
+        # The parameter imageIdsSet cannot be used with the parameter maxResults
+        if options[:image_ids].nil? || options[:image_ids].empty?
+          options[:max_results] ||= 1000
+        end
         super(options)
       end
 
       def instances(options = {})
-        options[:max_results] ||= 1000
+        # Prevent the error:
+        # The parameter instancesSet cannot be used with the parameter maxResults
+        if options[:instance_ids].nil? || options[:instance_ids].empty?
+          options[:max_results] ||= 1000
+        end
         super(options)
       end
 
       def snapshots(options = {})
-        options[:max_results] ||= 1000
+        # Prevent the error:
+        # The parameter snapshotSet cannot be used with the parameter maxResults
+        if options[:snapshot_ids].nil? || options[:snapshot_ids].empty?
+          options[:max_results] ||= 1000
+        end
         super(options)
       end
 
       def volumes(options = {})
-        options[:max_results] ||= 1000
+        # Prevent the error:
+        # The parameter volumeIdsSet cannot be used with the parameter maxResults
+        if options[:volume_ids].nil? || options[:volume_ids].empty?
+          options[:max_results] ||= 1000
+        end
         super(options)
       end
     end

--- a/gems/aws-sdk-ec2/spec/resource_spec.rb
+++ b/gems/aws-sdk-ec2/spec/resource_spec.rb
@@ -10,6 +10,188 @@ module Aws
 
       let(:ec2) { Resource.new(client: client) }
 
+      describe '#images' do
+
+        it 'sets max_results parameter when options without image_ids' do
+          expect(ec2.client).to receive(:describe_images).with(
+            {
+              filters: [
+                {
+                  name: 'image-type',
+                  values: ['machine'],
+                },
+              ],
+              max_results: 1000,
+            }
+          ).and_call_original
+
+          ec2.images(
+            filters: [
+              {
+                name: 'image-type',
+                values: ['machine'],
+              },
+            ],
+          ).to_a
+        end
+
+        it 'does not set max_results parameter when options with image_ids' do
+          expect(ec2.client).to receive(:describe_images).with(
+            {
+              filters: [
+                {
+                  name: 'image-type',
+                  values: ['machine'],
+                },
+              ],
+              image_ids: ['ami-12345678', 'ami-87654321'],
+            }
+          ).and_call_original
+
+          ec2.images(
+            filters: [
+              {
+                name: 'image-type',
+                values: ['machine'],
+              },
+            ],
+            image_ids: ['ami-12345678', 'ami-87654321'],
+          ).to_a
+        end
+
+      end
+
+      describe '#instances' do
+
+        it 'sets max_results parameter when options without instance_ids' do
+          expect(ec2.client).to receive(:describe_instances).with(
+            {
+              filters: [
+                {
+                  name: 'image-id',
+                  values: ['ami-12345678', 'ami-87654321'],
+                },
+              ],
+              max_results: 1000,
+            }
+          ).and_call_original
+
+          ec2.instances(
+            filters: [
+              {
+                name: 'image-id',
+                values: ['ami-12345678', 'ami-87654321'],
+              },
+            ],
+          ).to_a
+        end
+
+        it 'does not set max_results parameter when options with instance_ids' do
+          expect(ec2.client).to receive(:describe_instances).with(
+            {
+              filters: [
+                {
+                  name: 'image-id',
+                  values: ['ami-12345678', 'ami-87654321'],
+                },
+              ],
+              instance_ids: ['ami-12345678', 'ami-87654321'],
+            }
+          ).and_call_original
+
+          ec2.instances(
+            filters: [
+              {
+                name: 'image-id',
+                values: ['ami-12345678', 'ami-87654321'],
+              },
+            ],
+            instance_ids: ['ami-12345678', 'ami-87654321'],
+          ).to_a
+        end
+
+      end
+
+      describe '#snapshots' do
+
+        it 'sets max_results parameter when options without snapshot_ids' do
+          expect(ec2.client).to receive(:describe_snapshots).with(
+            {
+              owner_ids: ['self'],
+              max_results: 1000,
+            }
+          ).and_call_original
+
+          ec2.snapshots(
+            owner_ids: ['self'],
+          ).to_a
+        end
+
+        it 'does not set max_results parameter when options with snapshot_ids' do
+          expect(ec2.client).to receive(:describe_snapshots).with(
+            {
+              snapshot_ids: [
+                'snap-12345678',
+                'snap-87654321',
+              ],
+            }
+          ).and_call_original
+
+          ec2.snapshots(
+            snapshot_ids: [
+              'snap-12345678',
+              'snap-87654321',
+            ],
+          ).to_a
+        end
+
+      end
+
+      describe '#volumes' do
+
+        it 'sets max_results parameter when options without volume_ids' do
+          expect(ec2.client).to receive(:describe_volumes).with(
+            {
+              filters: [
+                {
+                  name: 'snapshot-id',
+                  values: ['snap-12345678'],
+                },
+              ],
+              max_results: 1000,
+            }
+          ).and_call_original
+
+          ec2.volumes(
+            filters: [
+              {
+                name: 'snapshot-id',
+                values: ['snap-12345678'],
+              },
+            ],
+          ).to_a
+        end
+
+        it 'does not set max_results parameter when options with volume_ids' do
+          expect(ec2.client).to receive(:describe_volumes).with(
+            {
+              volume_ids: [
+                'snap-12345678',
+                'snap-87654321',
+              ],
+            }
+          ).and_call_original
+
+          ec2.volumes(
+            volume_ids: [
+              'snap-12345678',
+              'snap-87654321',
+            ],
+          ).to_a
+        end
+
+      end
+
       describe '#create_tags' do
 
         it 'returns a batch of created tags, the product of ids and tags' do


### PR DESCRIPTION
This PR fixes https://github.com/aws/aws-sdk-ruby/issues/3028

- Added conditional `max_results` inclusion.
- Added specs for the change.

If any fixes/updates are needed, please let me know.
Thank you!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
