### PR TITLE
Add SEO meta description to title

### DIFF
--- a/doc-src/templates/default/layout/html/layout.erb
+++ b/doc-src/templates/default/layout/html/layout.erb
@@ -5,6 +5,7 @@
     <!-- Docs Metrics + Cookie Consent Script -->
     <meta name="guide-name" content="API Reference">
     <meta name="service-name" content="AWS SDK For Ruby V3">
+    <meta name="description" content="<%= @page_title %>">
     <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
   </head>
   <body>


### PR DESCRIPTION
Adds a description meta tag for SEO to title. Page title will be something like "Module: Aws::ACM" or "Class: Aws::SSO::Client"