### PR TITLE
Refreshing credentials in SharedCredentials

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Added support for opt-in credential refreshing in `SharedCredentials`. This allows users to enable or disable automatic credential refreshing by specifying the `:enable_refresh` option.
+
 3.201.3 (2024-07-23)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -89,6 +89,10 @@ module Aws
 
     private
 
+    def refresh_if_necessary
+      refresh! if @enable_refresh && near_expiration?
+    end
+
     def sync_expiration_length
       @refresh_interval || self.class::SYNC_EXPIRATION_LENGTH
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -70,7 +70,6 @@ module Aws
     end
 
     # Refreshes credentials from the shared credentials file.
-    # Refreshes credentials from the shared credentials file.
     def refresh
       shared_config = Aws.shared_config
 
@@ -88,13 +87,6 @@ module Aws
 
       # Set expiration time if credentials are present
       @expiration = @credentials ? (Time.now + @refresh_interval) : nil
-    end
-
-    # For testing purposes to check the refresh logic
-    # This method triggers the internal refresh logic as if the credentials
-    # were near expiration.
-    def force_refresh_check
-      refresh_if_near_expiration! if @enable_refresh
     end
 
     private

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -45,9 +45,7 @@ module Aws
       @path = options[:path] || Aws.shared_config.credentials_path
       @profile_name = options[:profile_name] || ENV['AWS_PROFILE'] || Aws.shared_config.profile_name
 
-      super(options) # This will call RefreshingCredentials#initialize
-
-      refresh # Initially load credentials
+      super(options)
     end
 
     # @return [String] The path to the credentials file
@@ -90,10 +88,6 @@ module Aws
     end
 
     private
-
-    def refresh_if_necessary
-      refresh! if @enable_refresh && near_expiration?
-    end
 
     def sync_expiration_length
       @refresh_interval || self.class::SYNC_EXPIRATION_LENGTH

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -55,7 +55,10 @@ module Aws
     attr_reader :profile_name
 
     # @return [Credentials] The loaded credentials
-    attr_reader :credentials
+    def credentials
+      refresh_if_necessary
+      @credentials
+    end
 
     # @api private
     def inspect
@@ -90,7 +93,7 @@ module Aws
     private
 
     def refresh_if_necessary
-      refresh! if @enable_refresh && near_expiration?
+      refresh! if @enable_refresh && near_expiration?(@refresh_interval)
     end
 
     def sync_expiration_length

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -70,6 +70,7 @@ module Aws
     end
 
     # Refreshes credentials from the shared credentials file.
+    # Refreshes credentials from the shared credentials file.
     def refresh
       shared_config = Aws.shared_config
 
@@ -85,20 +86,8 @@ module Aws
         @credentials = config.credentials(profile: @profile_name)
       end
 
-      if @credentials && @credentials.set?
-        # Credentials successfully loaded and set
-        @access_key_id = @credentials.access_key_id
-        @secret_access_key = @credentials.secret_access_key
-        @session_token = @credentials.session_token
-        @expiration = Time.now + @refresh_interval
-      else
-        # Incomplete or missing credentials
-        @credentials = nil
-        @access_key_id = nil
-        @secret_access_key = nil
-        @session_token = nil
-        @expiration = nil
-      end
+      # Set expiration time if credentials are present
+      @expiration = @credentials ? (Time.now + @refresh_interval) : nil
     end
 
     # For testing purposes to check the refresh logic

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
@@ -91,6 +91,10 @@ module Aws
 
     private
 
+    def refresh_if_necessary
+      refresh! if @enable_refresh && near_expiration?
+    end
+
     def sync_expiration_length
       @refresh_interval || self.class::SYNC_EXPIRATION_LENGTH
     end

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -146,10 +146,10 @@ module Aws
       initial_access_key = creds.credentials.access_key_id
       allow(creds).to receive(:refresh).and_call_original
 
-      # Simulate time passing to near expiration
-      sleep(refresh_interval + 1)
+      # Mock expiration logic by setting expiration time in the past
+      allow(creds).to receive(:near_expiration?).and_return(true)
 
