### PR TITLE
Add back Signer.use_crt? to fix backwards compatibility break.

### DIFF
--- a/gems/aws-sigv4/lib/aws-sigv4/signer.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/signer.rb
@@ -779,6 +779,13 @@ module Aws
       end
 
       class << self
+
+        # Kept for backwards compatability
+        # Always return false since we are not using crt signing functionality
+        def use_crt?
+          false
+        end
+
         # @api private
         def uri_escape_path(path)
           path.gsub(/[^\/]+/) { |part| uri_escape(part) }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
