### PR TITLE
add base64 as explicit dependency

### DIFF
--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-
   spec.name          = 'aws-sdk-core'
-  spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
+  spec.version       = File.read(File.expand_path('VERSION', __dir__)).strip
   spec.summary       = 'AWS SDK for Ruby - Core'
   spec.description   = 'Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby.'
   spec.author        = 'Amazon Web Services'
@@ -12,17 +11,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir['LICENSE.txt', 'CHANGELOG.md', 'VERSION', 'lib/**/*.rb', 'sig/**/*.rbs', 'ca-bundle.crt']
 
-  spec.add_dependency('jmespath', '~> 1', '>= 1.6.1') # necessary for secure jmespath JSON parsing
+  spec.add_dependency('aws-eventstream', '~> 1', '>= 1.3.0') # necessary for binary eventstream
   spec.add_dependency('aws-partitions', '~> 1', '>= 1.992.0') # necessary for new endpoint resolution
   spec.add_dependency('aws-sigv4', '~> 1.9') # necessary for s3 express auth/native sigv4a support
-  spec.add_dependency('aws-eventstream', '~> 1', '>= 1.3.0') # necessary for binary eventstream
+
+  spec.add_dependency('base64')
+  spec.add_dependency('jmespath', '~> 1', '>= 1.6.1') # necessary for secure jmespath JSON parsing
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/version-3/gems/aws-sdk-core',
-    'changelog_uri'   => 'https://github.com/aws/aws-sdk-ruby/tree/version-3/gems/aws-sdk-core/CHANGELOG.md'
+    'changelog_uri' => 'https://github.com/aws/aws-sdk-ruby/tree/version-3/gems/aws-sdk-core/CHANGELOG.md'
   }
 
   spec.required_ruby_version = '>= 2.5'
-
-  spec.add_runtime_dependency 'base64'
 end

--- a/gems/aws-sdk-core/aws-sdk-core.gemspec
+++ b/gems/aws-sdk-core/aws-sdk-core.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.5'
+
+  spec.add_runtime_dependency 'base64'
 end


### PR DESCRIPTION
closes #2984

was made into a bundled gem in ruby 3.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
