### PR TITLE
Skip sparse trait

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/views/client_api_module.rb
@@ -44,6 +44,7 @@ module AwsSdkCodeGenerator
         'eventpayload' => false,
         'exceptionEvent' => false, # internal, exceptions cannot be events
         # other
+        'sparse' => false,
         'synthetic' => false,
         'box' => false,
         'fault' => false,

--- a/build_tools/aws-sdk-code-generator/spec/protocol-tests-ignore-list.json
+++ b/build_tools/aws-sdk-code-generator/spec/protocol-tests-ignore-list.json
@@ -2,105 +2,105 @@
   "json": {
     "input": {
       "AwsJson11SparseMapsSerializeNullValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "AwsJson11SparseListsSerializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     },
     "output": {
       "AwsJson11SparseMapsDeserializeNullValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "AwsJson11SparseListsDeserializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     }
   },
   "rest-json": {
     "input": {
       "RestJsonSparseListsSerializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSparseJsonMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSerializesSparseNullMapValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSerializesZeroValuesInSparseMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSerializesSparseSetMap" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSerializesSparseSetMapAndRetainsNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     },
     "output": {
       "RestJsonSparseListsSerializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonSparseJsonMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonDeserializesSparseNullMapValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonDeserializesZeroValuesInSparseMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonDeserializesSparseSetMap" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RestJsonDeserializesSparseSetMapAndRetainsNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     }
   },
   "smithy-rpc-v2-cbor": {
     "input": {
       "RpcV2CborSparseMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSerializesNullMapValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSerializesSparseSetMap" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSerializesSparseSetMapAndRetainsNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSerializesZeroValuesInSparseMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSparseMapsSerializeNullValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSparseListsSerializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     },
     "output": {
       "RpcV2CborSparseJsonMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborDeserializesNullMapValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborDeserializesSparseSetMapAndRetainsNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborDeserializesZeroValuesInSparseMaps" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSparseMapsDeserializeNullValues" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       },
       "RpcV2CborSparseListsDeserializeNull" : {
-        "description": "Sparse trait support required to test"
+        "description": "Sparse trait not supported"
       }
     }
 


### PR DESCRIPTION
Some service models now include the `sparse` trait on list and map shapes. The v3 codegen in `client_api_module` doesn't support sparse semantics, but the presence of the trait in a model shouldn't break code generation.

This change makes codegen gracefully ignore the sparse trait so that affected services can still be generated.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
