### PR TITLE
Add transfer-encoding and connection to list of unsigned sigv4 headers

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Add `transfer-encoding` and `connection` to list of unsigned sigv4 headers.
+
 3.217.0 (2025-01-24)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/sign.rb
@@ -113,7 +113,7 @@ module Aws
               signing_algorithm: scheme_name.to_sym,
               uri_escape_path: !!!auth_scheme['disableDoubleEncoding'],
               normalize_path: !!!auth_scheme['disableNormalizePath'],
-              unsigned_headers: %w[content-length user-agent x-amzn-trace-id]
+              unsigned_headers: %w[content-length user-agent x-amzn-trace-id expect transfer-encoding connection]
             )
           rescue Aws::Sigv4::Errors::MissingCredentialsError
             raise Aws::Errors::MissingCredentialsError


### PR DESCRIPTION
Both `transfer-encoding` and `connection` may be removed by proxies and can cause signing failures.  AWS services do not require these headers to be signed.

The sigv4 signer provides its own [hard coded list of unsigned headers](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sigv4/lib/aws-sigv4/signer.rb#L140-L142), which cannot be overridden.  Rather than adding to this this, this change updates the default signer options used in the `sign` handler which will not affect the behavior for users using the aws-sigv4 signer outside of the SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
