### PR TITLE
Update deprecated trait

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -49,6 +49,7 @@ module AwsSdkCodeGenerator
         'fault' => false,
         'deprecated' => false,
         'deprecatedMessage' => false,
+        'deprecatedSince' => false,
         'type' => false,
         'documentation' => false,
         'members' => false,


### PR DESCRIPTION
**Context**
We already ignore `deprecatedMessage` in C2J models which is a result of the Smithy's [deprecated](https://smithy.io/2.0/spec/documentation-traits.html#deprecated-trait) trait. We should also ignore `deprecatedSince` as well.

**Why is this important?**
To ensure that we are able to build the sdk w/ translated c2j models that has this trait property in their shapes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
