### PR TITLE
FEATURE: Add support for credential_source=Environment in SharedConfig

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -9,10 +9,10 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.228.0"
+    MINIMUM_CORE_VERSION = "3.231.0"
 
     # Minimum `aws-sdk-core` version for new S3 gem builds
-    MINIMUM_CORE_VERSION_S3 = "3.228.0"
+    MINIMUM_CORE_VERSION_S3 = "3.231.0"
 
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add support for ENV as credential source for `AssumeRoleCredentials`.
+
 3.230.0 (2025-08-21)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -370,11 +370,14 @@ module Aws
       when 'EcsContainer'
         ECSCredentials.new
       when 'Environment'
-        Credentials.new(
+        creds = Credentials.new(
           ENV['AWS_ACCESS_KEY_ID'],
           ENV['AWS_SECRET_ACCESS_KEY'],
-          ENV['AWS_SESSION_TOKEN']
+          ENV['AWS_SESSION_TOKEN'],
+          account_id: ENV['AWS_ACCOUNT_ID']
         )
+        creds.metrics = ['CREDENTIALS_ENV_VARS']
+        creds
       else
         raise Errors::InvalidCredentialSourceError, "Unsupported credential_source: #{credential_source}"
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -369,6 +369,12 @@ module Aws
         )
       when 'EcsContainer'
         ECSCredentials.new
+      when 'Environment'
+        Credentials.new(
+          ENV['AWS_ACCESS_KEY_ID'],
+          ENV['AWS_SECRET_ACCESS_KEY'],
+          ENV['AWS_SESSION_TOKEN']
+        )
       else
         raise Errors::InvalidCredentialSourceError, "Unsupported credential_source: #{credential_source}"
       end

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -482,7 +482,8 @@ module Aws
           stub_const('ENV', {
             'AWS_ACCESS_KEY_ID' => 'test_access_key',
             'AWS_SECRET_ACCESS_KEY' => 'test_secret_key',
-            'AWS_SESSION_TOKEN' => 'test_session_token'
+            'AWS_SESSION_TOKEN' => 'test_session_token',
+            'AWS_ACCOUNT_ID' => 'test_account_id'
           })
         end
 
@@ -493,9 +494,10 @@ module Aws
           expect(credentials.access_key_id).to eq('test_access_key')
           expect(credentials.secret_access_key).to eq('test_secret_key')
           expect(credentials.session_token).to eq('test_session_token')
+          expect(credentials.account_id).to eq('test_account_id')
         end
 
-        context 'without session token' do
+        context 'minimum inputs required' do
           before do
             stub_const('ENV', {
               'AWS_ACCESS_KEY_ID' => 'test_access_key',
@@ -503,12 +505,13 @@ module Aws
             })
           end
 
-          it 'returns Credentials with nil session token' do
+          it 'returns Credentials with minimum inputs' do
             credentials = config.send(:credentials_from_source, 'Environment', nil)
 
             expect(credentials).to be_a(Aws::Credentials)
             expect(credentials.access_key_id).to eq('test_access_key')
             expect(credentials.secret_access_key).to eq('test_secret_key')
+            expect(credentials.session_token).to be_nil
             expect(credentials.session_token).to be_nil
           end
         end

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -473,5 +473,55 @@ module Aws
           .to eq('http://localhost:8000')
       end
     end
