### PR TITLE
fix sigv4a signing issue with derive_asymmetric_key

### DIFF
--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - fix sigv4a signing issue with derive_asymmetric_key for certain credentials.
+* Issue - Fix sigv4a signing issue with derive_asymmetric_key for certain credentials.
 
 1.10.0 (2024-09-17)
 ------------------

--- a/gems/aws-sigv4/CHANGELOG.md
+++ b/gems/aws-sigv4/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - fix sigv4a signing issue with derive_asymmetric_key for certain credentials.
+
 1.10.0 (2024-09-17)
 ------------------
 

--- a/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
@@ -64,8 +64,8 @@ module Aws
       def self.bn_to_be_bytes(bn)
         bytes = []
         while bn > 0
-          bytes << bn % 256
-          bn /= 256
+          bytes << (bn & 0xff)
+          bn = bn >> 8
         end
         bytes.reverse
       end

--- a/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
+++ b/gems/aws-sigv4/lib/aws-sigv4/asymmetric_credentials.rb
@@ -60,6 +60,16 @@ module Aws
         x
       end
 
+      # @return [Array] value of the BigNumber as a big-endian unsigned byte array.
+      def self.bn_to_be_bytes(bn)
+        bytes = []
+        while bn > 0
+          bytes << bn % 256
+          bn /= 256
+        end
+        bytes.reverse
+      end
+
       # Prior to openssl3 we could directly set public and private key on EC
       # However, openssl3 deprecated those methods and we must now construct
       # a der with the keys and load the EC from it.
@@ -67,7 +77,7 @@ module Aws
         # format reversed from: OpenSSL::ASN1.decode_all(OpenSSL::PKey::EC.new.to_der)
         asn1 = OpenSSL::ASN1::Sequence([
           OpenSSL::ASN1::Integer(OpenSSL::BN.new(1)),
-          OpenSSL::ASN1::OctetString([d.to_s(16)].pack('H*')),
+          OpenSSL::ASN1::OctetString(bn_to_be_bytes(d).pack('C*')),
           OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::ObjectId("prime256v1")], 0, :CONTEXT_SPECIFIC),
           OpenSSL::ASN1::ASN1Data.new(
             [OpenSSL::ASN1::BitString(public_key.to_octet_string(:uncompressed))],

--- a/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
+++ b/gems/aws-sigv4/spec/asymmetric_credentials_spec.rb
@@ -38,6 +38,19 @@ module Aws
           expect(extra[:pk_y]).to be_a(Integer)
           expect(extra[:pk_y]).to eq 60777455846638291266199385583357715250110920888403467466325436560561456866584
         end
+
+        # ensure that encoding of private keys with MSB set result in valid EC objects
+        context 'private key with most significant bit set' do
+
+          let(:access_key_id) { 'ASIAZRFOHJT45NGNWXS3' }
+          let(:secret_access_key) { 'WOuDKprKr+rt3Dl7+RCiNpZGzi3Jw/DdVifyifuC' }
+          let(:test_value) { 'test_value' }
+
+          it 'derives a valid EC PKey' do
+            signature = ec.dsa_sign_asn1(test_value)
+            expect(ec.dsa_verify_asn1(test_value, signature)).to be_truthy
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Sigv4a signing was failing for specific credential combinations that resulted in deriving a private key with a MSB of 1 due to differences in two's compliment vs unsigned integer interpretation when constructing the PKey::EC. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
