### PR TITLE
Add handling of block in response delegation

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add handling of block in response delegation (#3169). 
+
 3.216.0 (2025-01-15)
 ------------------
 

--- a/gems/aws-sdk-core/lib/seahorse/client/response.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/response.rb
@@ -75,6 +75,8 @@ module Seahorse
       # Necessary to define as a subclass of Delegator
       # @api private
       def __getobj__
+        return yield if block_given? && !defined?(@data)
+
         @data
       end
 


### PR DESCRIPTION
Fixes #3169 

Based on the implementation of [Delegator](https://github.com/ruby/ruby/blob/72fdba156d2963609141867b815e202d558582bf/lib/delegate.rb#L84) - calls the block if the @data object is undefined following behavior from [SimpleDelegator](https://github.com/ruby/ruby/blob/72fdba156d2963609141867b815e202d558582bf/lib/delegate.rb#L320). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