+
+    context 'credentials_from_source' do
+      let(:config) { SharedConfig.new }
+
+      context 'with Environment credential source' do
+        before do
+          stub_const('ENV', {
+            'AWS_ACCESS_KEY_ID' => 'test_access_key',
+            'AWS_SECRET_ACCESS_KEY' => 'test_secret_key',
+            'AWS_SESSION_TOKEN' => 'test_session_token'
+          })
+        end
+
+        it 'returns Credentials with environment variables' do
+          credentials = config.send(:credentials_from_source, 'Environment', nil)
+
+          expect(credentials).to be_a(Aws::Credentials)
+          expect(credentials.access_key_id).to eq('test_access_key')
+          expect(credentials.secret_access_key).to eq('test_secret_key')
+          expect(credentials.session_token).to eq('test_session_token')
+        end
+
+        context 'without session token' do
+          before do
+            stub_const('ENV', {
+              'AWS_ACCESS_KEY_ID' => 'test_access_key',
+              'AWS_SECRET_ACCESS_KEY' => 'test_secret_key'
+            })
+          end
+
+          it 'returns Credentials with nil session token' do
+            credentials = config.send(:credentials_from_source, 'Environment', nil)
+
+            expect(credentials).to be_a(Aws::Credentials)
+            expect(credentials.access_key_id).to eq('test_access_key')
+            expect(credentials.secret_access_key).to eq('test_secret_key')
+            expect(credentials.session_token).to be_nil
+          end
+        end
+      end
+
+      context 'with unsupported credential source' do
+        it 'raises InvalidCredentialSourceError' do
+          expect {
+            config.send(:credentials_from_source, 'UnsupportedSource', nil)
+          }.to raise_error(Aws::Errors::InvalidCredentialSourceError,
+                           'Unsupported credential_source: UnsupportedSource')
+        end
+      end
+    end
   end
 end

--- a/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/shared_config_spec.rb
@@ -473,58 +473,5 @@ module Aws
           .to eq('http://localhost:8000')
       end
     end
-
-    context 'credentials_from_source' do
-      let(:config) { SharedConfig.new }
-
-      context 'with Environment credential source' do
-        before do
-          stub_const('ENV', {
-            'AWS_ACCESS_KEY_ID' => 'test_access_key',
-            'AWS_SECRET_ACCESS_KEY' => 'test_secret_key',
-            'AWS_SESSION_TOKEN' => 'test_session_token',
-            'AWS_ACCOUNT_ID' => 'test_account_id'
-          })
-        end
-
-        it 'returns Credentials with environment variables' do
-          credentials = config.send(:credentials_from_source, 'Environment', nil)
-
-          expect(credentials).to be_a(Aws::Credentials)
-          expect(credentials.access_key_id).to eq('test_access_key')
-          expect(credentials.secret_access_key).to eq('test_secret_key')
-          expect(credentials.session_token).to eq('test_session_token')
-          expect(credentials.account_id).to eq('test_account_id')
-        end
-
-        context 'minimum inputs required' do
-          before do
-            stub_const('ENV', {
-              'AWS_ACCESS_KEY_ID' => 'test_access_key',
-              'AWS_SECRET_ACCESS_KEY' => 'test_secret_key'
-            })
-          end
-
-          it 'returns Credentials with minimum inputs' do
-            credentials = config.send(:credentials_from_source, 'Environment', nil)
-
-            expect(credentials).to be_a(Aws::Credentials)
-            expect(credentials.access_key_id).to eq('test_access_key')
-            expect(credentials.secret_access_key).to eq('test_secret_key')
-            expect(credentials.session_token).to be_nil
-            expect(credentials.session_token).to be_nil
-          end
-        end
-      end
-
-      context 'with unsupported credential source' do
-        it 'raises InvalidCredentialSourceError' do
-          expect {
-            config.send(:credentials_from_source, 'UnsupportedSource', nil)
-          }.to raise_error(Aws::Errors::InvalidCredentialSourceError,
-                           'Unsupported credential_source: UnsupportedSource')
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Implement missing `credential_source = Environment` support in Ruby SDK

### Problem

The [AWS CLI documentation](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) clearly states that `credential_source` supports three values:

- `Environment` – Specifies that the AWS CLI is to retrieve source credentials from environment variables
- `Ec2InstanceMetadata` – Specifies that the AWS CLI is to use the IAM role attached to the EC2 instance profile  
- `EcsContainer` – Specifies that the AWS CLI is to use the IAM role attached to the ECS container

However, the Ruby SDK only implemented the latter two, causing `InvalidCredentialSourceError` when users try to use the documented `Environment` option.

### Solution

This adds the missing `Environment` case in `SharedConfig#credentials_from_source` that retrieves credentials from:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY` 
- `AWS_SESSION_TOKEN`

This matches the documented AWS CLI behavior.

### Testing

- Added comprehensive test coverage for the new `Environment` credential source
- All existing gems tests pass (19620 examples, 0 failures)
- Verified no regressions across AWS SDK ecosystem

### Impact

Fixes a gap where documented AWS credential functionality throws `InvalidCredentialSourceError` in the Ruby SDK.


