### PR TITLE
Allow other retry configs to influence DynamoDB extended retries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'rake', require: false
 # SDK feature dependencies
 gem 'aws-crt' if ENV['CRT']
+gem 'base64'
 gem 'http-2'
 gem 'jmespath'
 if defined?(JRUBY_VERSION)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/rbs/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/rbs/client_class.rb
@@ -138,7 +138,7 @@ module AwsSdkCodeGenerator
           grouped = buffer.group_by { |name, _| name }
           grouped.transform_values(&:count).find_all { |_, c| 1 < c }.each do |name,|
             case name
-            when :endpoint, :endpoint_provider, :retry_limit, :disable_s3_express_session_auth, :account_id, :account_id_endpoint_mode
+            when :endpoint, :endpoint_provider, :retry_limit, :retry_base_delay, :disable_s3_express_session_auth, :account_id, :account_id_endpoint_mode
               # ok
             else
               warn("Duplicate client option in #{@service_name}: `#{grouped[name].map { |g| g.values_at(0, 2) }}`", uplevel: 0)

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/rbs/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/rbs/client_class.rb
@@ -138,7 +138,7 @@ module AwsSdkCodeGenerator
           grouped = buffer.group_by { |name, _| name }
           grouped.transform_values(&:count).find_all { |_, c| 1 < c }.each do |name,|
             case name
-            when :endpoint, :endpoint_provider, :retry_limit, :retry_base_delay, :disable_s3_express_session_auth, :account_id, :account_id_endpoint_mode
+            when :endpoint, :endpoint_provider, :retry_backoff, :retry_limit, :retry_base_delay, :disable_s3_express_session_auth, :account_id, :account_id_endpoint_mode
               # ok
             else
               warn("Duplicate client option in #{@service_name}: `#{grouped[name].map { |g| g.values_at(0, 2) }}`", uplevel: 0)

--- a/gems/aws-sdk-dynamodb/CHANGELOG.md
+++ b/gems/aws-sdk-dynamodb/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow other retry configs to influence DynamoDB extended retries.
+
 1.134.0 (2025-01-15)
 ------------------
 

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -301,7 +301,7 @@ module Aws::DynamoDB
     #     A proc or lambda used for backoff. Defaults to 2**retries * retry_base_delay.
     #     This option is only used in the `legacy` retry mode.
     #
-    #   @option options [Float] :retry_base_delay (0.05)
+    #   @option options [Float] :retry_base_delay (0.3)
     #     The base delay in seconds used by the default backoff function. This option
     #     is only used in the `legacy` retry mode.
     #
@@ -317,9 +317,8 @@ module Aws::DynamoDB
     #     The maximum number of times to retry failed requests.  Only
     #     ~ 500 level server errors and certain ~ 400 level client errors
     #     are retried.  Generally, these are throttling errors, data
-    #     checksum errors, networking errors, timeout errors, auth errors,
-    #     endpoint discovery, and errors from expired credentials.
-    #     This option is only used in the `legacy` retry mode.
+    #     checksum errors, networking errors, timeout errors and auth
+    #     errors from expired credentials.
     #
     #   @option options [Integer] :retry_max_delay (0)
     #     The maximum number of seconds to delay between retries (0 for no limit)

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/client.rb
@@ -301,7 +301,7 @@ module Aws::DynamoDB
     #     A proc or lambda used for backoff. Defaults to 2**retries * retry_base_delay.
     #     This option is only used in the `legacy` retry mode.
     #
-    #   @option options [Float] :retry_base_delay (0.3)
+    #   @option options [Float] :retry_base_delay (0.05)
     #     The base delay in seconds used by the default backoff function. This option
     #     is only used in the `legacy` retry mode.
     #
@@ -317,8 +317,9 @@ module Aws::DynamoDB
     #     The maximum number of times to retry failed requests.  Only
     #     ~ 500 level server errors and certain ~ 400 level client errors
     #     are retried.  Generally, these are throttling errors, data
