### PR TITLE
Update fixtures for json v3.0.0

### DIFF
--- a/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/async/api.json
+++ b/build_tools/aws-sdk-code-generator/spec/fixtures/interfaces/async/api.json
@@ -60,13 +60,6 @@
       },
       "eventstream": true
     },
-    "BazStream": {
-      "type": "structure",
-      "members": {
-        "Bar": { "shape": "BarEvent"}
-      },
-      "eventstream": true
-    },
     "BarEvent": {
       "type": "structure",
       "members": {

--- a/gems/aws-sdk-core/spec/fixtures/apis/dynamodb.json
+++ b/gems/aws-sdk-core/spec/fixtures/apis/dynamodb.json
@@ -3047,7 +3047,7 @@
       "type":"structure",
       "members":{
         "message":{"shape":"ErrorMessage"},
-        "foo":{"shape":"String"} // custom
+        "foo":{"shape":"String"}
       },
       "exception":true
     },

--- a/gems/aws-sdk-core/spec/fixtures/apis/logs.json
+++ b/gems/aws-sdk-core/spec/fixtures/apis/logs.json
@@ -3265,7 +3265,7 @@
     "ServiceUnavailableException":{
       "type":"structure",
       "members":{
-        "foo":{"shape":"Value"} // custom
+        "foo":{"shape":"Value"}
       },
       "exception":true,
       "fault":true


### PR DESCRIPTION
[json v3.0.0](https://github.com/ruby/json/releases/tag/v3.0.0) tightened parsing (rejects duplicate object keys and // comments), which broke 22 unit tests. This fixes the three fixtures at fault so they parse under both json 2.7.x and 3.0.0.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. To make sure we include your contribution in the release notes, please make sure to add description entry for your changes in the "unreleased changes" section of the `CHANGELOG.md` file (at corresponding gem). For the description entry, please make sure it lives in one line and starts with `Feature` or `Issue` in the correct format.

2. For generated code changes, please checkout below instructions first:
  https://github.com/aws/aws-sdk-ruby/blob/version-3/CONTRIBUTING.md

Thank you for your contribution!
