### PR TITLE
Fix `when_required` mode for `request_checksum_calculation`

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -9,10 +9,10 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.231.0"
+    MINIMUM_CORE_VERSION = "3.234.0"
 
     # Minimum `aws-sdk-core` version for new S3 gem builds
-    MINIMUM_CORE_VERSION_S3 = "3.231.0"
+    MINIMUM_CORE_VERSION_S3 = "3.234.0"
 
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix `request_checksum_calculation` when set to `when_required` to only calculate checksums when explicitly provided by user.
+* Issue - Fix `request_checksum_calculation` `when_required` mode to only calculate checksums when explicitly provided by user.
 
 3.233.0 (2025-09-23)
 ------------------

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `request_checksum_calculation` when set to `when_required` to only calculate checksums when explicitly provided by user.
+
 3.233.0 (2025-09-23)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
@@ -190,7 +190,6 @@ module Aws
               name: "x-amz-checksum-#{algorithm.downcase}",
               request_algorithm_header: request_algorithm_header(context)
             }
-
             context[:http_checksum][:request_algorithm] = request_algorithm
             calculate_request_checksum(context, request_algorithm)
           end
@@ -249,6 +248,7 @@ module Aws
           return unless context.operation.http_checksum
 
           input_member = context.operation.http_checksum['requestAlgorithmMember']
+
           context.params[input_member.to_sym] ||= DEFAULT_CHECKSUM if input_member
         end
 
@@ -271,25 +271,41 @@ module Aws
           context.operation.http_checksum['responseAlgorithms']
         end
 
-        def checksum_required?(context)
-          (http_checksum = context.operation.http_checksum) &&
-            (checksum_required = http_checksum['requestChecksumRequired']) &&
-            (checksum_required && context.config.request_checksum_calculation == 'when_required')
-        end
-
-        def checksum_optional?(context)
-          context.operation.http_checksum &&
-            context.config.request_checksum_calculation != 'when_required'
-        end
-
         def checksum_provided_as_header?(headers)
           headers.any? { |k, _| k.start_with?('x-amz-checksum-') }
         end
 
+        # Determines whether a request checksum should be calculated.
+        # 1. **No existing checksum in header**: Skips if checksum header already present
+        # 2. **Operation support**: Considers model, client configuration and user input.
         def should_calculate_request_checksum?(context)
           !checksum_provided_as_header?(context.http_request.headers) &&
-            request_algorithm_selection(context) &&
-            (checksum_required?(context) || checksum_optional?(context))
+            checksum_applicable?(context)
+        end
+
+        # Checks if checksum calculation should proceed based on operation requirements and client settings.
+        # Returns true when any of these conditions are met:
+        # 1. http checksum's requestChecksumRequired is true
+        # 2. Config for request_checksum_calculation is "when_supported"
+        # 3. Config for request_checksum_calculation is "when_required" AND user provided checksum algorithm
+        def checksum_applicable?(context)
+          http_checksum = context.operation.http_checksum
+          return false unless http_checksum
+
+          return true if http_checksum['requestChecksumRequired']
+
+          if (algorithm_member = http_checksum['requestAlgorithmMember'])
+            case context.config.request_checksum_calculation
+            when 'when_supported'
+              true
+            when 'when_required'
+              !context.params[algorithm_member.to_sym].nil?
+            else
+              false
+            end
+          else
+            false
+          end
         end
 
         def choose_request_algorithm!(context)

--- a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/plugins/checksum_algorithm.rb
@@ -294,15 +294,13 @@ module Aws
 
           return true if http_checksum['requestChecksumRequired']
 
-          if (algorithm_member = http_checksum['requestAlgorithmMember'])
-            case context.config.request_checksum_calculation
-            when 'when_supported'
-              true
-            when 'when_required'
-              !context.params[algorithm_member.to_sym].nil?
-            else
-              false
-            end
+          return false unless (algorithm_member = http_checksum['requestAlgorithmMember'])
+
+          case context.config.request_checksum_calculation
+          when 'when_supported'
+            true
+          when 'when_required'
+            !context.params[algorithm_member.to_sym].nil?
           else
             false
           end

