### PR TITLE
Fix spelling issue in event_emitter error

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased Changes
 ------------------
 
+3.226.1 (2025-06-23)
+------------------
+
+* Issue - Fixed spelling error (`singaling` to `signaling`) in event_emitter error.
+
 3.226.0 (2025-06-17)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/event_emitter.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/event_emitter.rb
@@ -31,7 +31,7 @@ module Aws
     def emit(type, params)
       unless @stream
         raise Aws::Errors::SignalEventError.new(
-          "Singaling events before making async request"\
+          "Signaling events before making async request"\
           " is not allowed."
         )
       end


### PR DESCRIPTION
## Purpose
Noticed this spelling error.

## Approach
Spell signaling correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
