### PR TITLE
Fix Aws::RDS::Resource#create_db_cluster throws NoMethodError on nil

### DIFF
--- a/apis/rds/2014-10-31/resources-1.json
+++ b/apis/rds/2014-10-31/resources-1.json
@@ -9,7 +9,7 @@
                         {
                             "target": "Id",
                             "source": "requestParameter",
-                            "path": "DBCluster.DBClusterIdentifier"
+                            "path": "DBClusterIdentifier"
                         }
                     ],
                     "path": "DBCluster"

--- a/gems/aws-sdk-rds/CHANGELOG.md
+++ b/gems/aws-sdk-rds/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix Aws::RDS::Resource#create_db_cluster throws NoMethodError on nil
+
 1.237.0 (2024-06-27)
 ------------------
 

--- a/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
+++ b/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb
@@ -956,7 +956,7 @@ module Aws::RDS
         @client.create_db_cluster(options)
       end
       DBCluster.new(
-        id: options[:db_cluster][:db_cluster_identifier],
+        id: options[:db_cluster_identifier],
         data: resp.data.db_cluster,
         client: @client
       )


### PR DESCRIPTION
When calling Aws::RDS::Resource#create_db_cluster, it throws an error because `options[:db_cluster]` is always nil here:
https://github.com/aws/aws-sdk-ruby/blob/1db6f09105a81a7a856b0f825321faa10c6d822c/gems/aws-sdk-rds/lib/aws-sdk-rds/resource.rb#L959

This is because the definition of RDS resource is wrong. This patch fixes that small typo.

Reproduction steps to throw the error:

```console
% bundle exec ruby -raws-sdk-rds -e 'Aws::RDS::Resource.new.create_db_cluster(db_cluster_identifier: "nekketsuuu-test", engine: "aurora-mysql", vpc_security_group_ids: ["REDACTED"], db_subnet_group_name: "REDACTED", master_username: "root", master_user_password: "REDACTED")'
/Users/nekketsuuu/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.196.1/lib/aws-sdk-core/assume_role_web_identity_credentials.rb:5: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of aws-sdk-core-3.196.1 to add base64 into its gemspec.
/Users/nekketsuuu/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/aws-sdk-rds-1.232.0/lib/aws-sdk-rds/resource.rb:959:in `create_db_cluster': undefined method `[]' for nil (NoMethodError)

        id: options[:db_cluster][:db_cluster_identifier],
                                ^^^^^^^^^^^^^^^^^^^^^^^^
	from -e:1:in `<main>'
% ruby --version
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin23]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