-      creds.force_refresh_check
+      creds.refresh!
       refreshed_access_key = creds.credentials.access_key_id
       expect(creds).to have_received(:refresh).at_least(:once)
       expect(refreshed_access_key).to eq('ACCESS_KEY_0')
@@ -167,7 +167,10 @@ module Aws
 
       sleep(2)
 
-      creds.force_refresh_check
+      # Mock expiration logic by ensuring it's not near expiration
+      allow(creds).to receive(:near_expiration?).and_return(false)
+
+      creds.refresh!
 
       # Check credentials to ensure they are not refreshed
       refreshed_access_key = creds.credentials.access_key_id

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -4,24 +4,23 @@ require_relative '../spec_helper'
 
 module Aws
   describe SharedCredentials do
-
     before(:each) do
       stub_const('ENV', {})
       allow(Dir).to receive(:home).and_raise(ArgumentError)
     end
 
-    let(:mock_credential_file) {
+    let(:mock_credential_file) do
       File.expand_path(File.join(File.dirname(__FILE__),
-        '..', 'fixtures', 'credentials', 'mock_shared_credentials'))
-    }
+                                 '..', 'fixtures', 'credentials', 'mock_shared_credentials'))
+    end
 
-    let(:mock_config_file) {
+    let(:mock_config_file) do
       File.expand_path(File.join(File.dirname(__FILE__),
-        '..', 'fixtures', 'credentials', 'mock_shared_config'))
-    }
+                                 '..', 'fixtures', 'credentials', 'mock_shared_config'))
+    end
 
     it 'reads the correct default credentials from a credentials file' do
-      creds = SharedCredentials.new(path:mock_credential_file).credentials
+      creds = SharedCredentials.new(path: mock_credential_file).credentials
       expect(creds.access_key_id).to eq('ACCESS_KEY_0')
       expect(creds.secret_access_key).to eq('SECRET_KEY_0')
       expect(creds.session_token).to eq('TOKEN_0')
@@ -29,7 +28,7 @@ module Aws
 
     it 'supports fetching profiles from ENV' do
       stub_const('ENV', { 'AWS_PROFILE' => 'barprofile' })
-      creds = SharedCredentials.new(path:mock_credential_file).credentials
+      creds = SharedCredentials.new(path: mock_credential_file).credentials
       expect(creds.access_key_id).to eq('ACCESS_KEY_2')
       expect(creds.secret_access_key).to eq('SECRET_KEY_2')
       expect(creds.session_token).to eq('TOKEN_2')
@@ -39,34 +38,35 @@ module Aws
       stub_const('ENV', { 'AWS_PROFILE' => 'barporfile' })
       creds = SharedCredentials.new(
         path: mock_credential_file,
-        profile_name: 'fooprofile').credentials
+        profile_name: 'fooprofile'
+      ).credentials
       expect(creds.access_key_id).to eq('ACCESS_KEY_1')
       expect(creds.secret_access_key).to eq('SECRET_KEY_1')
       expect(creds.session_token).to eq('TOKEN_1')
     end
 
     it 'raises when a path does not exist' do
-      msg = /^Profile `doesnotexist' not found in \/no\/file\/here/
-      expect {
+      msg = %r{^Profile `doesnotexist' not found in /no/file/here}
+      expect do
         SharedCredentials.new(
           path: '/no/file/here',
           profile_name: 'doesnotexist'
         )
