### PR TITLE
Fix error when attempting to format an unlinked tempfile

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fixed error when attempting to log an unlinked tempfile.
+
 3.215.0 (2025-01-10)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/log/param_formatter.rb
@@ -51,13 +51,17 @@ module Aws
         when String   then summarize_string(value)
         when Hash     then '{' + summarize_hash(value) + '}'
         when Array    then summarize_array(value)
-        when File     then summarize_file(value.path)
-        when Pathname then summarize_file(value)
+        when File     then summarize_file(value)
+        when Pathname then summarize_filepath(value)
         else value.inspect
         end
       end
 
-      def summarize_file(path)
+      def summarize_file(file)
+        "#<File:#{file.path} (#{file.size} bytes)>"
+      end
+
+      def summarize_filepath(path)
         "#<File:#{path} (#{File.size(path)} bytes)>"
       end
 

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -34,9 +34,12 @@ module Aws
         end
 
         it 'provides a :request_params replacement' do
-          tmpfile = Tempfile.create
-          File.unlink(tmpfile.path) unless RUBY_DESCRIPTION.match?(/mswin|ming|cygwin/)
-          tmpfile.write('foo=bar')
+          file = Tempfile.create
+          # This is not available on windows, see:
+          # - https://docs.ruby-lang.org/en/3.4/Tempfile.html#class-Tempfile-label-Unlink+after+creation
+          # - https://github.com/aws/aws-sdk-ruby/issues/3163
+          File.unlink(file.path) unless RUBY_DESCRIPTION.match?(/mswin|ming|cygwin/)
+          file.write('foo=bar')
 
           response.context.params = {
             foo: 'bar',
@@ -47,18 +50,19 @@ module Aws
             config: {
               nested: true,
               path: Pathname.new(__FILE__),
-              tmpfile:,
+              tmpfile: file,
               complex: double('obj', inspect: '"inspected"')
             },
-            huge: '-' * 1000
+            huge: '-' * 1000,
+            list: ['one', 'two']
           }
           formatted = format('{:request_params}', max_string_size: 20)
           size = File.size(__FILE__)
           expect(formatted).to eq(<<-FORMATTED.strip)
-{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,path:#<File:#{__FILE__} (#{size} bytes)>,tmpfile:#<File:#{tmpfile.path} (#{tmpfile.size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
+{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,path:#<File:#{__FILE__} (#{size} bytes)>,tmpfile:#<File:#{file.path} (#{file.size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>,list:["one","two"]}
           FORMATTED
         ensure
-          tmpfile.close
+          file.close
         end
 
         it 'provides a :time replacement' do

--- a/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/log/formatter_spec.rb
@@ -34,6 +34,10 @@ module Aws
         end
 
         it 'provides a :request_params replacement' do
+          tmpfile = Tempfile.create
+          File.unlink(tmpfile.path) unless RUBY_DESCRIPTION.match?(/mswin|ming|cygwin/)
+          tmpfile.write('foo=bar')
+
           response.context.params = {
             foo: 'bar',
             attributes: {
@@ -43,6 +47,7 @@ module Aws
             config: {
               nested: true,
               path: Pathname.new(__FILE__),
+              tmpfile:,
               complex: double('obj', inspect: '"inspected"')
             },
             huge: '-' * 1000
@@ -50,8 +55,10 @@ module Aws
           formatted = format('{:request_params}', max_string_size: 20)
           size = File.size(__FILE__)
           expect(formatted).to eq(<<-FORMATTED.strip)
-{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,path:#<File:#{__FILE__} (#{size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
+{foo:"bar",attributes:{"color"=>"red","size"=>"large"},config:{nested:true,path:#<File:#{__FILE__} (#{size} bytes)>,tmpfile:#<File:#{tmpfile.path} (#{tmpfile.size} bytes)>,complex:"inspected"},huge:#<String "--------------------" ... (1000 bytes)>}
           FORMATTED
+        ensure
+          tmpfile.close
         end
 
         it 'provides a :time replacement' do


### PR DESCRIPTION
Fixes #3163

This resolves an issue where a `File` object can be available to the running Ruby program, but no longer exist on disk. Previously, the log formatter would check a file's size using its path, this now uses the instance's `size` method.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!