### PR TITLE
Fix region configuration for LoginCredential's Signin client

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix region configuration for LoginCredential's Signin client.
+
 3.238.0 (2025-11-19)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -110,7 +110,10 @@ module Aws
       return unless Aws.shared_config.config_enabled? && options[:config]&.profile
 
       with_metrics('CREDENTIALS_CODE') do
-        creds = Aws.shared_config.login_credentials_from_config(profile: options[:config].profile)
+        creds = Aws.shared_config.login_credentials_from_config(
+          profile: options[:config].profile,
+          region: options[:config].region
+        )
         return unless creds
 
         creds.metrics << 'CREDENTIALS_CODE'
@@ -170,7 +173,7 @@ module Aws
       return unless Aws.shared_config.config_enabled?
 
       profile_name = determine_profile_name(options)
-      Aws.shared_config.login_credentials_from_config(profile: profile_name)
+      Aws.shared_config.login_credentials_from_config(profile: profile_name, region: options[:config].region)
     rescue Errors::NoSuchProfileError
       nil
     end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/shared_config.rb
@@ -176,8 +176,8 @@ module Aws
     # file, if present.
     def login_credentials_from_config(opts = {})
       p = opts[:profile] || @profile_name
-      credentials = login_credentials_from_profile(@parsed_credentials, p)
-      credentials ||= login_credentials_from_profile(@parsed_config, p) if @parsed_config
+      credentials = login_credentials_from_profile(@parsed_credentials, p, opts[:region])
+      credentials ||= login_credentials_from_profile(@parsed_config, p, opts[:region]) if @parsed_config
       credentials
     end
 
@@ -479,10 +479,12 @@ module Aws
       end
     end
 
-    def login_credentials_from_profile(cfg, profile)
+    def login_credentials_from_profile(cfg, profile, region)
       return unless @parsed_config && (prof_config = cfg[profile]) && prof_config['login_session']
 
-      creds = LoginCredentials.new(login_session: prof_config['login_session'])
+      cfg = { login_session: prof_config['login_session'] }
+      cfg[:region] = region if region
+      creds = LoginCredentials.new(cfg)
       creds.metrics << 'CREDENTIALS_PROFILE_LOGIN'
       creds
     end

--- a/gems/aws-sdk-core/spec/aws/login_credentials_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/login_credentials_spec.rb
@@ -186,6 +186,10 @@ module Aws
           }
         end
 
+        before do
+          allow_any_instance_of(LoginCredentials).to receive(:warn).with(/WARNING: OpenSSL 3.6.x/)
+        end
+
         it 'refreshes the token' do
           mock_token_file(login_session, cached_token)
           client.stub_responses(:create_o_auth_2_token, signin_resp)

--- a/services.json
+++ b/services.json
@@ -1220,7 +1220,8 @@
     "models": "signer/2017-08-25"
   },
   "Signin": {
-    "models": "signin/2023-01-01"
+    "models": "signin/2023-01-01",
+    "gemName": "aws-sdk-core"
   },
   "SimSpaceWeaver": {
     "models": "simspaceweaver/2022-10-28"


### PR DESCRIPTION
Fixes issue where Signin client initialization fails due to missing region configuration.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
