### PR TITLE
fix: prevent unbounded recursion in CBOR decoder

### DIFF
--- a/gems/aws-sdk-core/CHANGELOG.md
+++ b/gems/aws-sdk-core/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Prevent unbounded recursion in CBOR decoder that could cause process termination on malformed responses.
+
 3.249.0 (2026-05-22)
 ------------------
 

--- a/gems/aws-sdk-core/lib/aws-sdk-core/cbor/decoder.rb
+++ b/gems/aws-sdk-core/lib/aws-sdk-core/cbor/decoder.rb
@@ -7,6 +7,7 @@ module Aws
       def initialize(bytes)
         @buffer = bytes
         @pos = 0
+        @depth = 0
       end
 
       def decode
@@ -25,10 +26,14 @@ module Aws
       TAG_TYPE_BIGNUM = 2
       TAG_TYPE_NEG_BIGNUM = 3
       TAG_TYPE_BIGDEC = 4
+      MAX_DEPTH = 128 # Value chosen to match other SDKs
 
       # high level, generic decode. Based on the next type. Consumes and returns
       # the next item as a ruby object.
       def decode_item
+        @depth += 1
+        raise Error, "Maximum nesting depth (#{MAX_DEPTH}) exceeded" if @depth > MAX_DEPTH
+
         case (next_type = peek_type)
         when :array
           read_array.times.map { decode_item }
@@ -75,6 +80,8 @@ module Aws
         else
           send("read_#{next_type}")
         end
+      ensure
+        @depth -= 1
       end
 
       # low level streaming interface
@@ -121,8 +128,7 @@ module Aws
         when 0 then val
         when 1 then -1 - val
         else
-          raise Error,
-                "Expected Integer (0,1) got major type: #{major_type}"
+          raise Error, "Expected Integer (0,1) got major type: #{major_type}"
         end
       end
 
@@ -173,8 +179,7 @@ module Aws
 
       def read_reserved_undefined
         _major_type, add_info = read_info
-        raise Error,
-          "Undefined reserved additional information: #{add_info}"
+        raise Error, "Undefined reserved additional information: #{add_info}"
       end
 
       def read_boolean
@@ -183,9 +188,7 @@ module Aws
         when 20 then false
         when 21 then true
         else
-          raise Error,
-                'Invalid Boolean simple type, expected add_info of 20 or 21, ' \
-                 "got: #{add_info}"
+          raise Error, "Invalid Boolean simple type, expected add_info of 20 or 21, got: #{add_info}"
         end
       end
 
@@ -221,7 +224,7 @@ module Aws
             # exp-15-10
             Math.ldexp(1024 + mant, exp - 25)
           end
-        if (b16[15]).zero?
+        if b16[15].zero?
           val
         else
           -val
@@ -250,9 +253,7 @@ module Aws
         when 2 then v
         when 3 then -1 - v
         else
-          raise Error,
-                'Invalid Tag value for BigNum, ' \
-                "expected 2 or 3, got: #{tag_value}"
+          raise Error, "Invalid Tag value for BigNum, expected 2 or 3, got: #{tag_value}"
         end
       end
 

--- a/gems/aws-sdk-core/spec/aws/cbor/decoder_spec.rb
+++ b/gems/aws-sdk-core/spec/aws/cbor/decoder_spec.rb
@@ -63,23 +63,35 @@ module Aws
         end
 
         it 'decodes integer times' do
-          expect(cbor64_decode('wftB14MjtYAAAA=='))
-            .to eq(Time.parse('2020-01-01 12:21:42Z'))
+          expect(cbor64_decode('wftB14MjtYAAAA==')).to eq(Time.parse('2020-01-01 12:21:42Z'))
         end
 
         it 'decodes positive BigNums' do
-          value = 2 ** 64 + 1
+          value = 2**64 + 1
           expect(encode_decode(value)).to eq(value)
         end
 
         it 'decodes negative BigNums' do
-          value = -1*(2 ** 64 + 1)
+          value = -1 * (2**64 + 1)
           expect(encode_decode(value)).to eq(value)
         end
 
         it 'decodes BigDecimals' do
-          value = BigDecimal("273.15")
+          value = BigDecimal('273.15')
           expect(cbor64_decode('xIIhGWqz')).to eq(value)
+        end
+
+        it 'raises when nesting depth exceeds max depth' do
+          # 0xc6 = CBOR tag(6), each one recurses into decode_item.
+          # 128 tags + terminal value = 129 calls to decode_item.
+          payload = ("\xc6".b * 128) + "\x00".b
+          expect { Decoder.new(payload).decode }.to raise_error(Error, /Maximum nesting depth/)
+        end
+
+        it 'decodes payloads within the depth limit' do
+          # 127 tags + terminal value = 128 calls to decode_item (at the limit).
+          payload = ("\xc6".b * 127) + "\x00".b
+          expect { Decoder.new(payload).decode }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
## Summary
- Adds a depth counter to `decode_item` that raises `Cbor::Error` when nesting exceeds 128 levels
- Without this, a payload of nested CBOR containers causes unbounded recursion, raising `SystemStackError` which escapes our `rescue StandardError` handler and crashes the process
- `Cbor::Error` inherits from `StandardError`, so it is caught cleanly

## Context
Taken care of as part of oncall. Value of 128 chosen to match other SDKs. No AWS service currently uses `rpcv2Cbor` protocol, so practical exposure
is zero today. This is a proactive fix before any service adopts it.

Matching fix in smithy-ruby: https://github.com/smithy-lang/smithy-ruby/pull/340
