### PR TITLE
Fix Ruby 3.2+ compatibility in aws-sdk-neptunedata detailed_message overrides

### DIFF
--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/error_list.rb
@@ -13,10 +13,12 @@ module AwsSdkCodeGenerator
         # excluding event shapes marked as error
         if error_struct?(shape)
           members = shape['members'].inject([]) do |arr, (k, v)|
+            member_name = Underscore.underscore(k)
             arr << {
-              name: Underscore.underscore(k),
+              name: member_name,
               type: Docstring.ucfirst(v['type'] ||'String'),
-              shared: k.downcase == 'message' || k.downcase == 'code'
+              shared: k.downcase == 'message' || k.downcase == 'code',
+              detailed_message: member_name == 'detailed_message'
             }
             arr
           end

--- a/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/rbs/error_list.rb
+++ b/build_tools/aws-sdk-code-generator/lib/aws-sdk-code-generator/rbs/error_list.rb
@@ -11,10 +11,14 @@ module AwsSdkCodeGenerator
         @errors = @api['shapes'].inject([]) do |es, (name, shape)|
           if error_struct?(shape)
             members = shape["members"].map do |member_name, member_body|
-              MethodSignature.new(
-                method_name: Underscore.underscore(member_name),
-                overloads: ["() -> #{Docstring.ucfirst(member_body['type'] ||'::String')}"]
-              )
+              method_name = Underscore.underscore(member_name)
+              return_type = Docstring.ucfirst(member_body['type'] || '::String')
+              overload = if method_name == 'detailed_message'
+                           "(?highlight: bool) -> #{return_type}"
+                         else
+                           "() -> #{return_type}"
+                         end
+              MethodSignature.new(method_name: method_name, overloads: [overload])
             end
             es << {
               name: name,

--- a/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
+++ b/build_tools/aws-sdk-code-generator/templates/errors_module.mustache
@@ -58,7 +58,7 @@ module {{module_name}}
       {{#members}}
 
       # @return [{{type}}]
-      def {{name}}
+      def {{name}}{{#detailed_message}}(highlight: true, **){{/detailed_message}}
         {{#shared}}@{{name}} || {{/shared}}@data[:{{name}}]
       end
       {{/members}}

--- a/gems/aws-sdk-neptunedata/lib/aws-sdk-neptunedata/errors.rb
+++ b/gems/aws-sdk-neptunedata/lib/aws-sdk-neptunedata/errors.rb
@@ -78,7 +78,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -103,7 +103,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -128,7 +128,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -157,7 +157,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -182,7 +182,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -211,7 +211,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -240,7 +240,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -269,7 +269,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -294,7 +294,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -323,7 +323,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -348,7 +348,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -373,7 +373,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -398,7 +398,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -423,7 +423,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -448,7 +448,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -473,7 +473,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -498,7 +498,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -523,7 +523,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -552,7 +552,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -577,7 +577,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -602,7 +602,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -627,7 +627,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -652,7 +652,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -681,7 +681,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -706,7 +706,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -731,7 +731,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -756,7 +756,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -785,7 +785,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -810,7 +810,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -835,7 +835,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -860,7 +860,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -889,7 +889,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -918,7 +918,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 
@@ -947,7 +947,7 @@ module Aws::Neptunedata
       end
 
       # @return [String]
-      def detailed_message
+      def detailed_message(highlight: true, **)
         @data[:detailed_message]
       end
 

--- a/gems/aws-sdk-neptunedata/sig/errors.rbs
+++ b/gems/aws-sdk-neptunedata/sig/errors.rbs
@@ -12,172 +12,172 @@ module Aws
       end
 
       class AccessDeniedException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class BadRequestException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class BulkLoadIdNotFoundException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class CancelledByUserException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ClientTimeoutException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ConcurrentModificationException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ConstraintViolationException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ExpiredStreamException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class FailureByQueryException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class IllegalArgumentException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class InternalFailureException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class InvalidArgumentException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class InvalidNumericDataException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class InvalidParameterException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class LoadUrlAccessDeniedException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class MLResourceNotFoundException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class MalformedQueryException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class MemoryLimitExceededException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class MethodNotAllowedException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class MissingParameterException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ParsingException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class PreconditionsFailedException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class QueryLimitExceededException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class QueryLimitException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class QueryTooLargeException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ReadOnlyViolationException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class S3Exception < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ServerShutdownException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class StatisticsNotAvailableException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class StreamRecordsNotFoundException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class ThrottlingException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class TimeLimitExceededException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class TooManyRequestsException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end
       class UnsupportedOperationException < ::Aws::Errors::ServiceError
-        def detailed_message: () -> ::String
+        def detailed_message: (?highlight: bool) -> ::String
         def request_id: () -> ::String
         def code: () -> ::String
       end


### PR DESCRIPTION
## Summary

In Ruby 3.2, `Exception#full_message` was updated to internally call `detailed_message(highlight:)` passing a keyword argument ([source](https://github.com/ruby/ruby/blob/v3_3_0/error.c#L1491)). All 34 error classes in `aws-sdk-neptunedata` override `detailed_message` to expose the API-level `detailed_message` field, but none accepted the `highlight:` keyword — causing an `ArgumentError` whenever Ruby or tooling calls `full_message` on these exceptions.

A common trigger is OpenTelemetry SDK's `span.record_exception(e)` ([code here](https://github.com/open-telemetry/opentelemetry-ruby/blob/e851ad8fe3acdd22dea55e6c31a57e3057c81370/sdk/lib/opentelemetry/sdk/trace/span.rb#L199)), which calls `e.full_message(highlight: false, order: :top)` ([code here](https://github.com/open-telemetry/opentelemetry-ruby/blob/e851ad8fe3acdd22dea55e6c31a57e3057c81370/sdk/lib/opentelemetry/sdk/trace/span.rb#L199)) to capture the stacktrace. This silently breaks tracing and any instrumentation that records exceptions on spans.

## Change

Added `highlight: true, **` to all 34 `detailed_message` overrides in `errors.rb` and updated the corresponding `.rbs` type signatures.

```ruby
# Before
def detailed_message
  @data[:detailed_message]
end

# After
def detailed_message(highlight: true, **)
  @data[:detailed_message]
end
```

## Backward Compatibility

Fully backward compatible. Keyword arguments with defaults are valid Ruby syntax since 2.0. In Ruby < 3.2, `full_message` never calls `detailed_message` with keyword arguments, so the added parameter is never passed — no behavior change.

## Note on Code Generation

`errors.rb` and `sig/errors.rbs` are generated files. The corresponding generator template will also need to be updated to preserve this fix on future regeneration.