### PR TITLE
Close source file on multipart upload_file part failure

### DIFF
--- a/gems/aws-sdk-s3/CHANGELOG.md
+++ b/gems/aws-sdk-s3/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure the source file is closed on multipart `upload_file` part failure, preventing leaked file descriptors (#3408).
+
 1.228.0 (2026-07-16)
 ------------------
 

--- a/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
+++ b/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb
@@ -154,7 +154,6 @@ module Aws
             Thread.current[:net_http_override_body_stream_chunk] = @http_chunk_size if @http_chunk_size
             update_progress(progress, p)
             resp = @client.upload_part(p)
-            p[:body].close
             completed_part = { etag: resp.etag, part_number: p[:part_number] }
             apply_part_checksum(resp, completed_part)
             completed.push(completed_part)
@@ -162,6 +161,7 @@ module Aws
             abort_upload = true
             errors << e
           ensure
+            p[:body].close
             Thread.current[:net_http_override_body_stream_chunk] = nil if @http_chunk_size
             completion_queue << :done
           end

--- a/gems/aws-sdk-s3/spec/multipart_file_uploader_spec.rb
+++ b/gems/aws-sdk-s3/spec/multipart_file_uploader_spec.rb
@@ -126,6 +126,13 @@ module Aws
         end
 
         it 'closes all file parts even when a part upload fails' do
+          # Fail the last part so the posting loop can't break early and skip
+          # un-posted parts. This keeps the assertion deterministic across MRI
+          # (GIL-serialized) and JRuby (truly parallel) threads.
+          file = Tempfile.new('six-meg-file').tap do |f|
+            6.times { f.write(one_mb) }
+            f.rewind
+          end
           file_parts = []
           allow(FilePart).to receive(:new).and_wrap_original do |original, *args|
             original.call(*args).tap do |fp|
@@ -138,16 +145,14 @@ module Aws
             :upload_part,
             [
               { etag: 'etag-1' },
-              RuntimeError.new('part 2 failed'),
-              { etag: 'etag-3' },
-              { etag: 'etag-4' }
+              RuntimeError.new('part 2 failed')
             ]
           )
 
-          expect { subject.upload(large_file, params) }
+          expect { subject.upload(file, params) }
             .to raise_error(/multipart upload failed: part 2 failed/)
 
-          expect(file_parts).not_to be_empty
+          expect(file_parts.size).to eq(2)
           file_parts.each { |fp| expect(fp).to have_received(:close) }
         end
 

--- a/gems/aws-sdk-s3/spec/multipart_file_uploader_spec.rb
+++ b/gems/aws-sdk-s3/spec/multipart_file_uploader_spec.rb
@@ -125,6 +125,32 @@ module Aws
           expect { subject.upload(large_file, params) }.to raise_error(/multipart upload failed: part 3 failed/)
         end
 
+        it 'closes all file parts even when a part upload fails' do
+          file_parts = []
+          allow(FilePart).to receive(:new).and_wrap_original do |original, *args|
+            original.call(*args).tap do |fp|
+              allow(fp).to receive(:close).and_call_original
+              file_parts << fp
+            end
+          end
+
+          client.stub_responses(
+            :upload_part,
+            [
+              { etag: 'etag-1' },
+              RuntimeError.new('part 2 failed'),
+              { etag: 'etag-3' },
+              { etag: 'etag-4' }
+            ]
+          )
+
+          expect { subject.upload(large_file, params) }
+            .to raise_error(/multipart upload failed: part 2 failed/)
+
+          expect(file_parts).not_to be_empty
+          file_parts.each { |fp| expect(fp).to have_received(:close) }
+        end
+
         it 'reports when it is unable to abort a failed multipart upload', :jruby_flaky do
           client.stub_responses(:upload_part, RuntimeError.new('part failed'))
           client.stub_responses(:abort_multipart_upload, RuntimeError.new('network-error'))


### PR DESCRIPTION
## Issue

Fixes #3408

## Description
`MultipartFileUploader` closed each part's source file (`p[:body].close`) only on the success path, before the `rescue`/`ensure`. When a part upload raised, that line was skipped, so the failed part's `FilePart` was left open. `FilePart` opens the source lazily on first read and only releases it in `#close`, so every failed part leaked a file descriptor.

In long-running processes that retry failed uploads, this accumulates until file handles are exhausted. When the source is an unlinked temp file, the open descriptor also keeps its disk blocks allocated, so `/tmp` can fill (see the downstream report in mastodon/mastodon#39863).

## Fix

Move `p[:body].close` into the `ensure` block so the file is released on both the success and error paths. `FilePart#close` is a no-op when the file was never opened and `IO#close` is idempotent, so there is no double-close concern.

## Testing

Added a regression spec asserting every `FilePart` is closed when a part upload fails. It fails on `main` (the failed part is closed 0 times) and passes with this change. The existing specs and related uploader specs still pass.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*