### PR TITLE
Expand error documentation for query protocol

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
@@ -25,7 +25,8 @@ module AwsSdkCodeGenerator
             members: members,
             data_type: "#{@module_name}::Types::#{name}",
             retryable: !!shape['retryable'],
-            throttling: throttling?(shape)
+            throttling: throttling?(shape),
+            custom_error_class: custom_error_class(shape)
           )
         end
         es
@@ -45,6 +46,11 @@ module AwsSdkCodeGenerator
       shape['retryable'] && shape['retryable'].kind_of?(Hash) && shape['retryable']['throttling']
     end
 
+    def custom_error_class(shape)
+      return unless (custom_error_name = shape.dig('error', 'code'))
+
+      custom_error_name
+    end
 
     class Error
 
@@ -54,6 +60,7 @@ module AwsSdkCodeGenerator
         @members = options[:members]
         @retryable = options[:retryable]
         @throttling = options[:throttling]
+        @custom_error_class = options[:custom_error_class]
       end
 
       # @return [String]
@@ -70,6 +77,14 @@ module AwsSdkCodeGenerator
 
       # @return [Boolean]
       attr_reader :throttling
+
+      # @return [String, nil]
+      attr_reader :custom_error_class
+
+      # Covers dynamically created errors by query protocol
+      def custom_error_class?
+        !@custom_error_class.nil? && @name != @custom_error_class
+      end
 
     end
 

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/errors_module.rb
@@ -20,6 +20,7 @@ module AwsSdkCodeGenerator
       # @return [String|nil]
       def generated_src_warning
         return if @service.protocol == 'api-gateway'
+
         GENERATED_SRC_WARNING
       end
 
@@ -40,6 +41,10 @@ module AwsSdkCodeGenerator
       # @return [String]
       def customization_file_path
         "#{gem_name}/customizations/errors"
+      end
+
+      def query_protocol?
+        @service.protocol == 'query'
       end
 
       private

