### PR TITLE
Abort multi part download if the object is modified during download

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Add if_match to multipart download.
 
 1.186.0 (2025-05-12)
 ------------------

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased Changes
 ------------------
-* Issue - Add if_match to multipart download.
+* Issue - Abort multipart download if object is modified during download.
 
 1.186.0 (2025-05-12)
 ------------------

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -134,7 +134,7 @@ module Aws
           chunks << Part.new(
             part_number: part_number,
             size: (progress-offset),
-            params: @params.merge(range: range, is_match: etag)
+            params: @params.merge(range: range, if_match: etag)
           )
           part_number += 1
           offset = progress

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -90,7 +90,7 @@ module Aws
         if chunk_size < part_size
           multithreaded_get_by_ranges(file_size, etag)
         else
-          multithreaded_get_by_parts(count, file_size)
+          multithreaded_get_by_parts(count, file_size, etag)
         end
       end
 
@@ -142,9 +142,9 @@ module Aws
         download_in_threads(PartList.new(chunks), file_size)
       end
 
-      def multithreaded_get_by_parts(n_parts, total_size)
+      def multithreaded_get_by_parts(n_parts, total_size, etag)
         parts = (1..n_parts).map do |part|
-          Part.new(part_number: part, params: @params.merge(part_number: part))
+          Part.new(part_number: part, params: @params.merge(part_number: part, if_match: etag))
         end
         download_in_threads(PartList.new(parts), total_size)
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -43,7 +43,7 @@ module Aws
           when 'get_range'
             if @chunk_size
               resp = @client.head_object(@params)
-              multithreaded_get_by_ranges(resp.content_length)
+              multithreaded_get_by_ranges(resp.content_length, resp.etag)
             else
               msg = 'In :get_range mode, :chunk_size must be provided'
               raise ArgumentError, msg
@@ -71,7 +71,7 @@ module Aws
           if resp.content_length <= MIN_CHUNK_SIZE
             single_request
           else
-            multithreaded_get_by_ranges(resp.content_length)
+            multithreaded_get_by_ranges(resp.content_length, resp.etag)
           end
         else
           # partNumber is an option
@@ -79,16 +79,16 @@ module Aws
           if resp.content_length <= MIN_CHUNK_SIZE
             single_request
           else
-            compute_mode(resp.content_length, count)
+            compute_mode(resp.content_length, count, resp.etag)
           end
         end
       end
 
-      def compute_mode(file_size, count)
+      def compute_mode(file_size, count, etag)
         chunk_size = compute_chunk(file_size)
         part_size = (file_size.to_f / count.to_f).ceil
         if chunk_size < part_size
-          multithreaded_get_by_ranges(file_size)
+          multithreaded_get_by_ranges(file_size, etag)
         else
           multithreaded_get_by_parts(count, file_size)
         end
@@ -122,7 +122,7 @@ module Aws
         chunks.each_slice(@thread_count).to_a
       end
 
-      def multithreaded_get_by_ranges(file_size)
+      def multithreaded_get_by_ranges(file_size, etag)
         offset = 0
         default_chunk_size = compute_chunk(file_size)
         chunks = []
@@ -134,7 +134,7 @@ module Aws
           chunks << Part.new(
             part_number: part_number,
             size: (progress-offset),
-            params: @params.merge(range: range)
+            params: @params.merge(range: range, is_match: etag)
           )
           part_number += 1
           offset = progress

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -237,7 +237,7 @@ module Aws
 
           client.stub_responses(:get_object, -> (ctx) {
             expect(ctx.params[:if_match]).to eq('test-etag')
-            Aws::S3::Errors::PreconditionFailed.new(nil, nil)
+            'PreconditionFailed'
           })
 
           thread = double(value: nil)
@@ -262,7 +262,7 @@ module Aws
 
           client.stub_responses(:get_object, -> (ctx) {
             expect(ctx.params[:if_match]).to eq('test-etag')
-            Aws::S3::Errors::PreconditionFailed.new(nil, nil)
+            'PreconditionFailed'
           })
 
           thread = double(value: nil)

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -222,14 +222,23 @@ module Aws
         end
 
         it 'does not download object when ETAG does not match during multipart get by ranges' do
-          expect(client).to receive(:get_object).with({
+          allow(client).to receive(:head_object).with({
             bucket: 'bucket',
             key: 'single',
-            range: "bytes=0-5242879",
-            if_match: 'ETag'
-          }).and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, nil))
+            part_number: 1,
+          }).and_return(
+            client.stub_data(
+              :head_object,
+              content_length: 15 * one_meg,
+              parts_count: nil,
+              etag: 'test-etag'
+            )
+          )
 
-          expect(client).to_not receive(:write)
+          client.stub_responses(:get_object, -> (ctx) {
+            expect(ctx.params[:if_match]).to eq('test-etag')
+            Aws::S3::Errors::PreconditionFailed.new(nil, nil)
+          })
 
           thread = double(value: nil)
           expect(Thread).to receive(:new).and_yield.and_return(thread)
@@ -240,14 +249,21 @@ module Aws
         end
 
         it 'does not download object when ETAG does not match during multipart get by parts' do
-          expect(client).to receive(:get_object).with({
+          allow(client).to receive(:head_object).with({
             bucket: 'bucket',
-            key: 'large',
-            part_number: 1,
-            if_match: 'ETag'
-          }).and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, nil))
+            key: 'large'
+          }).and_return(
+            client.stub_data(
+              :head_object,
+              content_length: 20 * one_meg,
+              etag: 'test-etag'
+            )
+          )
 
-          expect(client).to_not receive(:write)
+          client.stub_responses(:get_object, -> (ctx) {
+            expect(ctx.params[:if_match]).to eq('test-etag')
+            Aws::S3::Errors::PreconditionFailed.new(nil, nil)
+          })
 
           thread = double(value: nil)
           expect(Thread).to receive(:new).and_yield.and_return(thread)

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -221,6 +221,42 @@ module Aws
           end.to raise_error(Aws::Errors::ChecksumError)
         end
 
+        it 'does not download object when ETAG does not match during multipart get by ranges' do
+          expect(client).to receive(:get_object).with({
+            bucket: 'bucket',
+            key: 'single',
+            range: "bytes=0-5242879",
+            if_match: 'ETag'
+          }).and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, nil))
+
+          expect(client).to_not receive(:write)
+
+          thread = double(value: nil)
+          expect(Thread).to receive(:new).and_yield.and_return(thread)
+
+          expect do
+            single_obj.download_file(path)
+          end.to raise_error(Aws::S3::Errors::PreconditionFailed)
+        end
+
+        it 'does not download object when ETAG does not match during multipart get by parts' do
+          expect(client).to receive(:get_object).with({
+            bucket: 'bucket',
+            key: 'large',
+            part_number: 1,
+            if_match: 'ETag'
+          }).and_raise(Aws::S3::Errors::PreconditionFailed.new(nil, nil))
+
+          expect(client).to_not receive(:write)
+
+          thread = double(value: nil)
+          expect(Thread).to receive(:new).and_yield.and_return(thread)
+
+          expect do
+            large_obj.download_file(path)
+          end.to raise_error(Aws::S3::Errors::PreconditionFailed)
+        end
+
         it 'calls on_checksum_validated on single part' do
           callback_data = {called: 0}
           mutex = Mutex.new


### PR DESCRIPTION
Adds an etag [if match statement](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) to the get by parts/ranges functionality during multipart download of the transfer manager. In the event a file is changed mid operation, multipart download will abort and no file will be downloaded.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
