### PR TITLE
Add recovery option to SAX parser

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Support parsing not well-formed text characters with the Nokogiri parser.
+
 3.201.3 (2024-07-23)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
@@ -41,7 +41,8 @@ module Aws
         end
 
         def error(msg)
-          if msg =~ /PCDATA invalid Char value (\d+)/
+          if msg =~ /PCDATA invalid Char value (\d+)/ ||
+             msg =~ /An invalid XML character \(Unicode: 0x([0-9a-fA-F]+)\)/ # jruby
             @stack.text([Regexp.last_match(1).to_i].pack('U*'))
           else
             @stack.error(msg)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
@@ -12,8 +12,8 @@ module Aws
         end
 
         def parse(xml)
-          p = Nokogiri::XML::SAX::Parser.new(self)
-          p.parse(xml) do |ctx|
+          parser = Nokogiri::XML::SAX::Parser.new(self)
+          parser.parse(xml) do |ctx|
             ctx.recovery = true
           end
         end
@@ -41,7 +41,11 @@ module Aws
         end
 
         def error(msg)
-          @stack.error(msg)
+          if msg =~ /PCDATA invalid Char value (\d+)/
+            @stack.text([Regexp.last_match(1).to_i].pack('U*'))
+          else
+            @stack.error(msg)
+          end
         end
 
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/xml/parser/nokogiri_engine.rb
@@ -12,7 +12,10 @@ module Aws
         end
 
         def parse(xml)
-          Nokogiri::XML::SAX::Parser.new(self).parse(xml)
+          p = Nokogiri::XML::SAX::Parser.new(self)
+          p.parse(xml) do |ctx|
+            ctx.recovery = true
+          end
         end
 
         def xmldecl(*args); end

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -8,20 +8,14 @@ module Aws
     describe Parser do
       [:ox, :oga, :nokogiri, :libxml, :rexml].each do |engine|
         describe("ENGINE: #{engine}") do
-
-          begin
-            Parser.engine = engine
-          rescue LoadError
-            next
-          end
-
           let(:shapes) { ApiHelper.sample_shapes }
 
-          let(:parser) {
+          let(:parser) do
             api = ApiHelper.sample_api(shapes:shapes)
             rules = api.operation(:example_operation).output
+            Parser.engine = engine
             Parser.new(rules)
-          }
+          end
 
           def parse(xml, to_h = true)
             data = parser.parse(xml)
@@ -408,6 +402,11 @@ module Aws
               </xml>
               XML
               expect(parse(xml)).to eq(string: 'a', nested: { string: 'b' })
+            end
+
+            it 'handles boundary characters' do
+              xml = "<xml><String>foo\bbar</String></xml>"
+              expect(parse(xml)).to eq(string: "foo\bbar")
             end
 
           end

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -404,7 +404,9 @@ module Aws
               expect(parse(xml)).to eq(string: 'a', nested: { string: 'b' })
             end
 
-            it 'handles boundary characters' do
+            it 'handles backspace characters' do
+              skip 'Unable to support' if engine == :libxml
+
               xml = "<xml><String>foo\bbar</String></xml>"
               expect(parse(xml)).to eq(string: "foo\bbar")
             end

--- a/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/xml/parser_spec.rb
@@ -8,12 +8,17 @@ module Aws
     describe Parser do
       [:ox, :oga, :nokogiri, :libxml, :rexml].each do |engine|
         describe("ENGINE: #{engine}") do
+          before(:all) do
+            Parser.engine = engine
+          rescue LoadError
+            skip "Skipping tests for missing engine: #{engine}"
+          end
+
           let(:shapes) { ApiHelper.sample_shapes }
 
           let(:parser) do
             api = ApiHelper.sample_api(shapes:shapes)
             rules = api.operation(:example_operation).output
-            Parser.engine = engine
             Parser.new(rules)
           end
 


### PR DESCRIPTION
fixes #3081 

SAX parsing fails on \b characters. Try recovery mode but currently fails with libxml too.