### PR TITLE
fix: consecutive open timeout errors

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -105,6 +105,17 @@ module Seahorse
             session.continue_timeout = http_continue_timeout if
               session.respond_to?(:continue_timeout=)
             yield(session)
+          rescue Net::OpenTimeout, Timeout::Error => error
+            session.finish if session
+            # For timeout errors, clear the entire pool for this endpoint
+            # to force fresh connections on subsequent requests
+            @pool_mutex.synchronize do
+              if @pool.key?(endpoint)
+                @pool[endpoint].each(&:finish)
+                @pool[endpoint].clear
+              end
+            end
+            raise
           rescue
             session.finish if session
             raise
@@ -143,6 +154,22 @@ module Seahorse
           @pool_mutex.synchronize do
             @pool.values.flatten.map(&:finish)
             @pool.clear
+          end
+          nil
+        end
+
+        # Closes and removes all sessions for a specific endpoint from the pool.
+        # This is useful for clearing potentially stale connections after 
+        # timeout errors.
+        # @param [URI::HTTP, URI::HTTPS] endpoint The endpoint to clear
+        # @return [nil]
+        def clear_endpoint!(endpoint)
+          endpoint = remove_path_and_query(endpoint)
+          @pool_mutex.synchronize do
+            if @pool.key?(endpoint)
+              @pool[endpoint].each(&:finish)
+              @pool[endpoint].clear
+            end
           end
           nil
         end

--- a/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
+++ b/gems/aws-sdk-core/spec/seahorse/client/net_http/connection_pool_spec.rb
@@ -33,6 +33,107 @@ module Seahorse
             expect(first_pool).to eq second_pool
           end
         end
+
+        describe "#session_for" do
+          let(:pool) { described_class.new }
+          let(:endpoint) { URI.parse('http://example.com') }
+
+          describe "timeout error handling" do
+            it "clears endpoint pool on Net::OpenTimeout" do
+              mock_session = double('session')
+              allow(pool).to receive(:start_session).and_return(mock_session)
+              allow(mock_session).to receive(:read_timeout=)
+              allow(mock_session).to receive(:continue_timeout=)
+              allow(mock_session).to receive(:respond_to?).with(:continue_timeout=).and_return(false)
+              allow(mock_session).to receive(:finish)
+
+              # First call succeeds and session gets added to pool
+              pool.session_for(endpoint) { |s| }
+              expect(pool.size).to eq(1)
+
+              # Second call raises Net::OpenTimeout
+              expect(mock_session).to receive(:finish)
+              expect do
+                pool.session_for(endpoint) { |s| raise Net::OpenTimeout.new }
+              end.to raise_error(Net::OpenTimeout)
+
+              # Pool should be cleared for this endpoint
+              expect(pool.size).to eq(0)
+            end
+
+            it "clears endpoint pool on Timeout::Error" do
+              mock_session = double('session')
+              allow(pool).to receive(:start_session).and_return(mock_session)
+              allow(mock_session).to receive(:read_timeout=)
+              allow(mock_session).to receive(:continue_timeout=)
+              allow(mock_session).to receive(:respond_to?).with(:continue_timeout=).and_return(false)
+              allow(mock_session).to receive(:finish)
+
+              # First call succeeds and session gets added to pool
+              pool.session_for(endpoint) { |s| }
+              expect(pool.size).to eq(1)
+
+              # Second call raises Timeout::Error
+              expect(mock_session).to receive(:finish)
+              expect do
+                pool.session_for(endpoint) { |s| raise Timeout::Error.new }
+              end.to raise_error(Timeout::Error)
+
+              # Pool should be cleared for this endpoint
+              expect(pool.size).to eq(0)
+            end
+
+            it "does not clear pool for other errors" do
+              mock_session = double('session')
+              allow(pool).to receive(:start_session).and_return(mock_session)
+              allow(mock_session).to receive(:read_timeout=)
+              allow(mock_session).to receive(:continue_timeout=)
+              allow(mock_session).to receive(:respond_to?).with(:continue_timeout=).and_return(false)
+              allow(mock_session).to receive(:finish)
+
+              # First call succeeds and session gets added to pool
+              pool.session_for(endpoint) { |s| }
+              expect(pool.size).to eq(1)
+
+              # Second call raises different error
+              expect(mock_session).to receive(:finish)
+              expect do
+                pool.session_for(endpoint) { |s| raise SocketError.new }
+              end.to raise_error(SocketError)
+
+              # Pool should still have the session since it wasn't a timeout error
+              expect(pool.size).to eq(1)
+            end
+          end
+        end
+
+        describe "#clear_endpoint!" do
+          let(:pool) { described_class.new }
+          let(:endpoint) { URI.parse('http://example.com') }
+
+          it "clears sessions for a specific endpoint" do
+            mock_session = double('session')
+            allow(pool).to receive(:start_session).and_return(mock_session)
+            allow(mock_session).to receive(:read_timeout=)
+            allow(mock_session).to receive(:continue_timeout=)
+            allow(mock_session).to receive(:respond_to?).with(:continue_timeout=).and_return(false)
+            allow(mock_session).to receive(:finish)
+
+            # Add session to pool
+            pool.session_for(endpoint) { |s| }
+            expect(pool.size).to eq(1)
+
+            # Clear the endpoint
+            expect(mock_session).to receive(:finish)
+            pool.clear_endpoint!(endpoint)
+            expect(pool.size).to eq(0)
+          end
+
+          it "handles non-existent endpoints gracefully" do
+            endpoint = URI.parse('http://nonexistent.com')
+            expect { pool.clear_endpoint!(endpoint) }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Sometimes AWS can close TCP connections but Ruby pool might not be aware of that. It leads to failures after failures while trying to reach the service on the same existing connection.

<img width="832" height="155" alt="image" src="https://github.com/user-attachments/assets/c1779658-5688-493a-9a6d-27845a8ce6cb" />

We run many services in production, only a few containers have this issue from time to time only in Ruby services. My investigations led to this issue.

This update ensure that when that happens, instead of retrying on the same stalled TCP connection, we create a new one which should work on second try right away.
