### PR TITLE
Add missing require for pathname to the sigv4 signer

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add missing require of `pathname` to `Signer`.
+
 1.9.0 (2024-07-23)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -6,6 +6,7 @@ require 'time'
 require 'uri'
 require 'set'
 require 'cgi'
+require 'pathname'
 require 'aws-eventstream'
 
 module Aws


### PR DESCRIPTION
This not being present causes issues in CI for the opensearch wrapper. Currently the signer cannot work in isolation.

Failures look like this: https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/actions/runs/10119006930/job/27986748248?pr=43

![image](https://github.com/user-attachments/assets/4d3462d3-a8a7-41e3-b449-2ec6a9e5b547)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
