### PR TITLE
Fix CloudFront `listConflictingAliasesMaxItemsInteger` is never used warning

### DIFF
--- a/build_tools/customizations.rb
+++ b/build_tools/customizations.rb
@@ -67,7 +67,7 @@ module BuildTools
     api('CloudFront') do |api|
 
       api['shapes'].each do |_, shape|
-        if shape['members'] && shape['members']['MaxItems']
+        if shape['members'] && shape['members']['MaxItems'] && shape['members']['MaxItems']['shape'] == 'string'
           shape['members']['MaxItems']['shape'] = 'integer'
         end
       end

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
@@ -2108,7 +2108,7 @@ module Aws::CloudFront
     ListConflictingAliasesRequest.add_member(:distribution_id, Shapes::ShapeRef.new(shape: distributionIdString, required: true, location: "querystring", location_name: "DistributionId"))
     ListConflictingAliasesRequest.add_member(:alias, Shapes::ShapeRef.new(shape: aliasString, required: true, location: "querystring", location_name: "Alias"))
     ListConflictingAliasesRequest.add_member(:marker, Shapes::ShapeRef.new(shape: string, location: "querystring", location_name: "Marker"))
-    ListConflictingAliasesRequest.add_member(:max_items, Shapes::ShapeRef.new(shape: integer, location: "querystring", location_name: "MaxItems"))
+    ListConflictingAliasesRequest.add_member(:max_items, Shapes::ShapeRef.new(shape: listConflictingAliasesMaxItemsInteger, location: "querystring", location_name: "MaxItems"))
     ListConflictingAliasesRequest.struct_class = Types::ListConflictingAliasesRequest
 
     ListConflictingAliasesResult.add_member(:conflicting_aliases_list, Shapes::ShapeRef.new(shape: ConflictingAliasesList, location_name: "ConflictingAliasesList"))

--- a/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
+++ b/gems/aws-sdk-cloudfront/lib/aws-sdk-cloudfront/client_api.rb
@@ -2108,7 +2108,7 @@ module Aws::CloudFront
     ListConflictingAliasesRequest.add_member(:distribution_id, Shapes::ShapeRef.new(shape: distributionIdString, required: true, location: "querystring", location_name: "DistributionId"))
     ListConflictingAliasesRequest.add_member(:alias, Shapes::ShapeRef.new(shape: aliasString, required: true, location: "querystring", location_name: "Alias"))
     ListConflictingAliasesRequest.add_member(:marker, Shapes::ShapeRef.new(shape: string, location: "querystring", location_name: "Marker"))
-    ListConflictingAliasesRequest.add_member(:max_items, Shapes::ShapeRef.new(shape: listConflictingAliasesMaxItemsInteger, location: "querystring", location_name: "MaxItems"))
+    ListConflictingAliasesRequest.add_member(:max_items, Shapes::ShapeRef.new(shape: integer, location: "querystring", location_name: "MaxItems"))
     ListConflictingAliasesRequest.struct_class = Types::ListConflictingAliasesRequest
 
     ListConflictingAliasesResult.add_member(:conflicting_aliases_list, Shapes::ShapeRef.new(shape: ConflictingAliasesList, location_name: "ConflictingAliasesList"))


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-ruby/issues/3179.

Customization in codegen for CloudFront was automatically setting the shape of `MaxItems` members to integers. Updated to only set the shape to integers when the shape was originally a string.

Running tests with current code and `$VERBOSE=true`
![Screenshot 2025-02-05 at 12 33 35 PM](https://github.com/user-attachments/assets/0689345f-be34-4ed1-bd30-05cfabcb28a2)

After change
![Screenshot 2025-02-05 at 1 03 04 PM](https://github.com/user-attachments/assets/93423928-b652-4bf3-8aa6-1fe2ef10c38f)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
