### PR TITLE
Pin rdoc < 8.0.0 on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,17 +9,19 @@ gem 'base64'
 gem 'bigdecimal'
 gem 'csv'
 gem 'http-2'
+gem 'jmespath'
 if defined?(JRUBY_VERSION)
   gem 'irb', '< 1.17.0'
+  # rdoc >= 8.0.0 depends on rbs, which fails to build its native ext on JRuby
+  # https://github.com/ruby/rbs/issues/3018
+  gem 'rdoc', '< 8.0.0'
+  gem 'jruby-openssl'
 else
   gem 'irb'
+  gem 'rdoc'
 end
-gem 'jmespath'
-gem 'jruby-openssl' if defined?(JRUBY_VERSION)
-gem 'rdoc'
 
 # protocol parsers
-
 gem 'json'
 gem 'nokogiri'
 gem 'oga'


### PR DESCRIPTION
## Context
JRuby CI (`test (jruby-10.0, KITCHEN_SINK)`) started failing at `bundle install` on 2026-06-26.
`rdoc 8.0.0` added a runtime dependency on `rbs`, and stable `rbs` has no JRuby-native gem, so
the native extension build fails on JRuby. Not a code or JRuby regression — a dependency drift.

## Fix
Pin `rdoc < 8.0.0` on JRuby, following the existing `irb` guard. Interim mitigation until a
stable `rbs` ships a `-java` gem (or rdoc drops the dep).