### PR TITLE
Chomp .rb from require paths in generated gems

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_class.rb
@@ -69,7 +69,7 @@ module AwsSdkCodeGenerator
 
       # @return [Array<String>]
       def plugin_requires
-        @plugins.map(&:require_path)
+        @plugins.map(&:require_path).map { |p| p.chomp('.rb') }
       end
 
       # @return [Array<String>]


### PR DESCRIPTION
Removes .rb from generated gem require paths

```
-require 'seahorse/client/plugins/content_length.rb'
+require 'seahorse/client/plugins/content_length'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
