### PR TITLE
fix error with login_credentials when config is enabled

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `login_credentials` in credentials chain when config is enabled.
+
 3.239.1 (2025-11-21)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb
@@ -173,7 +173,8 @@ module Aws
       return unless Aws.shared_config.config_enabled?
 
       profile_name = determine_profile_name(options)
-      Aws.shared_config.login_credentials_from_config(profile: profile_name, region: options[:config].region)
+      region = options[:config].region if options[:config]
+      Aws.shared_config.login_credentials_from_config(profile: profile_name, region: region)
     rescue Errors::NoSuchProfileError
       nil
     end

--- a/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/credential_provider_chain_spec.rb
@@ -169,6 +169,11 @@ module Aws
       it 'defaults to nil' do
         expect(credentials).to be(nil)
       end
+
+      it 'defaults to nil when config is enabled' do
+        Aws.shared_config.fresh(config_enabled: true)
+        expect(credentials).to be(nil)
+      end
     end
 
     describe 'with shared credentials' do


### PR DESCRIPTION
We're invoking the credential provider chain in our production code with no args:

```
Aws::CredentialProviderChain.new.resolve
```

This fails on 176 with a `NameError` when config is enabled:

```
NameError:
  undefined local variable or method `region' for #<Aws::CredentialProviderChain:0x00000001094dc100 @config=nil>
aws-sdk-core-3.239.1/lib/aws-sdk-core/credential_provider_chain.rb:176:in `login_credentials'
aws-sdk-core-3.239.1/lib/aws-sdk-core/credential_provider_chain.rb:13:in `block in resolve'
aws-sdk-core-3.239.1/lib/aws-sdk-core/credential_provider_chain.rb:12:in `each'
aws-sdk-core-3.239.1/lib/aws-sdk-core/credential_provider_chain.rb:12:in `resolve'
```

PR #3319[^1] inadvertently caused this error by not checking if config was passed. Elsewhere in the file the code is guarding against that.

Write a failing test, then make it pass.

[^1]: https://github.com/aws/aws-sdk-ruby/pull/3319

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
