### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,13 +29,14 @@ jobs:
 
     steps:
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install gems
         run: |
@@ -51,7 +52,7 @@ jobs:
         run: bundle exec rake benchmark:run
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         continue-on-error: true
         with:
           role-to-assume: arn:aws:iam::373952703873:role/BenchmarkReporter
@@ -73,7 +74,7 @@ jobs:
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' && steps.regressions.outputs.message }}
-        uses: thollander/actions-comment-pull-request@main
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: ${{ steps.regressions.outputs.message }}
           comment-tag: performance-regression

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Comment on PR
         if: ${{!contains(steps.changed-files.outputs.all_changed_files, 'gems/aws-sdk-core/CHANGELOG.md')}}
-        uses: thollander/actions-comment-pull-request@main
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: 'You have made a change to core without a corresponding change to the CHANGELOG.md. This change will not result in a new version and will not published unless an entry is added to CHANGELOG.md.'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,13 @@ jobs:
 
     steps:
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install gems
         run: |
@@ -52,11 +54,13 @@ jobs:
         env: [KITCHEN_SINK, CRT]
     steps:
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup ENV
         run: |

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -9,7 +9,7 @@ jobs:
           issues: write # to comment on issues
         runs-on: ubuntu-latest
         steps:
-        - uses: aws-actions/closed-issue-message@v2
+        - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: git-sync
-        uses: wei/git-sync@v3
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # v3
         with:
           source_repo: 'aws/aws-sdk-ruby'
           source_branch: 'version-3'

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -13,6 +13,6 @@ jobs:
       discussions: write
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1
+        uses: aws-github-ops/handle-stale-discussions@711a9813957be17629fc6933afcd8bd132c57254 # v1
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
@@ -24,8 +24,9 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
+        if [ "${STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION}" == "true" ]; then
           gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
         else
           gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@main
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ env.IAM_ROLE_ARN }}
           role-session-name: PullRequestBuildGitHubAction
@@ -37,7 +37,9 @@ jobs:
           aws-region: us-west-2
       - name: Checkout
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Download Build Script
         run: |
           aws s3 cp s3://aws-sdk-builds-github-assets-prod-us-west-2/$SCRIPT_LOCATION ./$DOWNLOAD_FOLDER/$SCRIPT_LOCATION --no-progress
@@ -46,7 +48,7 @@ jobs:
         id: pr
         if: github.event_name == 'workflow_dispatch'
         run: |
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state all --head "${{ github.ref_name }}" --json number --jq '.[0].number // ""')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state all --head "${GITHUB_REF_NAME}" --json number --jq '.[0].number // ""')
           echo "number=${PR_NUMBER:-}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
> [!NOTE]
> Some actions may be pinned to versions that are not the latest available. This PR intentionally preserves the currently used compatible versions where possible. The scope is to make action references immutable and address the zizmor findings, not to upgrade actions to their latest releases.

## Overview

This PR hardens GitHub Actions configuration for `aws-sdk-ruby` to resolve [zizmor](https://docs.zizmor.sh/) findings around action pinning, credential persistence, Dependabot update cooldown, and shell template expansion.

## Summary

- Pins GitHub Actions `uses:` references to full commit SHAs while retaining version comments for readability.
- Uses stable release-version SHAs where available instead of pinning moving branches like `main`.
- Sets `persist-credentials: false` for checkout steps that do not need persisted Git credentials.
- Adds a Dependabot cooldown window for bundler updates.
- Moves GitHub Actions expression values into environment variables before using them in shell `run:` blocks, avoiding inline `${{ ... }}` expansion in `issue-regression-labeler` and `pull-request-build.yaml`.

These changes address the relevant zizmor audit guidance for [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses), [`dependabot-cooldown`](https://docs.zizmor.sh/audits/#dependabot-cooldown), [`artipacked`](https://docs.zizmor.sh/audits/#artipacked), and [`template-injection`](https://docs.zizmor.sh/audits/#template-injection).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.