### PR TITLE
Auto refresh shared credentials

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+3.201.4 (2024-07-30)
+------------------
+* Feature - Add opt-in auto-refresh functionality to `Aws::SharedCredentials`.
+
 3.201.3 (2024-07-23)
 ------------------
 

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -136,5 +136,24 @@ aws_secret_access_key=commented-secret
       expect(creds).to eq(nil)
     end
 
+    it 'will refresh the cache credentials' do
+      creds_provider = SharedCredentials.new(path:mock_credential_file)
+      creds = creds_provider.credentials
+      expect(creds.access_key_id).to eq('ACCESS_KEY_0')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_0')
+      expect(creds.session_token).to eq('TOKEN_0')
+
+      creds_provider.instance_variable_set(:@path, mock_config_file)
+      expect(creds.access_key_id).to eq('ACCESS_KEY_0')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_0')
+      expect(creds.session_token).to eq('TOKEN_0')
+
+      creds_provider.instance_variable_set(:@last_refresh, Time.now - 60*60)
+      creds = creds_provider.credentials
+      expect(creds.access_key_id).to eq('ACCESS_KEY_SHARED')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_SHARED')
+      expect(creds.session_token).to eq('TOKEN_SHARED')
+    end
+
   end
 end


### PR DESCRIPTION
### Add Opt-in Auto-Refresh Functionality to Aws::SharedCredentials

This PR builds on the previous effort submitted in [PR #1619](https://github.com/aws/aws-sdk-ruby/pull/1619) to add auto-refresh functionality to `Aws::SharedCredentials` in the AWS SDK for Ruby. The original PR aimed to enable auto-refresh by default, but we have modified the implementation to make it opt-in.

### Changes Made:
1. Integrated with the existing `RefreshingCredentials` module to leverage its thread-safe refresh logic.
2. Modified the `Aws::SharedCredentials` class to accept a `:refresh_cycle` option. If `:refresh_cycle` is provided, auto-refresh is enabled; otherwise, it is disabled by default.
3. Ensured backward compatibility by not enabling auto-refresh if the `:refresh_cycle` option is not specified.

### Why This Change:
The auto-refresh feature is valuable for long-running applications, but enabling it by default may not fit all use cases. By making it opt-in, it provides flexibility while maintaining the integrity of existing workflows.

**Original PR:** [PR #1619](https://github.com/aws/aws-sdk-ruby/pull/1619)

I believe this functionality will significantly enhance the SDK by allowing seamless credential management for long-running applications. Thank you for considering this contribution.