### PR TITLE
fix: Fix download_file single-request mode not using temp file for String/Pathname destinations

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix `download_file` single-request mode not writing to a temporary file when given a String/Pathname destination.
+
 1.225.0 (2026-06-02)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/file_downloader.rb
@@ -196,7 +196,9 @@ module Aws
       end
 
       def single_request(opts)
-        params = get_opts(opts[:params]).merge(response_target: opts[:destination])
+        resolve_temp_path(opts)
+        target = opts[:temp_path] || opts[:destination]
+        params = get_opts(opts[:params]).merge(response_target: target)
         params[:on_chunk_received] = single_part_progress(opts) if opts[:progress_callback]
         resp = @client.get_object(params)
         return resp unless opts[:on_checksum_validated]

--- a/gems/aws-sdk-s3/spec/file_downloader_spec.rb
+++ b/gems/aws-sdk-s3/spec/file_downloader_spec.rb
@@ -44,8 +44,9 @@ module Aws
         end
 
         it 'downloads a single object using Client#get_object' do
-          expect(client).to receive(:get_object).with(single_params.merge(response_target: path)).exactly(1).times
+          client.stub_responses(:get_object, { body: 'body' })
           subject.download(path, single_params)
+          expect(File.read(path)).to eq('body')
         end
 
         it 'downloads a large object in parts' do
@@ -73,7 +74,10 @@ module Aws
 
         it 'supports download object with version_id' do
           params = single_params.merge(version_id: 'foo')
-          expect(client).to receive(:get_object).with(params.merge(response_target: path)).exactly(1).times
+          client.stub_responses(:get_object, lambda do |ctx|
+            expect(ctx.params[:version_id]).to eq('foo')
+            { body: 'body' }
+          end)
 
           subject.download(path, params)
         end
@@ -140,9 +144,8 @@ module Aws
         context 'multipart progress' do
           it 'reports progress for single object' do
             small_file_size = 1024
-            expect(client)
-              .to receive(:get_object)
-              .with(single_params.merge(response_target: path, on_chunk_received: instance_of(Proc))) do |args|
+            allow(File).to receive(:rename) # mocked get_object writes no temp file
+            expect(client).to receive(:get_object).exactly(1).times do |args|
               args[:on_chunk_received].call(Tempfile.new('small-file'), small_file_size, small_file_size)
             end
 
@@ -237,6 +240,17 @@ module Aws
             client.stub_responses(:get_object, { body: 'body', content_range: 'bytes 0-3/4' })
             expect { subject.download(path, range_params.merge(mode: 'get_range', chunk_size: one_meg)) }
               .to raise_error(Aws::S3::MultipartDownloadError)
+          end
+
+          it 'does not overwrite existing file when single object download fails mid-stream' do
+            File.write(path, 'existing content')
+            expect(client).to receive(:get_object) do |params|
+              File.write(params[:response_target], 'partial')
+              raise Aws::S3::Errors::InternalError.new(nil, 'connection lost')
+            end
+
+            expect { subject.download(path, single_params) }.to raise_error(Aws::S3::Errors::InternalError)
+            expect(File.read(path)).to eq('existing content')
           end
 
           it 'does not overwrite existing file when download fails' do

--- a/gems/aws-sdk-s3/spec/object/download_file_spec.rb
+++ b/gems/aws-sdk-s3/spec/object/download_file_spec.rb
@@ -31,7 +31,10 @@ module Aws
         it 'calls progress callback when given' do
           n_calls = 0
           callback = proc { |_b, _p, _t| n_calls += 1 }
-          expect(client).to receive(:get_object) { |args| args[:on_chunk_received]&.call('chunk', 1024, 1024) }
+          expect(client).to receive(:get_object) do |args|
+            File.write(args[:response_target], 'data')
+            args[:on_chunk_received]&.call('chunk', 1024, 1024)
+          end
 
           subject.download_file(path, progress_callback: callback)
           expect(n_calls).to eq(1)

--- a/gems/aws-sdk-s3/spec/transfer_manager_spec.rb
+++ b/gems/aws-sdk-s3/spec/transfer_manager_spec.rb
@@ -75,7 +75,10 @@ module Aws
         it 'calls progress callback when given' do
           n_calls = 0
           callback = proc { |_b, _p, _t| n_calls += 1 }
-          expect(client).to receive(:get_object) { |args| args[:on_chunk_received]&.call('chunk', 1024, 1024) }
+          expect(client).to receive(:get_object) do |args|
+            File.write(args[:response_target], 'data')
+            args[:on_chunk_received]&.call('chunk', 1024, 1024)
+          end
 
           subject.download_file(path, bucket: 'bucket', key: 'key', progress_callback: callback)
           expect(n_calls).to eq(1)


### PR DESCRIPTION
## Summary
Addresses #3391 

Fixes `FileDownloader#single_request` to write to a temporary file before atomically renaming to the destination, matching the behavior of all other download paths (multipart, range).

Previously, `single_request` passed the destination directly as `response_target`, so the file could be observed in a partially written state by concurrent readers.