### PR TITLE
Do not warn using process credentials in shared config

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `Aws::ProcessCredentials` warning in cases where shared config is used.
+
 3.201.0 (2024-07-02)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -84,7 +84,7 @@ module Aws
     def static_profile_process_credentials(options)
       if Aws.shared_config.config_enabled? && options[:config] && options[:config].profile
         process_provider = Aws.shared_config.credential_process(profile: options[:config].profile)
-        ProcessCredentials.new(process_provider) if process_provider
+        ProcessCredentials.new([process_provider]) if process_provider
       end
     rescue Errors::NoSuchProfileError
       nil
@@ -117,9 +117,9 @@ module Aws
 
     def process_credentials(options)
       profile_name = determine_profile_name(options)
-      if Aws.shared_config.config_enabled? &&
-         (process_provider = Aws.shared_config.credential_process(profile: profile_name))
-        ProcessCredentials.new(process_provider)
+      if Aws.shared_config.config_enabled?
+        process_provider = Aws.shared_config.credential_process(profile: profile_name)
+        ProcessCredentials.new([process_provider]) if process_provider
       end
     rescue Errors::NoSuchProfileError
       nil

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -339,7 +339,7 @@ module Aws
       if @parsed_config
         credential_process ||= @parsed_config.fetch(profile, {})['credential_process']
       end
-      ProcessCredentials.new(credential_process) if credential_process
+      ProcessCredentials.new([credential_process]) if credential_process
     end
 
     def credentials_from_shared(profile, _opts)

--- a/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_resolution_chain_spec.rb
@@ -4,10 +4,6 @@ require_relative '../spec_helper'
 
 module Aws
   describe 'Credential Resolution Chain' do
-    before(:each) do
-      allow_any_instance_of(ProcessCredentials).to receive(:warn)
-    end
-
     let(:mock_credential_file) do
       File.expand_path(
         File.join(
@@ -35,6 +31,8 @@ module Aws
 
     before(:each) do
       allow(InstanceProfileCredentials).to receive(:new).and_return(mock_instance_creds)
+
+      expect_any_instance_of(ProcessCredentials).not_to receive(:warn)
     end
 
     describe 'default behavior' do


### PR DESCRIPTION
Closes #3061 

Shared config values are strings only. Strings will always warn for Process Credentials. So any time Process Credentials come from shared config, wrap it in an array.