### PR TITLE
Declare dependency on json 2.4.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+gemspec path: "gems/aws-sdk-core/"
+
 gem 'rake', require: false
 # SDK feature dependencies
 gem 'aws-crt' if ENV['CRT']
@@ -14,7 +16,6 @@ if defined?(JRUBY_VERSION)
 end
 
 # protocol parsers
-gem 'json', '2.7.5' if RUBY_VERSION < '3.0.0'  # temporary due to json 2.8.0 release
 gem 'nokogiri', '>= 1.6.8.1'
 gem 'oga'
 gem 'rexml'

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['LICENSE.txt', 'CHANGELOG.md', 'VERSION', 'lib/**/*.rb', 'sig/**/*.rbs', 'ca-bundle.crt']
 
+  spec.add_dependency('json', '>= 2.4.0')
   spec.add_dependency('jmespath', '~> 1', '>= 1.6.1') # necessary for secure jmespath JSON parsing
   spec.add_dependency('aws-partitions', '~> 1', '>= 1.992.0') # necessary for new endpoint resolution
   spec.add_dependency('aws-sigv4', '~> 1.9') # necessary for s3 express auth/native sigv4a support


### PR DESCRIPTION
If the gems use `JSON.load_file` and are compatible with Ruby >= 2.5 they must declare that they require `json 2.4.0` otherwise they may get a much older version.

cc @jterapin, I don't know this project enough to know if `aws-sdk-core` is the right gemspec to add the dependency to, but that should solve your issues.