### PR TITLE
Explicitly set 0600 permissions on SSO/login cache files

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Explicitly set 0600 permissions on SSO/login cache files.
+
 3.244.0 (2026-03-18)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/login_credentials.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/login_credentials.rb
@@ -221,6 +221,7 @@ module Aws
         temp_file.write(Json.dump(cached_token))
         temp_file.close
         FileUtils.mv(temp_file.path, login_cache_file)
+        File.chmod(0o600, login_cache_file)
       ensure
         temp_file.unlink if File.exist?(temp_file.path) # Ensure temp file is cleaned up
       end

--- a/gems/aws-sdk-core/lib/aws-sdk-core/sso_token_provider.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/sso_token_provider.rb
@@ -108,6 +108,7 @@ module Aws
       cached_token = token_json.dup
       cached_token['expiresAt'] = cached_token['expiresAt'].iso8601
       File.write(sso_cache_file, Json.dump(cached_token))
+      File.chmod(0o600, sso_cache_file)
     end
 
     def sso_cache_file

--- a/gems/aws-sdk-core/spec/aws/sso_token_provider_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/sso_token_provider_spec.rb
@@ -56,6 +56,7 @@ module Aws
         expect(arg1).to eq(path)
         expect(Json.load(arg2)).to eq(expected_token)
       end
+      expect(File).to receive(:chmod).with(0o600, path)
     end
 
     describe '#initialize' do

--- a/gems/aws-sdk-core/spec/login_credentials_helper.rb
+++ b/gems/aws-sdk-core/spec/login_credentials_helper.rb
@@ -20,7 +20,7 @@ module LoginCredentialsHelper
   end
 
   def expect_token_write_back(expected_token)
-    actual_token = JSON.parse(File.read(token_file.path))
+    actual_token = JSON.load_file(token_file.path)
     expect(actual_token).to eq(JSON.parse(JSON.dump(expected_token)))
     expect(File.stat(token_file.path).mode & 0o777).to eq(0o600)
   end

--- a/gems/aws-sdk-core/spec/login_credentials_helper.rb
+++ b/gems/aws-sdk-core/spec/login_credentials_helper.rb
@@ -22,6 +22,7 @@ module LoginCredentialsHelper
   def expect_token_write_back(expected_token)
     actual_token = JSON.parse(File.read(token_file.path))
     expect(actual_token).to eq(JSON.parse(JSON.dump(expected_token)))
+    expect(File.stat(token_file.path).mode & 0o777).to eq(0o600)
   end
 
   def verify_dpop(dpop_proof)


### PR DESCRIPTION
Add explicit chmod to ensure correct permissions on SSO and login cache files regardless of how the file was originally created.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