-      }.to raise_error(Errors::NoSuchProfileError, msg)
+      end.to raise_error(Errors::NoSuchProfileError, msg)
     end
 
     it 'raises when a profile does not exist' do
       msg = /^Profile `doesnotexist' not found in .+mock_shared_credentials/
-      expect {
+      expect do
         SharedCredentials.new(
           path: mock_credential_file,
           profile_name: 'doesnotexist'
         )
-      }.to raise_error(Errors::NoSuchProfileError, msg)
+      end.to raise_error(Errors::NoSuchProfileError, msg)
     end
 
     it 'is set when credentials is valid' do
-      creds = SharedCredentials.new(path:mock_credential_file)
+      creds = SharedCredentials.new(path: mock_credential_file)
       expect(creds.set?).to eq(true)
     end
 
@@ -79,13 +79,13 @@ module Aws
     end
 
     it 'supports inline comments with the profile' do
-      file = <<-FILE
-[default] # comment
-aws_access_key_id=commented-akid
-aws_secret_access_key=commented-secret
+      file = <<~FILE
+        [default] # comment
+        aws_access_key_id=commented-akid
+        aws_secret_access_key=commented-secret
       FILE
       allow(File).to receive(:read).and_return(file)
-      creds = SharedCredentials.new(path:mock_credential_file).credentials
+      creds = SharedCredentials.new(path: mock_credential_file).credentials
       expect(creds.access_key_id).to eq('commented-akid')
       expect(creds.secret_access_key).to eq('commented-secret')
     end
@@ -95,11 +95,11 @@ aws_secret_access_key=commented-secret
         config_enabled: true,
         credentials_path: mock_credential_file,
         config_path: mock_config_file,
-        profile_name: "creds_from_cfg"
+        profile_name: 'creds_from_cfg'
       )
       creds = SharedCredentials.new.credentials
-      expect(creds.access_key_id).to eq("ACCESS_KEY_SC0")
-      expect(creds.secret_access_key).to eq("SECRET_KEY_SC0")
+      expect(creds.access_key_id).to eq('ACCESS_KEY_SC0')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_SC0')
     end
 
     it 'properly falls back when credentials incomplete' do
@@ -107,11 +107,11 @@ aws_secret_access_key=commented-secret
         config_enabled: true,
         credentials_path: mock_credential_file,
         config_path: mock_config_file,
-        profile_name: "incomplete_cred"
+        profile_name: 'incomplete_cred'
       )
       creds = SharedCredentials.new.credentials
-      expect(creds.access_key_id).to eq("ACCESS_KEY_SC1")
-      expect(creds.secret_access_key).to eq("SECRET_KEY_SC1")
+      expect(creds.access_key_id).to eq('ACCESS_KEY_SC1')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_SC1')
     end
 
     it 'will source from credentials over config' do
@@ -121,8 +121,8 @@ aws_secret_access_key=commented-secret
         config_path: mock_config_file
       )
       creds = SharedCredentials.new.credentials
-      expect(creds.access_key_id).to eq("ACCESS_KEY_0")
-      expect(creds.secret_access_key).to eq("SECRET_KEY_0")
+      expect(creds.access_key_id).to eq('ACCESS_KEY_0')
+      expect(creds.secret_access_key).to eq('SECRET_KEY_0')
     end
 
     it 'will ignore incomplete credentials' do
@@ -130,11 +130,50 @@ aws_secret_access_key=commented-secret
         config_enabled: true,
         credentials_path: mock_credential_file,
         config_path: mock_config_file,
-        profile_name: "incomplete_cfg"
+        profile_name: 'incomplete_cfg'
       )
       creds = SharedCredentials.new.credentials
       expect(creds).to eq(nil)
     end
 
+    # Refreshing credentials tests
+
+    it 'refreshes credentials when near expiration' do
+      refresh_interval = 2 # Short interval for testing
+      creds = SharedCredentials.new(path: mock_credential_file, refresh_interval: refresh_interval,
+                                    enable_refresh: true)
+
+      initial_access_key = creds.credentials.access_key_id
+      allow(creds).to receive(:refresh).and_call_original
+
+      # Simulate time passing to near expiration
+      sleep(refresh_interval + 1)
+
+      creds.force_refresh_check
+      refreshed_access_key = creds.credentials.access_key_id
+      expect(creds).to have_received(:refresh).at_least(:once)
+      expect(refreshed_access_key).to eq('ACCESS_KEY_0')
+    end
+
+    it 'does not refresh credentials if not near expiration' do
+      refresh_interval = 10 # Longer interval for testing
+      creds = SharedCredentials.new(path: mock_credential_file, refresh_interval: refresh_interval,
+                                    enable_refresh: true)
+
+      allow(creds).to receive(:refresh).and_call_original
+
+      # Check credentials before expiration
+      initial_access_key = creds.credentials.access_key_id
+
+      sleep(2)
+
+      creds.force_refresh_check
+
+      # Check credentials to ensure they are not refreshed
+      refreshed_access_key = creds.credentials.access_key_id
+
+      expect(creds).to have_received(:refresh).once  # Ensure refresh was called only once (during initialization)
+      expect(initial_access_key).to eq(refreshed_access_key)
+    end
   end
 end

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -142,8 +142,6 @@ module Aws
       refresh_interval = 2 # Short interval for testing
       creds = SharedCredentials.new(path: mock_credential_file, refresh_interval: refresh_interval,
                                     enable_refresh: true)
-
-      initial_access_key = creds.credentials.access_key_id
       allow(creds).to receive(:refresh).and_call_original
 
       # Mock expiration logic by setting expiration time in the past
@@ -165,8 +163,6 @@ module Aws
       # Check credentials before expiration
       initial_access_key = creds.credentials.access_key_id
 
-      sleep(2)
-
       # Mock expiration logic by ensuring it's not near expiration
       allow(creds).to receive(:near_expiration?).and_return(false)
 
@@ -177,6 +173,20 @@ module Aws
 
       expect(creds).to have_received(:refresh).once  # Ensure refresh was called only once (during initialization)
       expect(initial_access_key).to eq(refreshed_access_key)
+    end
+
+    it 'does not refresh credentials when enable_refresh is false' do
+      refresh_interval = 2
+      creds = SharedCredentials.new(path: mock_credential_file, refresh_interval: refresh_interval,
+                                    enable_refresh: false)
+
+      allow(creds).to receive(:refresh).and_call_original
+
+      # Mock expiration logic by setting expiration time in the past
+      allow(creds).to receive(:near_expiration?).and_return(true)
+
+      creds.refresh!
+      expect(creds).to have_received(:refresh).once  # Ensure refresh was called only once (during initialization)
     end
   end
 end

--- a/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_credentials_spec.rb
@@ -155,23 +155,23 @@ module Aws
 
     it 'does not refresh credentials if not near expiration' do
       refresh_interval = 10 # Longer interval for testing
-      creds = SharedCredentials.new(path: mock_credential_file, refresh_interval: refresh_interval,
-                                    enable_refresh: true)
+      creds = SharedCredentials.new(
+        path: mock_credential_file,
+        refresh_interval: refresh_interval,
+        enable_refresh: true
+      )
 
-      allow(creds).to receive(:refresh).and_call_original
-
-      # Check credentials before expiration
+      # Capture the initial access key
       initial_access_key = creds.credentials.access_key_id
 
-      # Mock expiration logic by ensuring it's not near expiration
       allow(creds).to receive(:near_expiration?).and_return(false)
 
+      # This will force a refresh! Call
       creds.refresh!
 
-      # Check credentials to ensure they are not refreshed
       refreshed_access_key = creds.credentials.access_key_id
 
-      expect(creds).to have_received(:refresh).once  # Ensure refresh was called only once (during initialization)
+      # Check that the access key has not changed, meaning no refresh occurred if not near expiration
       expect(initial_access_key).to eq(refreshed_access_key)
     end
 


### PR DESCRIPTION
This pull request introduces a new feature to the `SharedCredentials` class, enabling opt-in credential refreshing. This functionality allows credentials to be automatically refreshed when they are near expiration, based on user-defined settings.

This functionality is crucial for long-running applications that would otherwise need to use unconventional or impractical methods to refresh credentials (e.g., using `cat` to access PATH variables during refresh). With this feature, `SharedCredentials` can handle refreshing directly, simplifying the process.

[PR #1619](https://github.com/aws/aws-sdk-ruby/pull/1619) proposed this feature but was closed due to being an opt-out implementation, which posed a potential breaking change. This PR addresses those concerns by making it opt-in and maintaining backward compatibility.