### PR TITLE
Support array arguments for process credentials

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support an array of string arguments for `Aws::ProcessCredentials` to be executed by `system`.
+
 3.197.0 (2024-06-05)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/process_credentials.rb
@@ -44,13 +44,12 @@ module Aws
 
     def credentials_from_process
       r, w = IO.pipe
-      system(*@process, out: w)
+      success = system(*@process, out: w)
       w.close
       raw_out = r.read
       r.close
-      process_status = $?
 
-      unless process_status&.success?
+      unless success
         raise Errors::InvalidProcessCredentialsPayload.new(
           'credential_process provider failure, the credential process had '\
           'non zero exit status and failed to provide credentials'

--- a/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
@@ -9,19 +9,8 @@ module Aws
       allow(Dir).to receive(:home).and_raise(ArgumentError)
     end
 
-    def mock_process(process, output, success: true)
-      # JRuby has some issue with rspec and system (with multiple args) that
-      # produces no output
-      if defined?(JRUBY_VERSION)
-        allow_any_instance_of(ProcessCredentials).to receive(:system)
-          .with(*process, out: anything).and_return(success)
-        allow_any_instance_of(IO).to receive(:read).and_return(output)
-      end
-    end
-
     it 'will read credentials from a process' do
       process = %w[echo {"Version":1,"AccessKeyId":"AK_PROC1","SecretAccessKey":"SECRET_AK_PROC1","SessionToken":"TOKEN_PROC1"}]
-      mock_process(process, process[1])
       creds = ProcessCredentials.new(process).credentials
       expect(creds.access_key_id).to eq('AK_PROC1')
       expect(creds.secret_access_key).to eq('SECRET_AK_PROC1')
@@ -30,7 +19,6 @@ module Aws
 
     it 'will throw an error when invalid JSON is returned' do
       process = %w[echo {"Version":3,"AccessKeyId":"","SecretAccessKey":""\']
-      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -38,7 +26,6 @@ module Aws
 
     it 'will throw an error when the process credentials payload version is invalid' do
       process = %w[echo {"Version":3,"AccessKeyId":"","SecretAccessKey":""}]
-      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -46,7 +33,6 @@ module Aws
 
     it 'will throw an error when the process credentials payload is malformed' do
       process = %w[echo {"Version":1}]
-      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -54,7 +40,6 @@ module Aws
 
     it 'will throw an error when the credential process has a nonzero exit status' do
       process = ['fake_proc']
-      mock_process(process, process[1], success: false)
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -65,7 +50,7 @@ module Aws
         expect_any_instance_of(ProcessCredentials)
           .to receive(:warn).with(/array of system arguments/)
       end
-    
+
       it 'will read credentials from a process' do
         process = 'echo \'{"Version":1,"AccessKeyId":"AK_PROC1","SecretAccessKey":"SECRET_AK_PROC1","SessionToken":"TOKEN_PROC1"}\''
         creds = ProcessCredentials.new(process).credentials

--- a/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/process_credentials_spec.rb
@@ -9,8 +9,19 @@ module Aws
       allow(Dir).to receive(:home).and_raise(ArgumentError)
     end
 
+    def mock_process(process, output, success: true)
+      # JRuby has some issue with rspec and system (with multiple args) that
+      # produces no output
+      if defined?(JRUBY_VERSION)
+        allow_any_instance_of(ProcessCredentials).to receive(:system)
+          .with(*process, out: anything).and_return(success)
+        allow_any_instance_of(IO).to receive(:read).and_return(output)
+      end
+    end
+
     it 'will read credentials from a process' do
       process = %w[echo {"Version":1,"AccessKeyId":"AK_PROC1","SecretAccessKey":"SECRET_AK_PROC1","SessionToken":"TOKEN_PROC1"}]
+      mock_process(process, process[1])
       creds = ProcessCredentials.new(process).credentials
       expect(creds.access_key_id).to eq('AK_PROC1')
       expect(creds.secret_access_key).to eq('SECRET_AK_PROC1')
@@ -19,6 +30,7 @@ module Aws
 
     it 'will throw an error when invalid JSON is returned' do
       process = %w[echo {"Version":3,"AccessKeyId":"","SecretAccessKey":""\']
+      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -26,6 +38,7 @@ module Aws
 
     it 'will throw an error when the process credentials payload version is invalid' do
       process = %w[echo {"Version":3,"AccessKeyId":"","SecretAccessKey":""}]
+      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
@@ -33,14 +46,17 @@ module Aws
 
     it 'will throw an error when the process credentials payload is malformed' do
       process = %w[echo {"Version":1}]
+      mock_process(process, process[1])
       expect {
         ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
     end
 
     it 'will throw an error when the credential process has a nonzero exit status' do
+      process = ['fake_proc']
+      mock_process(process, process[1], success: false)
       expect {
-        ProcessCredentials.new(['fake_proc']).credentials
+        ProcessCredentials.new(process).credentials
       }.to raise_error(Errors::InvalidProcessCredentialsPayload)
     end
 
@@ -80,8 +96,9 @@ module Aws
       end
 
       it 'will throw an error when the credential process has a nonzero exit status' do
+        process = 'fake_proc'
         expect {
-          ProcessCredentials.new('fake_proc').credentials
+          ProcessCredentials.new(process).credentials
         }.to raise_error(Errors::InvalidProcessCredentialsPayload)
       end
     end

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -24,7 +24,11 @@ RSpec.configure do |config|
   config.before(:each) do
     # Clear the current ENV to avoid loading credentials.
     # This was previously mocked with stub_const but was provided a hash.
+    # tempfix
+    path = ENV['PATH']
+    original_env = ENV.to_h
     ENV.clear
+    ENV['PATH'] = path
 
     # disable loading credentials from shared file
     allow(Dir).to receive(:home).and_raise(ArgumentError)
@@ -37,6 +41,11 @@ RSpec.configure do |config|
     allow_any_instance_of(Aws::InstanceProfileCredentials).to receive(:warn)
 
     Aws.shared_config.fresh
+
+    # tempfix
+    original_env.each do |key, value|
+      ENV[key] = value
+    end
   end
 
   # Thread.report_on_exception was set to default true in Ruby 2.5

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -22,10 +22,8 @@ RSpec.configure do |config|
   config.include Sigv4Helper
 
   config.before(:each) do
-    # Clear the current ENV to avoid loading credentials.
-    # This was previously mocked with stub_const but was provided a hash.
-    # tempfix
-    path = ENV['PATH']
+    # Clear the current ENV to avoid loading credentials and other configs.
+    path = ENV['PATH'] # necessary for JRuby
     original_env = ENV.to_h
     ENV.clear
     ENV['PATH'] = path
@@ -42,7 +40,7 @@ RSpec.configure do |config|
 
     Aws.shared_config.fresh
 
-    # tempfix
+    # Restore the original ENV
     original_env.each do |key, value|
       ENV[key] = value
     end

--- a/gems/aws-sdk-core/spec/shared_spec_helper.rb
+++ b/gems/aws-sdk-core/spec/shared_spec_helper.rb
@@ -22,11 +22,8 @@ RSpec.configure do |config|
   config.include Sigv4Helper
 
   config.before(:each) do
-    # Clear the current ENV to avoid loading credentials and other configs.
-    path = ENV['PATH'] # necessary for JRuby
-    original_env = ENV.to_h
-    ENV.clear
-    ENV['PATH'] = path
+    # Clear the current ENV to avoid loading credentials.
+    ENV.keep_if { |k, _| k == 'PATH' }
 
     # disable loading credentials from shared file
     allow(Dir).to receive(:home).and_raise(ArgumentError)
@@ -39,11 +36,6 @@ RSpec.configure do |config|
     allow_any_instance_of(Aws::InstanceProfileCredentials).to receive(:warn)
 
     Aws.shared_config.fresh
-
-    # Restore the original ENV
-    original_env.each do |key, value|
-      ENV[key] = value
-    end
   end
 
   # Thread.report_on_exception was set to default true in Ruby 2.5


### PR DESCRIPTION
Use `system` instead of backticks for executing processes in process credentials, allowing for more secure argument passing. Adds a warning for existing usage of a single string and general refactors in this class.