### PR TITLE
Skip invalid operation parameters for endpoint operation inputs test

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/endpoint_provider_spec_class.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/spec/endpoint_provider_spec_class.rb
@@ -113,9 +113,11 @@ module AwsSdkCodeGenerator
             input_shape_name = @api['operations'][options[:operation_name]]['input']['shape']
             input = @api['shapes'][input_shape_name]
             @operation_params = options[:operation_params].map do |k,v|
+              next if input['members'][k].nil?
+
               member_shape = @api['shapes'][input['members'][k]['shape']]
               Param.new(Underscore.underscore(k), transform_operation_values(v, member_shape))
-            end
+            end.compact
             @client_params = options[:client_params].map do |k,v|
               Param.new(Underscore.underscore(k), v)
             end


### PR DESCRIPTION
Extra invalid operation parameters may be included in the endpoint test for a bad model. This change ensures SDK builds successfully but will result in failed tests for bad models.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
