### PR TITLE
Typo in QueuePoller stop polling opton docs

### DIFF
--- a/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
+++ b/gems/aws-sdk-sqs/lib/aws-sdk-sqs/queue_poller.rb
@@ -134,7 +134,7 @@ module Aws
     # ### `:idle_timeout` Option
     #
     # This is a configurable, maximum number of seconds to wait for a
-    # new message before the polling loop exists. By default, there is
+    # new message before the polling loop exits. By default, there is
     # no idle timeout.
     #
     #     # stops polling after a minute of no received messages


### PR DESCRIPTION
I think this is supposed to be "exits" no "exists"

It aint much but its honest work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
