### PR TITLE
fix: honor closed connection to avoid timeouts on all AWS API calls

### DIFF
--- a/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
+++ b/gems/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb
@@ -76,8 +76,14 @@ module Seahorse
         #
         # @return (see #session_for)
         def request(endpoint, request, &block)
-          session_for(endpoint) do |http|
-            yield(http.request(request))
+          response = nil
+          should_close = { value: false }
+
+          session_for(endpoint, close_connection: should_close) do |http|
+            response = http.request(request)
+            # Check if server wants to close the connection
+            should_close[:value] = response['connection']&.downcase == 'close'
+            yield(response)
           end
         end
 
@@ -87,7 +93,7 @@ module Seahorse
         # @yieldparam [Net::HTTPSession] session
         #
         # @return [nil]
-        def session_for(endpoint, &block)
+        def session_for(endpoint, close_connection: { value: false }, &block)
           endpoint = remove_path_and_query(endpoint)
           session = nil
 
@@ -109,10 +115,15 @@ module Seahorse
             session.finish if session
             raise
           else
-            # No error raised? Good, check the session into the pool.
-            @pool_mutex.synchronize do
-              @pool[endpoint] = [] unless @pool.key?(endpoint)
-              @pool[endpoint] << session
+            # Only pool if server didn't request close
+            if close_connection[:value]
+              session.finish
+            else
+              # No error raised? Good, check the session into the pool.
+              @pool_mutex.synchronize do
+                @pool[endpoint] = [] unless @pool.key?(endpoint)
+                @pool[endpoint] << session
+              end
             end
           end
           nil


### PR DESCRIPTION
We have several microservices (all using this library) that fail to open a TCP connection (execution expired), mainly in STS and S3.

When investigating and going to a node that hosts the pod with the issue, we see many connections left in CLOSE_WAIT. When checking the issue https://github.com/aws/aws-sdk-ruby/issues/3193#issuecomment-2667052220, we seem not to be alone in having this issue.

Since the only way connections are closed and not put in the queue it's either if:
- keep alive is reached
- exception is raised

But if AWS server send `Connection: close` the app will never close it.

This MR attempts to fix that behaviour to avoid any impact to apps using this lib.

## More context

```
ruby '3.3.6'

gem 'rails', '~> 7.2'
    aws-sdk-core (3.232.0)
      aws-eventstream (~> 1, >= 1.3.0)
      aws-partitions (~> 1, >= 1.992.0)
      aws-sigv4 (~> 1.9)
      base64
      bigdecimal
      jmespath (~> 1, >= 1.6.1)
      logger
    aws-sdk-kms (1.96.0)
      aws-sdk-core (~> 3, >= 3.210.0)
      aws-sigv4 (~> 1.5)
    aws-sdk-lambda (1.148.0)
      aws-sdk-core (~> 3, >= 3.216.0)
      aws-sigv4 (~> 1.5)
    aws-sdk-s3 (1.199.0)
      aws-sdk-core (~> 3, >= 3.231.0)
      aws-sdk-kms (~> 1)
      aws-sigv4 (~> 1.5)
    aws-sdk-ssm (1.191.0)
      aws-sdk-core (~> 3, >= 3.216.0)
      aws-sigv4 (~> 1.5)
    aws-sigv4 (1.10.1)
      aws-eventstream (~> 1, >= 1.0.2)
```

Example logs track traces

```
Seahorse::Client::NetworkingError (Failed to open TCP connection to XXXX.s3.eu-central-1.amazonaws.com:443 (execution expired)):
  
app/contexts/attachments/commands/create_attachment.rb:40:in `create_attachment'
app/contexts/attachments/commands/create_attachment.rb:22:in `find_or_create_attachment'
app/contexts/attachments/commands/create_attachment.rb:10:in `call'
app/contexts/attachments/services/create_attachment.rb:21:in `create_attachment'
app/contexts/attachments/services/create_attachment.rb:12:in `call'
app/service_controllers/attachment_service_controller.rb:4:in `create'
app/controllers/v3/attachments_controller.rb:44:in `create'
lib/middlewares/prometheus/team_tagger.rb:14:in `call'
```

When we go to the node where the issue happens, we have this
```
tcp      6 3380 CLOSE_WAIT src=10.XX.XX.XX dst=3.5.136.54 sport=40820 dport=443 src=3.5.136.54 dst=10.XX.XX.XX sport=443 dport=10434 [ASSURED] mark=128 secctx=system_u:object_r:unlabeled_t:s0 use=1
```

It's been nearly 8 MIN since the TCP received the FIN from S3 (meaning, S3 said to the app => please close this, the app waits for things to finish).
It's consistent with what AWS said; the app is somehow not closing its connection (we were in a live call with support).

All Ruby apps using this SDK are impacted by the issue (CLOSE_WAIT), and other calls to external services that don't rely on this SDK work fine.

When checking other issues we can see that we're not the only one impacted by these connection expired.