### PR TITLE
Support non x-amz headers in s3 presigned request

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Return all headers (not x-amz headers) to be sent in `Aws::S3::Presigner#presigned_request`.
+
 1.157.0 (2024-08-01)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
@@ -192,7 +192,7 @@ module Aws
       def sign_but_dont_send(
         req, expires_in, secure, time, unsigned_headers, hoist = true
       )
-        x_amz_headers = {}
+        headers = {}
 
         http_req = req.context.http_request
 
@@ -211,16 +211,18 @@ module Aws
 
           query = http_req.endpoint.query ? http_req.endpoint.query.split('&') : []
           http_req.headers.each do |key, value|
-            next unless key =~ /^x-amz/i
+            next if key == 'user-agent'
 
             if hoist
+              next unless key =~ /^x-amz/i
+
               value = Aws::Sigv4::Signer.uri_escape(value)
               key = Aws::Sigv4::Signer.uri_escape(key)
               # hoist x-amz-* headers to the querystring
               http_req.headers.delete(key)
               query << "#{key}=#{value}"
             else
-              x_amz_headers[key] = value
+              headers[key] = value
             end
           end
           http_req.endpoint.query = query.join('&') unless query.empty?
@@ -254,7 +256,7 @@ module Aws
           Seahorse::Client::Response.new(context: context, data: url)
         end
         # Return the headers
-        x_amz_headers
+        headers
       end
     end
   end

--- a/gems/aws-sdk-s3/spec/presigner_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigner_spec.rb
@@ -334,13 +334,20 @@ module Aws
           expect(url).to match(/^https:\/\/my.website.com\/foo/)
         end
 
-        it 'returns x-amz-* headers instead of hoisting to the query string' do
+        it 'returns headers instead of hoisting to the query string' do
           signer = Presigner.new(client: client)
           url, headers = signer.presigned_request(
-            :put_object, bucket: 'aws-sdk', key: 'foo', acl: 'public-read'
+            :put_object,
+            bucket: 'aws-sdk',
+            key: 'foo',
+            acl: 'public-read',
+            content_md5: 'md5'
           )
-          expect(url).to match(/X-Amz-SignedHeaders=host%3Bx-amz-acl/)
-          expect(headers).to eq('x-amz-acl' => 'public-read')
+          expect(url).to match(/X-Amz-SignedHeaders=content-md5%3Bhost%3Bx-amz-acl/)
+          expect(headers).to eq({
+            'x-amz-acl' => 'public-read',
+            'content-md5' => 'md5'
+          })
         end
 
         context 'credential expiration' do


### PR DESCRIPTION
With this change, add all headers (regardless if they are x-amz or not) to presigned request.