-    #     checksum errors, networking errors, timeout errors and auth
-    #     errors from expired credentials.
+    #     checksum errors, networking errors, timeout errors, auth errors,
+    #     endpoint discovery, and errors from expired credentials.
+    #     This option is only used in the `legacy` retry mode.
     #
     #   @option options [Integer] :retry_max_delay (0)
     #     The maximum number of seconds to delay between retries (0 for no limit)

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -4,6 +4,20 @@ module Aws
   module DynamoDB
     module Plugins
       class ExtendedRetries < Seahorse::Client::Plugin
+        DEFAULT_BACKOFF = lambda do |c|
+          return if c.retries < 1
+
+          delay = 2**(c.retries - 1) * c.config.retry_base_delay
+          if (c.config.retry_max_delay || 0) > 0
+            delay = [delay, c.config.retry_max_delay].min
+          end
+          jitter = c.config.retry_jitter
+          jitter = JITTERS[jitter] if jitter.is_a?(Symbol)
+          delay = jitter.call(delay) if jitter
+          Kernel.sleep(delay)
+        end
+
+
         option(
           :retry_limit,
           default: 10,
@@ -24,6 +38,15 @@ This option is only used in the `legacy` retry mode.
           docstring: <<-DOCS)
 The base delay in seconds used by the default backoff function. This option
 is only used in the `legacy` retry mode.
+        DOCS
+
+        option(
+          :retry_backoff,
+          default: DEFAULT_BACKOFF,
+          doc_type: Proc,
+          docstring: <<-DOCS)
+A proc or lambda used for backoff. Defaults to 2**retries * retry_base_delay.
+This option is only used in the `legacy` retry mode.
         DOCS
       end
     end

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -5,7 +5,7 @@ module Aws
     module Plugins
       class ExtendedRetries < Seahorse::Client::Plugin
         DEFAULT_BACKOFF = lambda do |c|
-          return if c.retries < 1
+          return unless c.retries > 1
 
           delay = 2**(c.retries - 1) * c.config.retry_base_delay
           if (c.config.retry_max_delay || 0) > 0

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -12,11 +12,10 @@ module Aws
             delay = [delay, c.config.retry_max_delay].min
           end
           jitter = c.config.retry_jitter
-          jitter = JITTERS[jitter] if jitter.is_a?(Symbol)
+          jitter = Aws::Plugins::RetryErrors::JITTERS[jitter] if jitter.is_a?(Symbol)
           delay = jitter.call(delay) if jitter
           Kernel.sleep(delay)
         end
-
 
         option(
           :retry_limit,

--- a/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
+++ b/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/extended_retries.rb
@@ -4,25 +4,27 @@ module Aws
   module DynamoDB
     module Plugins
       class ExtendedRetries < Seahorse::Client::Plugin
-
-        option(:retry_limit,
+        option(
+          :retry_limit,
           default: 10,
-          required: false,
           doc_type: Integer,
           docstring: <<-DOCS)
 The maximum number of times to retry failed requests.  Only
 ~ 500 level server errors and certain ~ 400 level client errors
 are retried.  Generally, these are throttling errors, data
-checksum errors, networking errors, timeout errors and auth
-errors from expired credentials.
-          DOCS
+checksum errors, networking errors, timeout errors, auth errors,
+endpoint discovery, and errors from expired credentials.
+This option is only used in the `legacy` retry mode.
+        DOCS
 
-        option(:retry_backoff, default: lambda { |context|
-          if context.retries > 1
-            Kernel.sleep(50 * (2 ** (context.retries - 1)) / 1000.0)
-          end
-        })
-
+        option(
+          :retry_base_delay,
+          default: 0.05,
+          doc_type: Float,
+          docstring: <<-DOCS)
+The base delay in seconds used by the default backoff function. This option
+is only used in the `legacy` retry mode.
+        DOCS
       end
     end
   end


### PR DESCRIPTION
Fixes #3172