### PR TITLE
Fix waiter error matcher to handle boolean acceptors

### DIFF
--- a/build_tools/services.rb
+++ b/build_tools/services.rb
@@ -9,10 +9,10 @@ module BuildTools
     MANIFEST_PATH = File.expand_path('../../services.json', __FILE__)
 
     # Minimum `aws-sdk-core` version for new gem builds
-    MINIMUM_CORE_VERSION = "3.241.4"
+    MINIMUM_CORE_VERSION = "3.243.1"
 
     # Minimum `aws-sdk-core` version for new S3 gem builds
-    MINIMUM_CORE_VERSION_S3 = "3.243.0"
+    MINIMUM_CORE_VERSION_S3 = "3.243.1"
 
     EVENTSTREAM_PLUGIN = "Aws::Plugins::EventStreamConfiguration"
 

--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix waiter error matcher to handle both boolean and boolean-string acceptors.
+
 3.243.0 (2026-03-05)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/waiters/poller.rb
@@ -97,8 +97,8 @@ module Aws
 
       def matches_error?(acceptor, response)
         case acceptor['expected']
-        when 'false' then response.error.nil?
-        when 'true' then !response.error.nil?
+        when 'false', false then response.error.nil?
+        when 'true', true then !response.error.nil?
         else
           response.error.is_a?(Aws::Errors::ServiceError) &&
             response.error.code == acceptor['expected'].delete('.')

--- a/gems/aws-sdk-core/spec/aws/waiters_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/waiters_spec.rb
@@ -221,8 +221,12 @@ module Aws
           context 'expected is true' do
             it 'succeeds when matched with any error' do
               client.stub_responses(:waiter_operation, RuntimeError.new)
-              expect { client.wait_until(:error_matcher_with_true) }
-                .not_to raise_error
+              expect { client.wait_until(:error_matcher_with_true) }.not_to raise_error
+            end
+
+            it 'succeeds when matched with any error' do
+              client.stub_responses(:waiter_operation, RuntimeError.new)
+              expect { client.wait_until(:error_matcher_with_boolean_true) }.not_to raise_error
             end
           end
 
@@ -233,8 +237,12 @@ module Aws
                 'ResourceNotFoundException',
                 { complex_object: { string_member: 'expected' } }
               )
-              expect { client.wait_until(:error_matcher_with_false) }
-                .not_to raise_error
+              expect { client.wait_until(:error_matcher_with_false) }.not_to raise_error
+            end
+
+            it 'succeeds when no error is received' do
+              client.stub_responses(:waiter_operation, complex_object: { string_member: 'expected' })
+              expect { client.wait_until(:error_matcher_with_boolean_false) }.not_to raise_error
             end
 
             it 'fails when matched' do

--- a/gems/aws-sdk-core/spec/fixtures/waiters/waiters.json
+++ b/gems/aws-sdk-core/spec/fixtures/waiters/waiters.json
@@ -383,6 +383,30 @@
           "argument": "BooleanList"
         }
       ]
+    },
+    "ErrorMatcherWithBooleanTrue": {
+      "delay": 0,
+      "operation": "WaiterOperation",
+      "maxAttempts": 25,
+      "acceptors": [
+        {
+          "matcher": "error",
+          "expected": true,
+          "state": "success"
+        }
+      ]
+    },
+    "ErrorMatcherWithBooleanFalse": {
+      "delay": 0,
+      "operation": "WaiterOperation",
+      "maxAttempts": 25,
+      "acceptors": [
+        {
+          "matcher": "error",
+          "expected": false,
+          "state": "success"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Some waiter models (Lambda `FunctionExists`, ACM-PCA `CertificateAuthorityCSRCreated`, `CertificateIssued`) define the error matcher's expected value as a boolean (`false`) instead of a string (`"false"`).

The `matches_error?` method in Poller only matched against string values in its case/when, so boolean expected values fell through to the else branch, causing the acceptor to silently never match. This resulted in unnecessary retries until max attempts.

This change adds boolean literals alongside the existing string variants in the when clauses so both types are handled correctly.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
