### PR TITLE
feat(DEVPRD-3179): add automated semantic versioning and commit linting

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,11 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    uses: KeepTruckin/github-workflows-catalog/.github/workflows/commitlint.yaml@master
+    with:
+      node_version: "20"

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,15 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+      - development
+
+jobs:
+  release:
+    uses: KeepTruckin/github-workflows-catalog/.github/workflows/semantic-release.yaml@master
+    secrets:
+      KTBOT_GH_PAT: ${{ secrets.KTBOT_GH_PAT }}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,52 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Type must be one of these
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat", // New feature
+        "fix", // Bug fix
+        "docs", // Documentation only changes
+        "style", // Changes that don't affect code meaning (formatting, etc)
+        "refactor", // Code change that neither fixes a bug nor adds a feature
+        "perf", // Performance improvement
+        "test", // Adding or updating tests
+        "chore", // Changes to build process or auxiliary tools
+        "revert", // Revert a previous commit
+        "build", // Changes to build system or dependencies
+        "ci", // Changes to CI configuration
+      ],
+    ],
+
+    // Scope is REQUIRED and should be the JIRA ticket (e.g., DEVPRD-3177)
+    "scope-empty": [2, "never"],
+    "scope-case": [2, "always", "upper-case"],
+
+    // Subject must not be sentence-case, start-case, pascal-case, upper-case
+    "subject-case": [
+      2,
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"],
+    ],
+
+    // Subject must not end with a period
+    "subject-full-stop": [2, "never", "."],
+
+    // Subject must not be empty
+    "subject-empty": [2, "never"],
+
+    // Type must not be empty
+    "type-empty": [2, "never"],
+
+    // Header max length (100 characters)
+    "header-max-length": [2, "always", 100],
+
+    // Body max line length (100 characters)
+    "body-max-line-length": [2, "always", 100],
+
+    // Footer max line length (100 characters)
+    "footer-max-line-length": [2, "always", 100],
+  },
+};


### PR DESCRIPTION
Implement semantic-release for automated version management and changelog generation, plus commitlint for commit message validation based on conventional commits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
