### PR TITLE
Docs: do not escape curly braces in example

### DIFF
--- a/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
+++ b/gems/aws-sdk-kinesis/lib/aws-sdk-kinesis/client.rb
@@ -663,7 +663,7 @@ module Aws::Kinesis
     # Delete a policy for the specified data stream or consumer. Request
     # patterns can be one of the following:
     #
-    # * Data stream pattern: `arn:aws.*:kinesis:.*:\d\{12\}:.*stream/\S+`
+    # * Data stream pattern: `arn:aws.*:kinesis:.*:\d{12}:.*stream/\S+`
     #
     # * Consumer pattern:
     #   `^(arn):aws.*:kinesis:.*:\d\{12\}:.*stream\/[a-zA-Z0-9_.-]+\/consumer\/[a-zA-Z0-9_.-]+:[0-9]+`


### PR DESCRIPTION
In the example regex pattern, the curly braces are escaped, but stream patterns don't appear to typically expect `{` or `}`. 

The Java [example](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-kinesis/src/main/java/com/amazonaws/services/kinesis/AmazonKinesisClient.java#L625C1-L626C1) seems to be what is intended. This PR makes that update. 


