### PR TITLE
Consider sigv4a supported without crt check

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow legacy/undocumented sigv4_signer configuration to override resolved signer.
 * Issue - Consider sigv4a supported without crt check.
 
 3.201.4 (2024-08-08)

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Consider sigv4a supported without crt check.
+
 3.201.4 (2024-08-08)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Allow legacy/undocumented sigv4_signer configuration to override resolved signer.
+* Issue - Allow legacy/undocumented `sigv4_signer` configuration to override resolved signer.
 * Issue - Consider sigv4a supported without crt check.
 
 3.201.4 (2024-08-08)

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('jmespath', '~> 1', '>= 1.6.1') # necessary for secure jmespath JSON parsing
   spec.add_dependency('aws-partitions', '~> 1', '>= 1.651.0') # necessary for new endpoint resolution
-  spec.add_dependency('aws-sigv4', '~> 1.8') # necessary for s3 express auth
+  spec.add_dependency('aws-sigv4', '~> 1.9') # necessary for s3 express auth/native sigv4a support
   spec.add_dependency('aws-eventstream', '~> 1', '>= 1.3.0') # necessary for binary eventstream
 
   spec.metadata = {

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
@@ -13,8 +13,7 @@ module Aws
       option(:sigv4_region)
       option(:unsigned_operations, default: [])
 
-      supported_auth_types = %w[sigv4 bearer sigv4-s3express none]
-      supported_auth_types += ['sigv4a'] if Aws::Sigv4::Signer.use_crt?
+      supported_auth_types = %w[sigv4 bearer sigv4-s3express sigv4a none]
       SUPPORTED_AUTH_TYPES = supported_auth_types.freeze
 
       def add_handlers(handlers, cfg)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
@@ -106,7 +106,7 @@ module Aws
                      auth_scheme['signingRegion']
                    end
           begin
-            @signer = Aws::Sigv4::Signer.new(
+            @signer = config.sigv4_signer || Aws::Sigv4::Signer.new(
               service: config.sigv4_name || auth_scheme['signingName'],
               region: sigv4_overrides[:region] || config.sigv4_region || region,
               credentials_provider: sigv4_overrides[:credentials] || config.credentials,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
