### PR TITLE
Correctly tests US-ASCII encoding in S3 200 errors

### DIFF
--- a/gems/aws-sdk-s3/spec/plugins/http_200_errors_spec.rb
+++ b/gems/aws-sdk-s3/spec/plugins/http_200_errors_spec.rb
@@ -33,7 +33,7 @@ module Aws
             .to raise_error(Seahorse::Client::NetworkingError, /Empty or incomplete response body/)
         end
 
-        it 'gracefully handle non-UTF encoding' do
+        it 'gracefully checks body when given ASCII encoding' do
           response = <<~XML
             <?xml version="1.0" encoding="UTF-8"?>
             <DeleteResult>
@@ -44,14 +44,16 @@ module Aws
             </DeleteResult>
           XML
 
+          allow_any_instance_of(Seahorse::Client::Http::Response)
+            .to receive(:body_contents)
+            .and_return(response.dup.force_encoding('US-ASCII'))
+
           # No headers to replicate omitted Content-Type header
-          stub_request(:post, 'https://test-bucket.s3.amazonaws.com/?delete')
-            .to_return(status: 200, body: response, headers: {})
+          stub_request(:post, 'https://test-bucket.s3.amazonaws.com/?delete').to_return(status: 200, headers: {})
 
           expect { client.delete_objects(bucket: 'test-bucket', delete: { objects: [{ key: 'test' }] }) }
             .not_to raise_error
         end
-
       end
     end
   end


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
