### PR TITLE
fix: Add backpressure on S3 stream upload to prevent unbounded buffering

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Fix stream uploader to not read ahead of thread pool capacity, to prevent unbounded usage of memory or disk.
+
 1.226.0 (2026-06-16)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/default_executor.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/default_executor.rb
@@ -9,6 +9,8 @@ module Aws
       SHUTTING_DOWN = :shutting_down
       SHUTDOWN = :shutdown
 
+      attr_reader :max_threads
+
       def initialize(options = {})
         @max_threads = options[:max_threads] || DEFAULT_MAX_THREADS
         @state = RUNNING

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'thread'
 require 'set'
 require 'tempfile'
 require 'stringio'
@@ -9,7 +8,6 @@ module Aws
   module S3
     # @api private
     class MultipartStreamUploader
-
       DEFAULT_PART_SIZE = 5 * 1024 * 1024 # 5MB
       CREATE_OPTIONS = Set.new(Client.api.operation(:create_multipart_upload).input.shape.member_names)
       UPLOAD_PART_OPTIONS = Set.new(Client.api.operation(:upload_part).input.shape.member_names)
@@ -133,10 +131,22 @@ module Aws
         queued_parts = 0
         part_number = 0
         mutex = Mutex.new
+        concurent_readed_parts = 0 # slots available for reading
+
         loop do
           part_body, current_part_num = mutex.synchronize do
-            [read_to_part_body(read_pipe), part_number += 1]
+            # Prevent reading ahead of the executor if no slots available
+            if concurent_readed_parts >= @executor.max_threads
+              [:skip, -1]
+            else
+              concurent_readed_parts += 1
+              [read_to_part_body(read_pipe), part_number += 1]
+            end
           end
+
+          next if part_body == :skip # Wait for the executor free a read slot
+
+          # No more parts to read or we need at least one part for empty content
           break unless part_body || current_part_num == 1
 
           queued_parts += 1
@@ -145,8 +155,10 @@ module Aws
             resp = @client.upload_part(part)
             completed_part = create_completed_part(resp, part)
             completed.push(completed_part)
+            mutex.synchronize { concurent_readed_parts -= 1 } # free a read slot
           rescue StandardError => e
             mutex.synchronize do
+              concurent_readed_parts -= 1 # free a read slot
               errors.push(e)
               read_pipe.close_read unless read_pipe.closed?
             end

--- a/gems/aws-sdk-s3/spec/multipart_stream_uploader_spec.rb
+++ b/gems/aws-sdk-s3/spec/multipart_stream_uploader_spec.rb
@@ -82,6 +82,68 @@ module Aws
           end
         end
 
+        let(:blocking_executor) do
+          Class.new(DefaultExecutor) do
+            attr_accessor :queue, :mutex, :paused
+
+            def initialize(options = {})
+              @paused = true
+              options[:max_threads] = 1
+              super
+            end
+
+            def post(*args, &block)
+              @mutex.synchronize do
+                if @state == :running
+                  new_block = lambda do
+                    block.call(*args)
+                    # Block until external shutdown
+                    loop do
+                      is_paused = @mutex.synchronize { @paused }
+                      sleep 0.01
+                      break unless is_paused
+                    end
+                  end
+                  @queue << [nil, new_block]
+                  ensure_worker_available
+                end
+              end
+              true
+            end
+          end.new
+        end
+
+        context 'with a faster writer than the executor can process' do
+          let(:subject) { MultipartStreamUploader.new(client: client, executor: blocking_executor) }
+
+          it 'only read when an executor is ready' do
+            client.stub_responses(:create_multipart_upload, upload_id: 'id')
+            client.stub_responses(:upload_part, etag: 'etag')
+            client.stub_responses(:complete_multipart_upload)
+
+            thread = Thread.new do
+              subject.upload(params) do |write_stream|
+                Thread.current[:io] = write_stream
+                write_stream << seventeen_mb
+              end
+            end
+
+            sleep 0.1 # Wait for multiple reads to occur
+
+            executor_queue_size = blocking_executor.mutex.synchronize do
+              queue_size = blocking_executor.queue.size # get the queue when executor is blocked
+              blocking_executor.paused = false # unblock the executor
+              queue_size
+            end
+            thread.join
+
+            # If the executor queue is not empty
+            # /!\ The IO pipe has been read ahead of the executor
+            # /!\ This will result in a memory leak in the Executor queue /!\
+            expect(executor_queue_size).to eq(0)
+          end
+        end
+
         it 'passes stringios with correct contents to upload_part' do
           client.stub_responses(:create_multipart_upload, upload_id: 'id')
           client.stub_responses(:complete_multipart_upload)


### PR DESCRIPTION
## TL;DR

The S3 stream uploader does not currently apply backpressure between reading from the input stream and uploading multipart parts.
When the input is written faster than parts can be uploaded, the uploader can read ahead and queue buffered parts indefinitely, causing unbounded memory usage or disk usage (with `tempfile: true`).

## Context

`MultipartStreamUploader` reads stream data into part buffers (`StringIO` or `Tempfile`) on a dedicated thread and posts each part to `DefaultExecutor` for upload when a executor `Thread` become available.

Previously, the reader `loop` could read ahead without waiting for executor, so parts could accumulate in the executor queue, causing unbounded memory use with `StringIO` or unbounded disk use of `Tempfile` with `tempfile: true`.

`MultipartFileUploader` does not have this issue because parts offsets are computed ahead and read inside the executor Thread.

This change tracks in-flight read slots and defers further reads until a posted part completes (or fails), keeping buffered data bounded by executor concurrency.

## Testing

Added an example reproducing unbounded read in `gems/aws-sdk-s3/spec/multipart_stream_uploader_spec.rb`.

```bash
bundle exec rspec gems/aws-sdk-s3/spec/multipart_stream_uploader_spec.rb
```

### Real-world

This issue resulted in memory leaks (near file size !) during a stream upload, to investigate we enabled the tempfile option which push to a `Tempfile` to follow what happen, this what we show:

[Screencast from 2026-07-02 11-06-15.webm](https://github.com/user-attachments/assets/0a730373-8bf3-42c4-9b91-0c65951eecf2)

For context, here we just read a big local file and send chunks to the stream upload.

## Changes

- Limit concurrent reads in `MultipartStreamUploader` to `@executor.max_threads`, so the reader does not pull data from `IO.pipe` faster than the executor can upload parts
- Expose `max_threads` on `DefaultExecutor` so the uploader can align read concurrency with executor capacity
- Add a spec with a single-threaded blocking executor to verify the executor queue stays empty when the writer is faster than uploads

