### PR TITLE
Fix UFC offset when deserializing `iso8601` timestamp values

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure no UTC offset when deserializing `iso8601` timestamp format values.
+
 3.196.1 (2024-05-14)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
@@ -90,7 +90,7 @@ module Aws
         end
       end
 
-      # @param [String, Integer] value
+      # @param [String] value
       # @return [Time]
       def deserialize_time(value)
         case value

--- a/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
@@ -95,11 +95,11 @@ module Aws
       def deserialize_time(value)
         case value
         when nil then nil
-        when /^\d+$/ then Time.at(value.to_i)
+        when /^\d+$/ then Time.at(value.to_i).utc
         else
           begin
-            fractional_time = Time.parse(value).utc.to_f
-            Time.at(fractional_time)
+            fractional_time = Time.parse(value).to_f
+            Time.at(fractional_time).utc
           rescue ArgumentError
             raise "unhandled timestamp format `#{value}'"
           end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/util.rb
@@ -95,7 +95,7 @@ module Aws
       def deserialize_time(value)
         case value
         when nil then nil
-        when /^\d+$/ then Time.at(value.to_i).utc
+        when /^[\d.]+$/ then Time.at(value.to_f).utc
         else
           begin
             fractional_time = Time.parse(value).to_f

--- a/gems/aws-sdk-core/spec/aws/util_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/util_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+module Aws
+  describe Util do
+    describe '.deserialize_time' do
+      it 'correctly parses when given value is nil' do
+        expect(Util.deserialize_time(nil)).to be_nil
+      end
+
+      it 'correctly parses when given value is a numeric string' do
+        expect(Util.deserialize_time('946702800').to_s)
+          .to eq('2000-01-01 05:00:00 UTC')
+      end
+
+      it 'correctly parses when given value is a string' do
+        expect(Util.deserialize_time('2000-01-02T20:34:56.123Z').to_s)
+          .to eq('2000-01-02 20:34:56 UTC')
+      end
+    end
+  end
+end

--- a/gems/aws-sdk-core/spec/aws/util_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/util_spec.rb
@@ -5,18 +5,20 @@ require_relative '../spec_helper'
 module Aws
   describe Util do
     describe '.deserialize_time' do
+      let(:time) { Time.at(946_845_296.123) }
+
       it 'correctly parses when given value is nil' do
         expect(Util.deserialize_time(nil)).to be_nil
       end
 
       it 'correctly parses when given value is a numeric string' do
-        expect(Util.deserialize_time('946702800').to_s)
-          .to eq('2000-01-01 05:00:00 UTC')
+        value = time.to_f.to_s
+        expect(Util.deserialize_time(value)).to eq(time.utc)
       end
 
       it 'correctly parses when given value is a string' do
-        expect(Util.deserialize_time('2000-01-02T20:34:56.123Z').to_s)
-          .to eq('2000-01-02 20:34:56 UTC')
+        value = time.strftime '%Y-%m-%d %H:%M:%S.%N %z' # preserves frac secs
+        expect(Util.deserialize_time(value)).to eq(time.utc)
       end
     end
   end


### PR DESCRIPTION
This fix is to ensure that there are no UFC offset when deserializing. 

Previously, there were some adjustments made to deserializing timestamps so that it handles fractional seconds (to pass smithy protocol-tests).  However, when `Time.at(...)` is used, the value always reflect local system time by default. 


Also, see [Smithy Docs](https://smithy.io/2.0/spec/protocol-traits.html#timestampformat-trait) on timestamp formats:
> Date time as defined by the date-time production in [RFC 3339#section-5.6](https://datatracker.ietf.org/doc/html/rfc3339.html#section-5.6) with optional millisecond precision but no UTC offset (for example, 1985-04-12T23:20:50.520Z). Values that are more granular than millisecond precision SHOULD be truncated to fit millisecond precision. Deserializers SHOULD parse date-time values that contain offsets gracefully by normalizing them to UTC.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