--- a/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
@@ -29,7 +29,7 @@ module {{module_name}}
   <%={{ }}=%>
   {{#query_protocol?}}
   {{#custom_error_class?}}
-  #    * `{{custom_error_class}}` may be generated to use instead of this class name.
+  #    * This error class is not used. `{{custom_error_class}}` is used during parsing instead.
   {{/custom_error_class?}}
   {{/query_protocol?}}
   {{/errors}}
@@ -37,7 +37,7 @@ module {{module_name}}
   # Additionally, error classes are dynamically generated for service errors based on the error code
   # if they are not defined above.
   {{#query_protocol?}}
-  # Some existing error classes may use a different class name than documented.
+  # Some existing error classes may use a different class name than the one documented.
   {{/query_protocol?}}
   module Errors
 
@@ -46,7 +46,8 @@ module {{module_name}}
     {{#errors}}
     {{#query_protocol?}}
     {{#custom_error_class?}}
-    # `{{custom_error_class}}` may be used instead of the class name documented below.
+    # @deprecated This error class is not used during parsing.
+    #   Please use `{{custom_error_class}}` instead.
     {{/custom_error_class?}}
     {{/query_protocol?}}
     class {{name}} < ServiceError

--- a/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
@@ -29,7 +29,7 @@ module {{module_name}}
   <%={{ }}=%>
   {{#query_protocol?}}
   {{#custom_error_class?}}
-  #    * `{{custom_error_class}}` may generated to use instead of this class name.
+  #    * `{{custom_error_class}}` may be generated to use instead of this class name.
   {{/custom_error_class?}}
   {{/query_protocol?}}
   {{/errors}}

--- a/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
@@ -27,15 +27,28 @@ module {{module_name}}
   {{=<% %>=}}
   # * {<% name %>}
   <%={{ }}=%>
+  {{#query_protocol?}}
+  {{#custom_error_class?}}
+  #    * `{{custom_error_class}}` may generated to use instead of this class name.
+  {{/custom_error_class?}}
+  {{/query_protocol?}}
   {{/errors}}
   #
   # Additionally, error classes are dynamically generated for service errors based on the error code
   # if they are not defined above.
+  {{#query_protocol?}}
+  # Some existing error classes may use a different class name than documented.
+  {{/query_protocol?}}
   module Errors
 
     extend Aws::Errors::DynamicErrors
 
     {{#errors}}
+    {{#query_protocol?}}
+    {{#custom_error_class?}}
+    # `{{custom_error_class}}` may be used instead of the class name documented below.
+    {{/custom_error_class?}}
+    {{/query_protocol?}}
     class {{name}} < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
@@ -30,39 +30,68 @@ module Aws::IAM
   # * {AccountNotManagementOrDelegatedAdministratorException}
   # * {CallerIsNotManagementAccountException}
   # * {ConcurrentModificationException}
+  #    * `ConcurrentModification` may generated to use instead of this class name.
   # * {CredentialReportExpiredException}
+  #    * `ReportExpired` may generated to use instead of this class name.
   # * {CredentialReportNotPresentException}
+  #    * `ReportNotPresent` may generated to use instead of this class name.
   # * {CredentialReportNotReadyException}
+  #    * `ReportInProgress` may generated to use instead of this class name.
   # * {DeleteConflictException}
+  #    * `DeleteConflict` may generated to use instead of this class name.
   # * {DuplicateCertificateException}
+  #    * `DuplicateCertificate` may generated to use instead of this class name.
   # * {DuplicateSSHPublicKeyException}
+  #    * `DuplicateSSHPublicKey` may generated to use instead of this class name.
   # * {EntityAlreadyExistsException}
+  #    * `EntityAlreadyExists` may generated to use instead of this class name.
   # * {EntityTemporarilyUnmodifiableException}
+  #    * `EntityTemporarilyUnmodifiable` may generated to use instead of this class name.
   # * {InvalidAuthenticationCodeException}
+  #    * `InvalidAuthenticationCode` may generated to use instead of this class name.
   # * {InvalidCertificateException}
+  #    * `InvalidCertificate` may generated to use instead of this class name.
   # * {InvalidInputException}
+  #    * `InvalidInput` may generated to use instead of this class name.
   # * {InvalidPublicKeyException}
+  #    * `InvalidPublicKey` may generated to use instead of this class name.
   # * {InvalidUserTypeException}
+  #    * `InvalidUserType` may generated to use instead of this class name.
   # * {KeyPairMismatchException}
+  #    * `KeyPairMismatch` may generated to use instead of this class name.
   # * {LimitExceededException}
+  #    * `LimitExceeded` may generated to use instead of this class name.
   # * {MalformedCertificateException}
+  #    * `MalformedCertificate` may generated to use instead of this class name.
   # * {MalformedPolicyDocumentException}
+  #    * `MalformedPolicyDocument` may generated to use instead of this class name.
   # * {NoSuchEntityException}
+  #    * `NoSuchEntity` may generated to use instead of this class name.
   # * {OpenIdIdpCommunicationErrorException}
+  #    * `OpenIdIdpCommunicationError` may generated to use instead of this class name.
   # * {OrganizationNotFoundException}
   # * {OrganizationNotInAllFeaturesModeException}
   # * {PasswordPolicyViolationException}
+  #    * `PasswordPolicyViolation` may generated to use instead of this class name.
   # * {PolicyEvaluationException}
+  #    * `PolicyEvaluation` may generated to use instead of this class name.
   # * {PolicyNotAttachableException}
+  #    * `PolicyNotAttachable` may generated to use instead of this class name.
   # * {ReportGenerationLimitExceededException}
+  #    * `ReportGenerationLimitExceeded` may generated to use instead of this class name.
   # * {ServiceAccessNotEnabledException}
   # * {ServiceFailureException}
+  #    * `ServiceFailure` may generated to use instead of this class name.
   # * {ServiceNotSupportedException}
+  #    * `NotSupportedService` may generated to use instead of this class name.
   # * {UnmodifiableEntityException}
+  #    * `UnmodifiableEntity` may generated to use instead of this class name.
   # * {UnrecognizedPublicKeyEncodingException}
+  #    * `UnrecognizedPublicKeyEncoding` may generated to use instead of this class name.
   #
   # Additionally, error classes are dynamically generated for service errors based on the error code
   # if they are not defined above.
+  # Some existing error classes may use a different class name than documented.
   module Errors
 
     extend Aws::Errors::DynamicErrors
@@ -87,6 +116,7 @@ module Aws::IAM
       end
     end
 
+    # `ConcurrentModification` may be used instead of the class name documented below.
     class ConcurrentModificationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -102,6 +132,7 @@ module Aws::IAM
       end
     end
 
+    # `ReportExpired` may be used instead of the class name documented below.
     class CredentialReportExpiredException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -117,6 +148,7 @@ module Aws::IAM
       end
     end
 
+    # `ReportNotPresent` may be used instead of the class name documented below.
     class CredentialReportNotPresentException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -132,6 +164,7 @@ module Aws::IAM
       end
     end
 
+    # `ReportInProgress` may be used instead of the class name documented below.
     class CredentialReportNotReadyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -147,6 +180,7 @@ module Aws::IAM
       end
     end
 
+    # `DeleteConflict` may be used instead of the class name documented below.
     class DeleteConflictException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -162,6 +196,7 @@ module Aws::IAM
       end
     end
 
+    # `DuplicateCertificate` may be used instead of the class name documented below.
     class DuplicateCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -177,6 +212,7 @@ module Aws::IAM
       end
     end
 
+    # `DuplicateSSHPublicKey` may be used instead of the class name documented below.
     class DuplicateSSHPublicKeyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -192,6 +228,7 @@ module Aws::IAM
       end
     end
 
+    # `EntityAlreadyExists` may be used instead of the class name documented below.
     class EntityAlreadyExistsException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -207,6 +244,7 @@ module Aws::IAM
       end
     end
 
+    # `EntityTemporarilyUnmodifiable` may be used instead of the class name documented below.
     class EntityTemporarilyUnmodifiableException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -222,6 +260,7 @@ module Aws::IAM
       end
     end
 
+    # `InvalidAuthenticationCode` may be used instead of the class name documented below.
     class InvalidAuthenticationCodeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -237,6 +276,7 @@ module Aws::IAM
       end
     end
 
+    # `InvalidCertificate` may be used instead of the class name documented below.
     class InvalidCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -252,6 +292,7 @@ module Aws::IAM
       end
     end
 
+    # `InvalidInput` may be used instead of the class name documented below.
     class InvalidInputException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -267,6 +308,7 @@ module Aws::IAM
       end
     end
 
+    # `InvalidPublicKey` may be used instead of the class name documented below.
     class InvalidPublicKeyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -282,6 +324,7 @@ module Aws::IAM
       end
     end
 
+    # `InvalidUserType` may be used instead of the class name documented below.
     class InvalidUserTypeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -297,6 +340,7 @@ module Aws::IAM
       end
     end
 
+    # `KeyPairMismatch` may be used instead of the class name documented below.
     class KeyPairMismatchException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -312,6 +356,7 @@ module Aws::IAM
       end
     end
 
+    # `LimitExceeded` may be used instead of the class name documented below.
     class LimitExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -327,6 +372,7 @@ module Aws::IAM
       end
     end
 
+    # `MalformedCertificate` may be used instead of the class name documented below.
     class MalformedCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -342,6 +388,7 @@ module Aws::IAM
       end
     end
 
+    # `MalformedPolicyDocument` may be used instead of the class name documented below.
     class MalformedPolicyDocumentException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -357,6 +404,7 @@ module Aws::IAM
       end
     end
 
+    # `NoSuchEntity` may be used instead of the class name documented below.
     class NoSuchEntityException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -372,6 +420,7 @@ module Aws::IAM
       end
     end
 
+    # `OpenIdIdpCommunicationError` may be used instead of the class name documented below.
     class OpenIdIdpCommunicationErrorException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -407,6 +456,7 @@ module Aws::IAM
       end
     end
 
+    # `PasswordPolicyViolation` may be used instead of the class name documented below.
     class PasswordPolicyViolationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -422,6 +472,7 @@ module Aws::IAM
       end
     end
 
+    # `PolicyEvaluation` may be used instead of the class name documented below.
     class PolicyEvaluationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -437,6 +488,7 @@ module Aws::IAM
       end
     end
 
+    # `PolicyNotAttachable` may be used instead of the class name documented below.
     class PolicyNotAttachableException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -452,6 +504,7 @@ module Aws::IAM
       end
     end
 
+    # `ReportGenerationLimitExceeded` may be used instead of the class name documented below.
     class ReportGenerationLimitExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -477,6 +530,7 @@ module Aws::IAM
       end
     end
 
+    # `ServiceFailure` may be used instead of the class name documented below.
     class ServiceFailureException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -492,6 +546,7 @@ module Aws::IAM
       end
     end
 
+    # `NotSupportedService` may be used instead of the class name documented below.
     class ServiceNotSupportedException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -507,6 +562,7 @@ module Aws::IAM
       end
     end
 
+    # `UnmodifiableEntity` may be used instead of the class name documented below.
     class UnmodifiableEntityException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -522,6 +578,7 @@ module Aws::IAM
       end
     end
 
+    # `UnrecognizedPublicKeyEncoding` may be used instead of the class name documented below.
     class UnrecognizedPublicKeyEncodingException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context

--- a/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
+++ b/gems/aws-sdk-iam/lib/aws-sdk-iam/errors.rb
@@ -30,68 +30,39 @@ module Aws::IAM
   # * {AccountNotManagementOrDelegatedAdministratorException}
   # * {CallerIsNotManagementAccountException}
   # * {ConcurrentModificationException}
-  #    * `ConcurrentModification` may generated to use instead of this class name.
   # * {CredentialReportExpiredException}
-  #    * `ReportExpired` may generated to use instead of this class name.
   # * {CredentialReportNotPresentException}
-  #    * `ReportNotPresent` may generated to use instead of this class name.
   # * {CredentialReportNotReadyException}
-  #    * `ReportInProgress` may generated to use instead of this class name.
   # * {DeleteConflictException}
-  #    * `DeleteConflict` may generated to use instead of this class name.
   # * {DuplicateCertificateException}
-  #    * `DuplicateCertificate` may generated to use instead of this class name.
   # * {DuplicateSSHPublicKeyException}
-  #    * `DuplicateSSHPublicKey` may generated to use instead of this class name.
   # * {EntityAlreadyExistsException}
-  #    * `EntityAlreadyExists` may generated to use instead of this class name.
   # * {EntityTemporarilyUnmodifiableException}
-  #    * `EntityTemporarilyUnmodifiable` may generated to use instead of this class name.
   # * {InvalidAuthenticationCodeException}
-  #    * `InvalidAuthenticationCode` may generated to use instead of this class name.
   # * {InvalidCertificateException}
-  #    * `InvalidCertificate` may generated to use instead of this class name.
   # * {InvalidInputException}
-  #    * `InvalidInput` may generated to use instead of this class name.
   # * {InvalidPublicKeyException}
-  #    * `InvalidPublicKey` may generated to use instead of this class name.
   # * {InvalidUserTypeException}
-  #    * `InvalidUserType` may generated to use instead of this class name.
   # * {KeyPairMismatchException}
-  #    * `KeyPairMismatch` may generated to use instead of this class name.
   # * {LimitExceededException}
-  #    * `LimitExceeded` may generated to use instead of this class name.
   # * {MalformedCertificateException}
-  #    * `MalformedCertificate` may generated to use instead of this class name.
   # * {MalformedPolicyDocumentException}
-  #    * `MalformedPolicyDocument` may generated to use instead of this class name.
   # * {NoSuchEntityException}
-  #    * `NoSuchEntity` may generated to use instead of this class name.
   # * {OpenIdIdpCommunicationErrorException}
-  #    * `OpenIdIdpCommunicationError` may generated to use instead of this class name.
   # * {OrganizationNotFoundException}
   # * {OrganizationNotInAllFeaturesModeException}
   # * {PasswordPolicyViolationException}
-  #    * `PasswordPolicyViolation` may generated to use instead of this class name.
   # * {PolicyEvaluationException}
-  #    * `PolicyEvaluation` may generated to use instead of this class name.
   # * {PolicyNotAttachableException}
-  #    * `PolicyNotAttachable` may generated to use instead of this class name.
   # * {ReportGenerationLimitExceededException}
-  #    * `ReportGenerationLimitExceeded` may generated to use instead of this class name.
   # * {ServiceAccessNotEnabledException}
   # * {ServiceFailureException}
-  #    * `ServiceFailure` may generated to use instead of this class name.
   # * {ServiceNotSupportedException}
-  #    * `NotSupportedService` may generated to use instead of this class name.
   # * {UnmodifiableEntityException}
-  #    * `UnmodifiableEntity` may generated to use instead of this class name.
   # * {UnrecognizedPublicKeyEncodingException}
-  #    * `UnrecognizedPublicKeyEncoding` may generated to use instead of this class name.
   #
   # Additionally, error classes are dynamically generated for service errors based on the error code
   # if they are not defined above.
-  # Some existing error classes may use a different class name than documented.
   module Errors
 
     extend Aws::Errors::DynamicErrors
@@ -116,7 +87,6 @@ module Aws::IAM
       end
     end
 
-    # `ConcurrentModification` may be used instead of the class name documented below.
     class ConcurrentModificationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -132,7 +102,6 @@ module Aws::IAM
       end
     end
 
-    # `ReportExpired` may be used instead of the class name documented below.
     class CredentialReportExpiredException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -148,7 +117,6 @@ module Aws::IAM
       end
     end
 
-    # `ReportNotPresent` may be used instead of the class name documented below.
     class CredentialReportNotPresentException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -164,7 +132,6 @@ module Aws::IAM
       end
     end
 
-    # `ReportInProgress` may be used instead of the class name documented below.
     class CredentialReportNotReadyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -180,7 +147,6 @@ module Aws::IAM
       end
     end
 
-    # `DeleteConflict` may be used instead of the class name documented below.
     class DeleteConflictException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -196,7 +162,6 @@ module Aws::IAM
       end
     end
 
-    # `DuplicateCertificate` may be used instead of the class name documented below.
     class DuplicateCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -212,7 +177,6 @@ module Aws::IAM
       end
     end
 
-    # `DuplicateSSHPublicKey` may be used instead of the class name documented below.
     class DuplicateSSHPublicKeyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -228,7 +192,6 @@ module Aws::IAM
       end
     end
 
-    # `EntityAlreadyExists` may be used instead of the class name documented below.
     class EntityAlreadyExistsException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -244,7 +207,6 @@ module Aws::IAM
       end
     end
 
-    # `EntityTemporarilyUnmodifiable` may be used instead of the class name documented below.
     class EntityTemporarilyUnmodifiableException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -260,7 +222,6 @@ module Aws::IAM
       end
     end
 
-    # `InvalidAuthenticationCode` may be used instead of the class name documented below.
     class InvalidAuthenticationCodeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -276,7 +237,6 @@ module Aws::IAM
       end
     end
 
-    # `InvalidCertificate` may be used instead of the class name documented below.
     class InvalidCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -292,7 +252,6 @@ module Aws::IAM
       end
     end
 
-    # `InvalidInput` may be used instead of the class name documented below.
     class InvalidInputException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -308,7 +267,6 @@ module Aws::IAM
       end
     end
 
-    # `InvalidPublicKey` may be used instead of the class name documented below.
     class InvalidPublicKeyException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -324,7 +282,6 @@ module Aws::IAM
       end
     end
 
-    # `InvalidUserType` may be used instead of the class name documented below.
     class InvalidUserTypeException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -340,7 +297,6 @@ module Aws::IAM
       end
     end
 
-    # `KeyPairMismatch` may be used instead of the class name documented below.
     class KeyPairMismatchException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -356,7 +312,6 @@ module Aws::IAM
       end
     end
 
-    # `LimitExceeded` may be used instead of the class name documented below.
     class LimitExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -372,7 +327,6 @@ module Aws::IAM
       end
     end
 
-    # `MalformedCertificate` may be used instead of the class name documented below.
     class MalformedCertificateException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -388,7 +342,6 @@ module Aws::IAM
       end
     end
 
-    # `MalformedPolicyDocument` may be used instead of the class name documented below.
     class MalformedPolicyDocumentException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -404,7 +357,6 @@ module Aws::IAM
       end
     end
 
-    # `NoSuchEntity` may be used instead of the class name documented below.
     class NoSuchEntityException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -420,7 +372,6 @@ module Aws::IAM
       end
     end
 
-    # `OpenIdIdpCommunicationError` may be used instead of the class name documented below.
     class OpenIdIdpCommunicationErrorException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -456,7 +407,6 @@ module Aws::IAM
       end
     end
 
-    # `PasswordPolicyViolation` may be used instead of the class name documented below.
     class PasswordPolicyViolationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -472,7 +422,6 @@ module Aws::IAM
       end
     end
 
-    # `PolicyEvaluation` may be used instead of the class name documented below.
     class PolicyEvaluationException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -488,7 +437,6 @@ module Aws::IAM
       end
     end
 
-    # `PolicyNotAttachable` may be used instead of the class name documented below.
     class PolicyNotAttachableException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -504,7 +452,6 @@ module Aws::IAM
       end
     end
 
-    # `ReportGenerationLimitExceeded` may be used instead of the class name documented below.
     class ReportGenerationLimitExceededException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -530,7 +477,6 @@ module Aws::IAM
       end
     end
 
-    # `ServiceFailure` may be used instead of the class name documented below.
     class ServiceFailureException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -546,7 +492,6 @@ module Aws::IAM
       end
     end
 
-    # `NotSupportedService` may be used instead of the class name documented below.
     class ServiceNotSupportedException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -562,7 +507,6 @@ module Aws::IAM
       end
     end
 
-    # `UnmodifiableEntity` may be used instead of the class name documented below.
     class UnmodifiableEntityException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context
@@ -578,7 +522,6 @@ module Aws::IAM
       end
     end
 
-    # `UnrecognizedPublicKeyEncoding` may be used instead of the class name documented below.
     class UnrecognizedPublicKeyEncodingException < ServiceError
 
       # @param [Seahorse::Client::RequestContext] context


### PR DESCRIPTION
Prompted by #1347 

This PR affects services that meets the following conditions:
* Uses `query` as their protocol
* Contains error shapes with a custom code, which is then used to create dynamic error class

Adds documentation on what the actual error class may be (than the one noted).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
