### PR TITLE
docs: Fix documentation that references a non-existent method

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix documentation that references a non-existent method.
+
 3.214.0 (2024-11-25)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
@@ -24,9 +24,6 @@ module Aws
   #   arn.resource
   #   # => foo/bar
   #
-  #   # Note: parser available for parsing resource details
-  #   @see Aws::ARNParser#parse_resource
-  #
   # @see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-arns
   class ARN
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/arn.rb
@@ -24,6 +24,7 @@ module Aws
   #   arn.resource
   #   # => foo/bar
   #
+  # @see ARNParser
   # @see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-arns
   class ARN
 


### PR DESCRIPTION
YARD comments for Aws::ARN says there is Aws::ARNParser#parse_resource method, which is not. It seems that this is just a documentation bug. So I've removed the lines.

Follow-up: fdb74d66458dfb9e37bdf28f8240359fbd6fdba1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

