### PR TITLE
Prioritize json over cbor for stubbed client

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix protocol selection for stubbed clients.
+
 3.239.2 (2025-11-25)
 ------------------
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Fix protocol selection for stubbed clients.
+* Issue - Prioritizes JSON over CBOR when both are supported for stubbed clients.
 
 3.239.2 (2025-11-25)
 ------------------

--- a/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/client_stubs.rb
@@ -280,6 +280,12 @@ module Aws
     end
 
     def protocol_helper
+      # Prioritize JSON over CBOR when CBOR is the configured protocol but both are supported. This is to match similar
+      # prioritization in service.rb code generation.
+      if @config.api.metadata['protocol'] == 'smithy-rpc-v2-cbor' && @config.api.metadata['protocols']&.include?('json')
+        return Stubbing::Protocols::Json.new
+      end
+
       case @config.api.metadata['protocol']
       when 'json'               then Stubbing::Protocols::Json
       when 'rest-json'          then Stubbing::Protocols::RestJson

--- a/gems/aws-sdk-core/spec/aws/client_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/client_spec.rb
@@ -208,6 +208,36 @@ Known AWS regions include (not specific to this service):
 
       end
 
+      describe 'protocol_helper' do
+        it 'returns configured protocol' do
+          service = ApiHelper.sample_service(metadata: { 'protocol' => 'query' })
+          client_class = ApiHelper.sample_client(service: service)
+          client = client_class.new(options)
+
+          helper = client.send(:protocol_helper)
+          expect(helper).to be_a(Aws::Stubbing::Protocols::Query)
+        end
+
+        it 'prioritizes Json over RpcV2 when both protocols are supported' do
+          service = ApiHelper.sample_service(
+            metadata: {
+              'protocol' => 'smithy-rpc-v2-cbor',
+              'protocols' => %w[smithy-rpc-v2-cbor json]
+            }
+          )
+          client_class = ApiHelper.sample_client(service: service)
+          client = client_class.new(options)
+
+          helper = client.send(:protocol_helper)
+          expect(helper).to be_a(Aws::Stubbing::Protocols::Json)
+        end
+
+        it 'raises error for unsupported protocol' do
+          expect do
+            ApiHelper.sample_service(metadata: { 'protocol' => 'unsupported' })
+          end.to raise_error(/unsupported protocol/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-ruby/issues/3325.

During protocol selection, JSON is prioritized over CBOR for performance reasons (https://github.com/aws/aws-sdk-ruby/pull/3256). However, this customized behavior was not reflected in stubbed clients. This PR adds a fix to prioritize JSON over CBOR for stubbed clients.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