--- a/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/plugins/checksum_algorithm_spec.rb
@@ -47,7 +47,7 @@ module Aws
             'String' => { 'type' => 'string' },
             'ChecksumAlgorithm' => {
               'type' => 'string',
-              'enum' => ['CRC32', 'CRC32C', 'CRC64NVME', 'SHA1', 'SHA256']
+              'enum' => %w[CRC32 CRC32C CRC64NVME SHA1 SHA256]
             },
             'SomeInput' => {
               'type' => 'structure',
@@ -404,6 +404,16 @@ module Aws
           resp = client.http_checksum_operation
           expect(resp.context.http_request.headers['x-amz-checksum-crc32'])
             .to be_nil
+        end
+
+        it 'when_required; given algorithm; include a checksum' do
+          client = checksum_client.new(
+            stub_responses: true,
+            request_checksum_calculation: 'when_required'
+          )
+          resp = client.http_checksum_operation(checksum_algorithm: 'CRC32')
+          expect(resp.context.http_request.headers['x-amz-checksum-crc32'])
+            .to eq('AAAAAA==')
         end
       end
 

--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix multipart upload to respect `request_checksum_calculation` `when_required` mode.
+
 1.200.0 (2025-10-15)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -117,7 +117,10 @@ module Aws
       end
 
       def create_opts(options)
-        opts = checksum_not_required?(options) ? {} : { checksum_algorithm: Aws::Plugins::ChecksumAlgorithm::DEFAULT_CHECKSUM }
+        opts = {}
+        unless checksum_not_required?(options)
+          opts[:checksum_algorithm] = Aws::Plugins::ChecksumAlgorithm::DEFAULT_CHECKSUM
+        end
         opts[:checksum_type] = 'FULL_OBJECT' if has_checksum_key?(options.keys)
         CREATE_OPTIONS.each_with_object(opts) { |k, h| h[k] = options[k] if options.key?(k) }
       end

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -51,11 +51,10 @@ module Aws
 
       def complete_upload(upload_id, parts, file_size, options)
         @client.complete_multipart_upload(
-          **complete_opts(options).merge(
-            upload_id: upload_id,
-            multipart_upload: { parts: parts },
-            mpu_object_size: file_size
-          )
+          **complete_opts(options),
+          upload_id: upload_id,
+          multipart_upload: { parts: parts },
+          mpu_object_size: file_size
         )
       rescue StandardError => e
         abort_upload(upload_id, options, [e])
@@ -79,8 +78,8 @@ module Aws
       rescue MultipartUploadError => e
         raise e
       rescue StandardError => e
-        msg = "failed to abort multipart upload: #{e.message}. "\
-          "Multipart upload failed: #{errors.map(&:message).join('; ')}"
+        msg = "failed to abort multipart upload: #{e.message}. " \
+              "Multipart upload failed: #{errors.map(&:message).join('; ')}"
         raise MultipartUploadError.new(msg, errors + [e])
       end
 
@@ -113,8 +112,12 @@ module Aws
         keys.any? { |key| checksum_key?(key) }
       end
 
+      def checksum_not_required?(options)
+        @client.config.request_checksum_calculation == 'when_required' && !options[:checksum_algorithm]
+      end
+
       def create_opts(options)
-        opts = { checksum_algorithm: Aws::Plugins::ChecksumAlgorithm::DEFAULT_CHECKSUM }
+        opts = checksum_not_required?(options) ? {} : { checksum_algorithm: Aws::Plugins::ChecksumAlgorithm::DEFAULT_CHECKSUM }
         opts[:checksum_type] = 'FULL_OBJECT' if has_checksum_key?(options.keys)
         CREATE_OPTIONS.each_with_object(opts) { |k, h| h[k] = options[k] if options.key?(k) }
       end
@@ -148,9 +151,7 @@ module Aws
             resp = @client.upload_part(p)
             p[:body].close
             completed_part = { etag: resp.etag, part_number: p[:part_number] }
-            algorithm = resp.context.params[:checksum_algorithm].downcase
-            k = "checksum_#{algorithm}".to_sym
-            completed_part[k] = resp.send(k)
+            apply_part_checksum(resp, completed_part)
             completed.push(completed_part)
           rescue StandardError => e
             abort_upload = true
@@ -162,6 +163,13 @@ module Aws
 
         upload_attempts.times { completion_queue.pop }
         errors
+      end
+
+      def apply_part_checksum(resp, part)
+        return unless (checksum = resp.context.params[:checksum_algorithm])
+
+        k = :"checksum_#{checksum.downcase}"
+        part[k] = resp.send(k)
       end
 
       def compute_default_part_size(file_size)


### PR DESCRIPTION
When using our multipart upload utility, I’m noticed that there's a checksum attached to the request - even if I set the client to only consider checksums when required:
```ruby
client_params = {region: 'us-west-2', request_checksum_calculation: 'when_required'}
client = Aws::S3::Client.new(client_params)
tm = Aws::S3::TransferManager.new(client: client)
upload_params = { thread_count: 100 }
tm.upload_file(file, bucket: 'terajul-hagrid', key: 'test-key2', **upload_params)
 
# [Aws::S3::Client 200 1.999035 0 retries] 
#   put_object(
#          bucket:"terajul-hagrid",
#          key:"test-key2",
#          body:#<File:test_30mb.bin (31457280 bytes)>,
#          checksum_algorithm:"CRC32"
#   ) 
```

[PutObject](https://github.com/aws/aws-sdk-ruby/blob/version-3/apis/s3/2006-03-01/api-2.json#L1183-L1186) and [UploadPart](https://github.com/aws/aws-sdk-ruby/blob/version-3/apis/s3/2006-03-01/api-2.json#L1350-L1353) models does not require checksum. So when the client is set to `when_required` mode, checksum should not be applied unless the user has specified it.  This PR intends to fix that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
