### PR TITLE
Do not normalize presigned url object keys in s3

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Do not normalize object keys when calling `presigned_url` or `presigned_request`.
+
 1.176.0 (2024-12-03)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/presigner.rb
@@ -238,6 +238,7 @@ module Aws
             credentials_provider: context[:sigv4_credentials] || context.config.credentials,
             signing_algorithm: scheme_name.to_sym,
             uri_escape_path: !!!auth_scheme['disableDoubleEncoding'],
+            normalize_path: !!!auth_scheme['disableNormalizePath'],
             unsigned_headers: unsigned_headers,
             apply_checksum_header: false
           )

--- a/gems/aws-sdk-s3/spec/presigner_spec.rb
+++ b/gems/aws-sdk-s3/spec/presigner_spec.rb
@@ -189,6 +189,15 @@ module Aws
           expect(url).to match(/x-amz-acl=public-read/)
         end
 
+        it 'does not normalize object keys' do
+          url = subject.presigned_url(
+            :get_object,
+            bucket: 'aws-sdk',
+            key: 'foo/../bar'
+          )
+          expect(url).to include('foo/../bar')
+        end
+
         context 'credential expiration' do
           let(:credentials) do
             credentials_provider_class.new(expiration_time)
@@ -331,12 +340,20 @@ module Aws
         end
 
         it 'returns x-amz-* headers instead of hoisting to the query string' do
-          signer = Presigner.new(client: client)
-          url, headers = signer.presigned_request(
+          url, headers = subject.presigned_request(
             :put_object, bucket: 'aws-sdk', key: 'foo', acl: 'public-read'
           )
           expect(url).to match(/X-Amz-SignedHeaders=host%3Bx-amz-acl/)
           expect(headers).to eq('x-amz-acl' => 'public-read')
+        end
+
+        it 'does not normalize object keys' do
+          url, = subject.presigned_request(
+            :get_object,
+            bucket: 'aws-sdk',
+            key: 'foo/../bar'
+          )
+          expect(url).to include('foo/../bar')
         end
 
         context 'credential expiration' do


### PR DESCRIPTION
Follow S3's signing requirements and do not use normalized objects when signing.